### PR TITLE
fix: robust JSON extraction for mixed LLM responses

### DIFF
--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -62,11 +62,41 @@ class LLMClient:
             kwargs["response_format"] = response_format
         
         response = self.client.chat.completions.create(**kwargs)
-        content = response.choices[0].message.content
-        # 部分模型（如MiniMax M2.5）会在content中包含<think>思考内容，需要移除
-        content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
+        content = response.choices[0].message.content or ""
+        # 部分模型会在 content 中夹带 <think>...</think>，且标签可能大小写不一致
+        content = re.sub(r'<think\b[^>]*>[\s\S]*?</think>', '', content, flags=re.IGNORECASE).strip()
         return content
     
+    @staticmethod
+    def _extract_json_payload(response_text: str) -> str:
+        """从模型文本中提取可解析的 JSON 负载。"""
+        text = (response_text or "").strip().lstrip('\ufeff')
+
+        # 清理 markdown 代码块
+        text = re.sub(r'^```(?:json)?\s*\n?', '', text, flags=re.IGNORECASE)
+        text = re.sub(r'\n?```\s*$', '', text)
+        text = text.strip()
+
+        # 如果整体已是合法 JSON，直接返回
+        try:
+            json.loads(text)
+            return text
+        except json.JSONDecodeError:
+            pass
+
+        # 提取首个 JSON 对象（兼容前后混入解释文本）
+        start = text.find('{')
+        end = text.rfind('}')
+        if start != -1 and end != -1 and end > start:
+            candidate = text[start:end + 1].strip()
+            try:
+                json.loads(candidate)
+                return candidate
+            except json.JSONDecodeError:
+                pass
+
+        return text
+
     def chat_json(
         self,
         messages: List[Dict[str, str]],
@@ -90,11 +120,7 @@ class LLMClient:
             max_tokens=max_tokens,
             response_format={"type": "json_object"}
         )
-        # 清理markdown代码块标记
-        cleaned_response = response.strip()
-        cleaned_response = re.sub(r'^```(?:json)?\s*\n?', '', cleaned_response, flags=re.IGNORECASE)
-        cleaned_response = re.sub(r'\n?```\s*$', '', cleaned_response)
-        cleaned_response = cleaned_response.strip()
+        cleaned_response = self._extract_json_payload(response)
 
         try:
             return json.loads(cleaned_response)

--- a/backend/tests/test_llm_client_json_extract.py
+++ b/backend/tests/test_llm_client_json_extract.py
@@ -1,0 +1,23 @@
+from app.utils.llm_client import LLMClient
+
+
+def test_extract_json_payload_from_markdown_fence():
+    raw = """```json
+    {"a": 1, "b": [2,3]}
+    ```"""
+
+    payload = LLMClient._extract_json_payload(raw)
+
+    assert payload == '{"a": 1, "b": [2,3]}'
+
+
+def test_extract_json_payload_with_prefixed_reasoning_text():
+    raw = """分析如下：
+<think>先思考</think>
+最终答案：
+{"entity_types": [], "edge_types": []}
+"""
+
+    payload = LLMClient._extract_json_payload(raw)
+
+    assert payload == '{"entity_types": [], "edge_types": []}'


### PR DESCRIPTION
## SummarynnHarden backend JSON parsing for LLM responses so mixed outputs (markdown fences, pre/post text) are handled more robustly, reducing 500 errors reported during ontology generation.nn## Changesnn- Updated `LLMClient.chat()` to remove `<think ...>...</think>` tags case-insensitivelyn- Added `LLMClient._extract_json_payload()` to normalize and extract JSON from noisy model responsesn- Updated `chat_json()` to parse extracted payload instead of raw contentn- Added unit tests in `backend/tests/test_llm_client_json_extract.py` for fenced JSON and mixed-text extractionnn## Testingnn- Added targeted unit tests for extraction behaviorn- Could not execute tests in this environment because backend dev dependencies are not installed (`pytest`, `flask` missing)nnFixes 666ghj/MiroFish#64