### PR TITLE
Fix #180: Handle unsupported response_format parameter for non-OpenAI providers

### DIFF
--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -526,16 +526,32 @@ class OasisProfileGenerator:
         
         for attempt in range(max_attempts):
             try:
-                response = self.client.chat.completions.create(
-                    model=self.model_name,
-                    messages=[
+                kwargs = {
+                    "model": self.model_name,
+                    "messages": [
                         {"role": "system", "content": self._get_system_prompt(is_individual)},
                         {"role": "user", "content": prompt}
                     ],
-                    response_format={"type": "json_object"},
-                    temperature=0.7 - (attempt * 0.1)  # 每次重试降低温度
+                    "temperature": 0.7 - (attempt * 0.1)  # 每次重试降低温度
                     # 不设置max_tokens，让LLM自由发挥
-                )
+                }
+                
+                # 尝试使用 response_format，如果不支持则回退
+                try:
+                    kwargs["response_format"] = {"type": "json_object"}
+                    response = self.client.chat.completions.create(**kwargs)
+                except Exception as api_error:
+                    error_str = str(api_error).lower()
+                    if ("response_format" in error_str or 
+                        "json_object" in error_str or
+                        "unsupported" in error_str or
+                        "400" in error_str or
+                        "500" in error_str):
+                        # 移除 response_format 后重试
+                        kwargs.pop("response_format", None)
+                        response = self.client.chat.completions.create(**kwargs)
+                    else:
+                        raise
                 
                 content = response.choices[0].message.content
                 

--- a/backend/app/services/simulation_config_generator.py
+++ b/backend/app/services/simulation_config_generator.py
@@ -439,16 +439,32 @@ class SimulationConfigGenerator:
         
         for attempt in range(max_attempts):
             try:
-                response = self.client.chat.completions.create(
-                    model=self.model_name,
-                    messages=[
+                kwargs = {
+                    "model": self.model_name,
+                    "messages": [
                         {"role": "system", "content": system_prompt},
                         {"role": "user", "content": prompt}
                     ],
-                    response_format={"type": "json_object"},
-                    temperature=0.7 - (attempt * 0.1)  # 每次重试降低温度
+                    "temperature": 0.7 - (attempt * 0.1)  # 每次重试降低温度
                     # 不设置max_tokens，让LLM自由发挥
-                )
+                }
+                
+                # 尝试使用 response_format，如果不支持则回退
+                try:
+                    kwargs["response_format"] = {"type": "json_object"}
+                    response = self.client.chat.completions.create(**kwargs)
+                except Exception as api_error:
+                    error_str = str(api_error).lower()
+                    if ("response_format" in error_str or 
+                        "json_object" in error_str or
+                        "unsupported" in error_str or
+                        "400" in error_str or
+                        "500" in error_str):
+                        # 移除 response_format 后重试
+                        kwargs.pop("response_format", None)
+                        response = self.client.chat.completions.create(**kwargs)
+                    else:
+                        raise
                 
                 content = response.choices[0].message.content
                 finish_reason = response.choices[0].finish_reason

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -61,7 +61,22 @@ class LLMClient:
         if response_format:
             kwargs["response_format"] = response_format
         
-        response = self.client.chat.completions.create(**kwargs)
+        try:
+            response = self.client.chat.completions.create(**kwargs)
+        except Exception as e:
+            # 如果是因为 response_format 导致的错误，尝试不使用 response_format 重试
+            error_str = str(e).lower()
+            if response_format and ("response_format" in error_str or 
+                                    "json_object" in error_str or
+                                    "unsupported" in error_str or
+                                    "400" in error_str or
+                                    "500" in error_str):
+                # 移除 response_format 后重试
+                kwargs.pop("response_format", None)
+                response = self.client.chat.completions.create(**kwargs)
+            else:
+                raise
+        
         content = response.choices[0].message.content
         # 部分模型（如MiniMax M2.5）会在content中包含<think>思考内容，需要移除
         content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
@@ -84,12 +99,31 @@ class LLMClient:
         Returns:
             解析后的JSON对象
         """
-        response = self.chat(
-            messages=messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            response_format={"type": "json_object"}
-        )
+        try:
+            # 首先尝试使用 response_format 参数（OpenAI 原生支持）
+            response = self.chat(
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                response_format={"type": "json_object"}
+            )
+        except Exception as e:
+            # 如果失败，尝试不使用 response_format 重试
+            error_str = str(e).lower()
+            if ("response_format" in error_str or 
+                "json_object" in error_str or
+                "unsupported" in error_str or
+                "400" in error_str or
+                "500" in error_str):
+                # 不使用 response_format，依赖系统提示词中的 JSON 格式要求
+                response = self.chat(
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens
+                )
+            else:
+                raise
+        
         # 清理markdown代码块标记
         cleaned_response = response.strip()
         cleaned_response = re.sub(r'^```(?:json)?\s*\n?', '', cleaned_response, flags=re.IGNORECASE)
@@ -100,4 +134,3 @@ class LLMClient:
             return json.loads(cleaned_response)
         except json.JSONDecodeError:
             raise ValueError(f"LLM返回的JSON格式无效: {cleaned_response}")
-


### PR DESCRIPTION
## Problem
Ontology generation fails with 500 error when using LLM providers like Groq that don't support the OpenAI-specific `response_format={"type": "json_object"}` parameter.

## Root Cause
The code uses `response_format={"type": "json_object"}` which is an OpenAI-specific feature. When using Groq or other providers that don't support this parameter, the API call fails with a 500 error.

## Solution
Added graceful fallback logic in three files:
1. **llm_client.py** - Core LLM client with automatic retry without response_format
2. **simulation_config_generator.py** - Direct API calls with fallback
3. **oasis_profile_generator.py** - Direct API calls with fallback

When a 400/500 error related to response_format is detected, the code automatically retries without the parameter and relies on the system prompt to enforce JSON output format.

## Testing
- Tested with Groq API (llama-3.1-8b-instant, llama-3.2-1b-preview, llama-3.1-70b-versatile)
- Backwards compatible with OpenAI API
- No breaking changes to existing functionality

Fixes #180