### PR TITLE
fix: make vite proxy target configurable via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ ZEP_API_KEY=your_zep_api_key_here
 LLM_BOOST_API_KEY=your_api_key_here
 LLM_BOOST_BASE_URL=your_base_url_here
 LLM_BOOST_MODEL_NAME=your_model_name_here
+
+# ===== 前端配置（可选）=====
+# 后端 API 地址，默认 http://localhost:5001
+# 如果后端部署在其他地址或端口，请修改此项
+# VITE_API_BASE_URL=http://localhost:5001

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,17 +1,22 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [vue()],
-  server: {
-    port: 3000,
-    open: true,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:5001',
-        changeOrigin: true,
-        secure: false
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const apiBaseUrl = env.VITE_API_BASE_URL || 'http://localhost:5001'
+  
+  return {
+    plugins: [vue()],
+    server: {
+      port: 3000,
+      open: true,
+      proxy: {
+        '/api': {
+          target: apiBaseUrl,
+          changeOrigin: true,
+          secure: false
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

This PR addresses issue #93 - `frontend/src/api/index.js`中的`baseURL`不应该硬编码

## Problem

While `api/index.js` already supports `VITE_API_BASE_URL`, the vite dev server proxy in `vite.config.js` was still hardcoded to `http://localhost:5001`, causing issues when:
- Deploying with Docker using custom port mappings
- Running backend on a remote server
- Using non-standard ports

## Changes

1. **Updated `vite.config.js`** to read `VITE_API_BASE_URL` from environment variables
2. **Added documentation** in `.env.example` for the new configuration option

## Usage

```bash
# In .env file
VITE_API_BASE_URL=http://your-backend-host:5001
```

If not set, it defaults to `http://localhost:5001` for backward compatibility.

Closes #93