### PR TITLE
清理模型返回的markdown标记

### DIFF
--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -86,6 +86,17 @@ class LLMClient:
             max_tokens=max_tokens,
             response_format={"type": "json_object"}
         )
-        
-        return json.loads(response)
+        # 清理markdown代码块标记
+        cleaned_response = response.strip()
+        if cleaned_response.startswith("```json"):
+            cleaned_response = cleaned_response[7:]  # 移除 ```json
+        elif cleaned_response.startswith("```"):
+            cleaned_response = cleaned_response[3:]  # 移除 ```
+        if cleaned_response.endswith("```"):
+            cleaned_response = cleaned_response[:-3]  # 移除结尾的 ```
+        cleaned_response = cleaned_response.strip()
 
+        try:
+            return json.loads(cleaned_response)
+        except json.JSONDecodeError:
+            raise ValueError(f"LLM返回的JSON格式无效: {cleaned_response}")


### PR DESCRIPTION
生成本体结构时部分模型（已测试minimax-m2.1 minimax-m2.5 glm-4.7 glm-5都有相同情况）似乎不遵守json_object的格式，会返回markdown包裹的json代码块 导致json.loads()解析错误

对md代码块标记进行了清理并额外增加了try except防止出错导致500

https://github.com/666ghj/MiroFish/issues/64 
https://github.com/666ghj/MiroFish/issues/58 
https://github.com/666ghj/MiroFish/issues/48 
不确定是否都是这个原因导致的
