### PR TITLE
fix(llm_client): remove response_format json_object for local LLM compatibility

### DIFF
--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -88,7 +88,8 @@ class LLMClient:
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
-            response_format={"type": "json_object"}
+            # 不設 response_format 以相容 LM Studio / Ollama 等本地模型
+            # 依賴 prompt 中的 JSON 指示 + 下方的 markdown 清理邏輯
         )
         # 清理markdown代码块标记
         cleaned_response = response.strip()


### PR DESCRIPTION
## Problem

`chat_json()` uses `response_format={"type": "json_object"}`, but LM Studio and Ollama do not support this parameter (only `json_schema` or `text`), causing API calls to fail when using local LLMs.

Related references:
- LM Studio: https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/534
- Similar to issue #110 (API call failures)

## Solution

Remove `response_format` from `chat_json()`. The method already has robust markdown code fence cleanup logic (L93-97) that correctly parses JSON from raw LLM output, making `response_format` unnecessary.

This follows the same approach as commit 985f89f (handling `<think>` tags from reasoning models) — improving compatibility with diverse model outputs.

## Changed Files

- `backend/app/utils/llm_client.py`: Remove `response_format` in `chat_json()`, rely on prompt instructions + markdown cleanup

## Testing

- LM Studio + qwen3.5-9b: Full prediction pipeline (ontology → graph → prepare → simulate → report) passes
- Does not affect OpenAI API users (removing response_format is backwards compatible)