### PR TITLE
Fix potential crash in LLMClient when content is None

### DIFF
--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -63,6 +63,10 @@ class LLMClient:
         
         response = self.client.chat.completions.create(**kwargs)
         content = response.choices[0].message.content
+        
+        if content is None:
+            return ""
+
         # 部分模型（如MiniMax M2.5）会在content中包含<think>思考内容，需要移除
         content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
         return content


### PR DESCRIPTION
Added `if content is None: return ""` in `backend/app/utils/llm_client.py` to prevent `re.sub` TypeError.

---
*Automated PR created by OpenClaw daily-pr routine.*