### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,13 +17,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/mirofish
           tags: |
@@ -40,7 +40,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `docker/build-push-action` | [`v5`](https://github.com/docker/build-push-action/releases/tag/v5) | [`v7`](https://github.com/docker/build-push-action/releases/tag/v7) | [Release](https://github.com/docker/build-push-action/releases/tag/v7) | docker-image.yml |
| `docker/login-action` | [`v3`](https://github.com/docker/login-action/releases/tag/v3) | [`v4`](https://github.com/docker/login-action/releases/tag/v4) | [Release](https://github.com/docker/login-action/releases/tag/v4) | docker-image.yml |
| `docker/metadata-action` | [`v5`](https://github.com/docker/metadata-action/releases/tag/v5) | [`v6`](https://github.com/docker/metadata-action/releases/tag/v6) | [Release](https://github.com/docker/metadata-action/releases/tag/v6) | docker-image.yml |
| `docker/setup-buildx-action` | [`v3`](https://github.com/docker/setup-buildx-action/releases/tag/v3) | [`v4`](https://github.com/docker/setup-buildx-action/releases/tag/v4) | [Release](https://github.com/docker/setup-buildx-action/releases/tag/v4) | docker-image.yml |
| `docker/setup-qemu-action` | [`v3`](https://github.com/docker/setup-qemu-action/releases/tag/v3) | [`v4`](https://github.com/docker/setup-qemu-action/releases/tag/v4) | [Release](https://github.com/docker/setup-qemu-action/releases/tag/v4) | docker-image.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **docker/setup-qemu-action** (v3 → v4): Major version upgrade — review the [release notes](https://github.com/docker/setup-qemu-action/releases) for breaking changes
- **docker/setup-buildx-action** (v3 → v4): Major version upgrade — review the [release notes](https://github.com/docker/setup-buildx-action/releases) for breaking changes
- **docker/login-action** (v3 → v4): Major version upgrade — review the [release notes](https://github.com/docker/login-action/releases) for breaking changes
- **docker/metadata-action** (v5 → v6): Major version upgrade — review the [release notes](https://github.com/docker/metadata-action/releases) for breaking changes
- **docker/build-push-action** (v5 → v7): Major version upgrade — review the [release notes](https://github.com/docker/build-push-action/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
