### PR TITLE
fix(ci): add multi-platform Docker build for ARM64 support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem

ARM64 machines (e.g., Apple Silicon Macs, ARM servers) cannot deploy MiroFish via Docker:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

## Solution

Add `platforms: linux/amd64,linux/arm64` to `docker/build-push-action`.

The workflow already has QEMU and Buildx configured, just needed the platforms flag.

## Changes

- Update `.github/workflows/docker-image.yml`
- Add `platforms: linux/amd64,linux/arm64`

Fixes #99