### PR TITLE
fix: Handle string entities/edges in _validate_and_process

### DIFF
--- a/backend/app/services/ontology_generator.py
+++ b/backend/app/services/ontology_generator.py
@@ -266,7 +266,15 @@ class OntologyGenerator:
             result["analysis_summary"] = ""
         
         # 验证实体类型
+        validated_entities = []
         for entity in result["entity_types"]:
+            # 修复：如果 entity 是字符串，包装成字典格式
+            if isinstance(entity, str):
+                entity = {"name": entity, "description": f"Entity type: {entity}"}
+            
+            if not isinstance(entity, dict):
+                continue  # 跳过无效数据
+                
             if "attributes" not in entity:
                 entity["attributes"] = []
             if "examples" not in entity:
@@ -274,15 +282,31 @@ class OntologyGenerator:
             # 确保description不超过100字符
             if len(entity.get("description", "")) > 100:
                 entity["description"] = entity["description"][:97] + "..."
+            
+            validated_entities.append(entity)
+        
+        result["entity_types"] = validated_entities
         
         # 验证关系类型
+        validated_edges = []
         for edge in result["edge_types"]:
+            # 修复：如果 edge 是字符串，包装成字典格式
+            if isinstance(edge, str):
+                edge = {"name": edge, "description": f"Relationship type: {edge}"}
+            
+            if not isinstance(edge, dict):
+                continue  # 跳过无效数据
+                
             if "source_targets" not in edge:
                 edge["source_targets"] = []
             if "attributes" not in edge:
                 edge["attributes"] = []
             if len(edge.get("description", "")) > 100:
                 edge["description"] = edge["description"][:97] + "..."
+            
+            validated_edges.append(edge)
+        
+        result["edge_types"] = validated_edges
         
         # Zep API 限制：最多 10 个自定义实体类型，最多 10 个自定义边类型
         MAX_ENTITY_TYPES = 10


### PR DESCRIPTION
## Problem
When LLM returns malformed JSON where `entity_types` or `edge_types` contain strings instead of dictionaries, the `_validate_and_process` method crashes with:
```
TypeError: 'str' object does not support item assignment
```

## Solution
Added type checking in `_validate_and_process`:
- If entity/edge is a string, wrap it into proper dict format
- Skip invalid (non-dict) entries to prevent crashes
- Collect valid entries into new lists

## Testing
Tested with DeepSeek model via OpenRouter. Successfully generates ontology without crashes.