### PR TITLE
docs: fix README alt text URL encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </br>
 <em>A Simple and Universal Swarm Intelligence Engine, Predicting Anything</em>
 
-<a href="https://www.shanda.com/" target="_blank"><img src="./static/image/shanda_logo.png" alt="666ghj%2MiroFish | Shanda" height="40"/></a>
+<a href="https://www.shanda.com/" target="_blank"><img src="./static/image/shanda_logo.png" alt="666ghj%2FMiroFish | Shanda" height="40"/></a>
 
 [![GitHub Stars](https://img.shields.io/github/stars/666ghj/MiroFish?style=flat-square&color=DAA520)](https://github.com/666ghj/MiroFish/stargazers)
 [![GitHub Watchers](https://img.shields.io/github/watchers/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/watchers)


### PR DESCRIPTION
## Summary

  Fix the Shanda image alt text in README.md by changing 666ghj%2MiroFish to 666ghj%2FMiroFish.

  ## Details

  666ghj%2MiroFish is not a valid URL-encoded representation, so it cannot be decoded correctly.
  Using 666ghj%2FMiroFish correctly encodes the slash and can be properly decoded to 666ghj/
  MiroFish.

  ## Impact

  Documentation-only change. No code or runtime behavior is affected.