### PR TITLE
feat: add configurable API timeout for slow local LLMs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ ZEP_API_KEY=your_zep_api_key_here
 LLM_BOOST_API_KEY=your_api_key_here
 LLM_BOOST_BASE_URL=your_base_url_here
 LLM_BOOST_MODEL_NAME=your_model_name_here
+# ===== 前端API超时配置（可选）=====
+# 本地大模型响应较慢时可以增加此值（毫秒）
+# VITE_API_TIMEOUT=600000  # 10分钟

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -3,7 +3,7 @@ import axios from 'axios'
 // 创建axios实例
 const service = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5001',
-  timeout: 300000, // 5分钟超时（本体生成可能需要较长时间）
+  timeout: parseInt(import.meta.env.VITE_API_TIMEOUT) || 300000, // 可配置超时时间，默认5分钟（本地大模型可能需要更长时间）
   headers: {
     'Content-Type': 'application/json'
   }


### PR DESCRIPTION
## Summary

Fixes #58 - 允许用户配置API超时时间以支持响应较慢的本地大模型（如Ollama）。

## Changes

- 添加 `VITE_API_TIMEOUT` 环境变量支持
- 默认保持300000ms（5分钟）
- 用户可根据需要增加超时时间

## Usage

在 `.env` 文件中添加：
```bash
# 本地大模型响应较慢时增加超时时间
VITE_API_TIMEOUT=600000  # 10分钟
```

## Testing

- 默认值300000ms正常工作
- 配置后使用配置的值

Fixes #58