### PR TITLE
fix(frontend): use relative baseURL in production, avoid hardcoded localhost

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,8 +1,21 @@
 import axios from 'axios'
 
 // 创建axios实例
+// 优先级: VITE_API_BASE_URL > 生产环境相对路径 > 开发环境localhost
+const getBaseURL = () => {
+  if (import.meta.env.VITE_API_BASE_URL) {
+    return import.meta.env.VITE_API_BASE_URL
+  }
+  // 生产环境使用相对路径（同源部署）
+  if (import.meta.env.PROD) {
+    return ''  // 相对路径，使用当前域名
+  }
+  // 开发环境默认localhost
+  return 'http://localhost:5001'
+}
+
 const service = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5001',
+  baseURL: getBaseURL(),
   timeout: 300000, // 5分钟超时（本体生成可能需要较长时间）
   headers: {
     'Content-Type': 'application/json'


### PR DESCRIPTION
## Problem

Frontend `baseURL` defaults to `http://localhost:5001` in all environments, causing:

1. Users can only access from the machine running MiroFish
2. Docker deployments with non-5001 ports fail
3. Server deployments require frontend rebuild to change URL

## Solution

Make baseURL environment-aware:

- **Production**: Use relative path (empty string) for same-origin deployment
- **Development**: Keep `localhost:5001` default
- **Override**: `VITE_API_BASE_URL` still takes highest priority

```javascript
const getBaseURL = () => {
  if (import.meta.env.VITE_API_BASE_URL) {
    return import.meta.env.VITE_API_BASE_URL
  }
  if (import.meta.env.PROD) {
    return ''  // relative path in production
  }
  return 'http://localhost:5001'  // dev default
}
```

## Testing

- Dev: Works with localhost:5001
- Prod (Docker): Works with any port mapping
- Custom: Works with `VITE_API_BASE_URL` set

Fixes #93, related to #59, #57