### PR TITLE
fix(frontend): handle simulation failed status

### DIFF
--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -508,6 +508,15 @@ const fetchRunStatus = async () => {
         prevRedditRound.value = data.reddit_current_round
       }
       
+      // 检测模拟是否失败
+      if (data.runner_status === 'failed') {
+        const errorMsg = data.error || '模拟运行失败'
+        addLog(`✗ 模拟失败: ${errorMsg}`)
+        stopPolling()
+        emit('update-status', 'error')
+        return
+      }
+
       // 检测模拟是否已完成（通过 runner_status 或平台完成状态判断）
       const isCompleted = data.runner_status === 'completed' || data.runner_status === 'stopped'
       


### PR DESCRIPTION
## Summary

- Add check for `runner_status === 'failed'` in `fetchRunStatus()` to properly display error messages when simulation fails
- Previously the UI would stay in "running" state indefinitely when simulation failed

Closes #14

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.