### PR TITLE
ci: upgrade GitHub Actions and add ARM64 Docker support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,11 +39,14 @@ jobs:
             type=sha
             type=raw,value=latest
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
+      - name: Build and push (multi-platform)
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

This PR addresses two issues:
- #92 - Upgrade GitHub Actions
- #99 - Docker镜像没有arm版本

## Changes

1. **Upgraded docker/build-push-action** from v5 to v6
2. **Added multi-platform build support** for both `linux/amd64` and `linux/arm64`
3. **Added GitHub Actions cache** (`cache-from` and `cache-to`) for faster subsequent builds

## Benefits

- Users on ARM-based machines can now use the official Docker image:
  - Apple Silicon Macs (M1/M2/M3/M4)
  - AWS Graviton instances
  - Raspberry Pi
  - Other ARM64 devices
- Faster CI builds with caching enabled

## Testing

The workflow uses QEMU for cross-platform emulation, which is already set up in the existing workflow.

Closes #92
Closes #99