### PR TITLE
feat(utils): add json_utils module for robust LLM JSON parsing

### DIFF
--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -4,6 +4,7 @@
 
 from .file_parser import FileParser
 from .llm_client import LLMClient
+from .json_utils import clean_llm_json_response, parse_llm_json, safe_parse_llm_json
 
-__all__ = ['FileParser', 'LLMClient']
+__all__ = ['FileParser', 'LLMClient', 'clean_llm_json_response', 'parse_llm_json', 'safe_parse_llm_json']
 

--- a/backend/app/utils/json_utils.py
+++ b/backend/app/utils/json_utils.py
@@ -1,0 +1,79 @@
+"""
+JSON工具函数
+处理LLM返回的JSON解析，包括markdown代码块清理
+"""
+
+import json
+import re
+from typing import Any, Optional
+
+
+def clean_llm_json_response(response: str) -> str:
+    """
+    清理LLM返回的JSON字符串
+    
+    部分模型（如MiniMax M2.5, GLM-4.7, GLM-5）不遵守json_object格式，
+    会返回markdown包裹的JSON代码块，需要清理。
+    
+    Args:
+        response: LLM返回的原始响应
+        
+    Returns:
+        清理后的JSON字符串
+    """
+    if not response:
+        return response
+        
+    cleaned = response.strip()
+    
+    # 移除markdown代码块标记 ```json ... ``` 或 ``` ... ```
+    cleaned = re.sub(r'^```(?:json)?\s*\n?', '', cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r'\n?```\s*$', '', cleaned)
+    
+    # 移除可能的前后空白
+    cleaned = cleaned.strip()
+    
+    return cleaned
+
+
+def parse_llm_json(response: str, default: Optional[Any] = None) -> Any:
+    """
+    解析LLM返回的JSON，自动清理markdown代码块
+    
+    Args:
+        response: LLM返回的原始响应
+        default: 解析失败时的默认返回值（None表示抛出异常）
+        
+    Returns:
+        解析后的Python对象
+        
+    Raises:
+        json.JSONDecodeError: 当解析失败且未提供default时
+    """
+    cleaned = clean_llm_json_response(response)
+    
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        if default is not None:
+            return default
+        raise ValueError(f"LLM返回的JSON格式无效: {cleaned[:200]}...") from e
+
+
+def safe_parse_llm_json(response: str) -> tuple[bool, Any]:
+    """
+    安全解析LLM返回的JSON，返回成功标志和结果
+    
+    Args:
+        response: LLM返回的原始响应
+        
+    Returns:
+        (success, result) 元组：
+        - success: 是否解析成功
+        - result: 解析结果（失败时为错误信息字符串）
+    """
+    try:
+        result = parse_llm_json(response)
+        return True, result
+    except (json.JSONDecodeError, ValueError) as e:
+        return False, str(e)

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -84,20 +84,14 @@ class LLMClient:
         Returns:
             解析后的JSON对象
         """
+        from .json_utils import parse_llm_json
+        
         response = self.chat(
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
             response_format={"type": "json_object"}
         )
-        # 清理markdown代码块标记
-        cleaned_response = response.strip()
-        cleaned_response = re.sub(r'^```(?:json)?\s*\n?', '', cleaned_response, flags=re.IGNORECASE)
-        cleaned_response = re.sub(r'\n?```\s*$', '', cleaned_response)
-        cleaned_response = cleaned_response.strip()
-
-        try:
-            return json.loads(cleaned_response)
-        except json.JSONDecodeError:
-            raise ValueError(f"LLM返回的JSON格式无效: {cleaned_response}")
+        
+        return parse_llm_json(response)
 


### PR DESCRIPTION
## Problem

Some LLM models don't respect `json_object` format and return markdown-wrapped JSON:

```
```json
{"key": "value"}
```
```

This causes `json.loads()` to fail with JSONDecodeError.

Affected models: MiniMax M2.5, GLM-4.7, GLM-5

Related issues: #72, #64, #58, #48

## Solution

Add `json_utils.py` module with:

- `clean_llm_json_response()` - Strip markdown code blocks
- `parse_llm_json()` - Parse with auto-cleanup, optional default value
- `safe_parse_llm_json()` - Non-throwing version returning `(success, result)`

## Usage

```python
from app.utils import parse_llm_json

# Auto-strips ```json ... ``` wrappers
result = parse_llm_json(llm_response)

# With default fallback
result = parse_llm_json(llm_response, default={})

# Safe version (no exceptions)
success, result = safe_parse_llm_json(llm_response)
```

## Changes

- New file: `backend/app/utils/json_utils.py`
- Update: `backend/app/utils/llm_client.py` uses new helper
- Update: `backend/app/utils/__init__.py` exports new functions