### PR TITLE
feat(xml): add XML file support for parsing and ontology generation

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -170,35 +170,35 @@ def generate_ontology():
                 "success": False,
                 "error": "请至少上传一个文档文件"
             }), 400
-        
+
         # 创建项目
         project = ProjectManager.create_project(name=project_name)
         project.simulation_requirement = simulation_requirement
         logger.info(f"创建项目: {project.project_id}")
-        
+
         # 保存文件并提取文本
         document_texts = []
         all_text = ""
-        
+
         for file in uploaded_files:
             if file and file.filename and allowed_file(file.filename):
                 # 保存文件到项目目录
                 file_info = ProjectManager.save_file_to_project(
-                    project.project_id, 
-                    file, 
+                    project.project_id,
+                    file,
                     file.filename
                 )
                 project.files.append({
                     "filename": file_info["original_filename"],
                     "size": file_info["size"]
                 })
-                
+
                 # 提取文本
                 text = FileParser.extract_text(file_info["path"])
                 text = TextProcessor.preprocess_text(text)
                 document_texts.append(text)
                 all_text += f"\n\n=== {file_info['original_filename']} ===\n{text}"
-        
+
         if not document_texts:
             ProjectManager.delete_project(project.project_id)
             return jsonify({

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -38,7 +38,7 @@ class Config:
     # 文件上传配置
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50MB
     UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), '../uploads')
-    ALLOWED_EXTENSIONS = {'pdf', 'md', 'txt', 'markdown'}
+    ALLOWED_EXTENSIONS = {'pdf', 'md', 'txt', 'markdown', 'xml'}
     
     # 文本处理配置
     DEFAULT_CHUNK_SIZE = 500  # 默认切块大小

--- a/backend/app/utils/file_parser.py
+++ b/backend/app/utils/file_parser.py
@@ -1,9 +1,10 @@
 """
 文件解析工具
-支持PDF、Markdown、TXT文件的文本提取
+支持PDF、Markdown、TXT、XML文件的文本提取
 """
 
 import os
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import List, Optional
 
@@ -61,7 +62,7 @@ def _read_text_with_fallback(file_path: str) -> str:
 class FileParser:
     """文件解析器"""
     
-    SUPPORTED_EXTENSIONS = {'.pdf', '.md', '.markdown', '.txt'}
+    SUPPORTED_EXTENSIONS = {'.pdf', '.md', '.markdown', '.txt', '.xml'}
     
     @classmethod
     def extract_text(cls, file_path: str) -> str:
@@ -90,7 +91,9 @@ class FileParser:
             return cls._extract_from_md(file_path)
         elif suffix == '.txt':
             return cls._extract_from_txt(file_path)
-        
+        elif suffix == '.xml':
+            return cls._extract_from_xml(file_path)
+
         raise ValueError(f"无法处理的文件格式: {suffix}")
     
     @staticmethod
@@ -119,7 +122,79 @@ class FileParser:
     def _extract_from_txt(file_path: str) -> str:
         """从TXT提取文本，支持自动编码检测"""
         return _read_text_with_fallback(file_path)
-    
+
+    @staticmethod
+    def _extract_from_xml(file_path: str) -> str:
+        """
+        从XML文件提取文本，使用流式解析支持大文件。
+        自动检测Wikipedia XML dump格式，提取文章标题和正文。
+        对于普通XML，递归提取所有文本内容。
+        """
+        is_mediawiki = False
+        try:
+            for event, elem in ET.iterparse(file_path, events=('start',)):
+                local_tag = elem.tag.split('}')[-1] if '}' in elem.tag else elem.tag
+                if local_tag == 'mediawiki':
+                    is_mediawiki = True
+                break
+        except ET.ParseError:
+            pass
+
+        if is_mediawiki:
+            return FileParser._extract_mediawiki_xml(file_path)
+        else:
+            return FileParser._extract_generic_xml(file_path)
+
+    @staticmethod
+    def _extract_mediawiki_xml(file_path: str) -> str:
+        """
+        流式解析Wikipedia/MediaWiki XML dump。
+        提取每篇文章的标题和正文，适合1GB+大文件。
+        """
+        parts = []
+        current_title = None
+
+        for event, elem in ET.iterparse(file_path, events=('end',)):
+            tag = elem.tag.split('}')[-1] if '}' in elem.tag else elem.tag
+
+            if tag == 'title':
+                current_title = (elem.text or '').strip()
+            elif tag == 'text':
+                raw = (elem.text or '').strip()
+                if current_title and raw:
+                    parts.append(f"=== {current_title} ===\n{raw}")
+                elem.clear()
+            elif tag == 'page':
+                current_title = None
+                elem.clear()
+
+        return "\n\n".join(parts)
+
+    @staticmethod
+    def _extract_generic_xml(file_path: str) -> str:
+        """
+        解析普通XML文件，递归提取所有文本节点内容。
+        """
+        try:
+            tree = ET.parse(file_path)
+        except ET.ParseError as e:
+            raise ValueError(f"XML解析失败: {e}")
+
+        parts = []
+
+        def collect_text(elem):
+            text = (elem.text or '').strip()
+            tail = (elem.tail or '').strip()
+            if text:
+                parts.append(text)
+            for child in elem:
+                collect_text(child)
+            if tail:
+                parts.append(tail)
+
+        collect_text(tree.getroot())
+        return "\n".join(parts)
+
     @classmethod
     def extract_from_multiple(cls, file_paths: List[str]) -> str:
         """

--- a/backend/tests/test_file_parser_xml.py
+++ b/backend/tests/test_file_parser_xml.py
@@ -1,0 +1,152 @@
+"""Unit tests for XML parsing in FileParser."""
+
+import os
+import tempfile
+import textwrap
+import unittest
+
+from app.utils.file_parser import FileParser
+
+
+class TestExtractFromGenericXml(unittest.TestCase):
+    def _write(self, content: str, suffix=".xml") -> str:
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False, encoding="utf-8")
+        f.write(content)
+        f.close()
+        return f.name
+
+    def tearDown(self):
+        # nothing to clean up – each test removes its own file
+        pass
+
+    def test_simple_elements(self):
+        path = self._write("<root><a>Hello</a><b>World</b></root>")
+        try:
+            result = FileParser.extract_text(path)
+        finally:
+            os.unlink(path)
+        self.assertIn("Hello", result)
+        self.assertIn("World", result)
+
+    def test_nested_elements(self):
+        path = self._write("<root><outer><inner>Deep text</inner></outer></root>")
+        try:
+            result = FileParser.extract_text(path)
+        finally:
+            os.unlink(path)
+        self.assertIn("Deep text", result)
+
+    def test_tail_text(self):
+        path = self._write("<root><a>A</a>tail<b>B</b></root>")
+        try:
+            result = FileParser.extract_text(path)
+        finally:
+            os.unlink(path)
+        self.assertIn("tail", result)
+
+    def test_empty_xml(self):
+        path = self._write("<root></root>")
+        try:
+            result = FileParser.extract_text(path)
+        finally:
+            os.unlink(path)
+        self.assertEqual(result.strip(), "")
+
+    def test_invalid_xml_raises(self):
+        path = self._write("<root><unclosed>")
+        try:
+            with self.assertRaises(ValueError):
+                FileParser.extract_text(path)
+        finally:
+            os.unlink(path)
+
+
+class TestExtractFromMediawikiXml(unittest.TestCase):
+    MEDIAWIKI_TEMPLATE = textwrap.dedent("""\
+        <mediawiki xmlns="http://www.mediawiki.org/xml/export-0.11/">
+          <page>
+            <title>{title1}</title>
+            <revision>
+              <text>{text1}</text>
+            </revision>
+          </page>
+          <page>
+            <title>{title2}</title>
+            <revision>
+              <text>{text2}</text>
+            </revision>
+          </page>
+        </mediawiki>
+    """)
+
+    def _write_mediawiki(self, title1="Art1", text1="Content one",
+                         title2="Art2", text2="Content two") -> str:
+        xml = self.MEDIAWIKI_TEMPLATE.format(
+            title1=title1, text1=text1, title2=title2, text2=text2
+        )
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False, encoding="utf-8")
+        f.write(xml)
+        f.close()
+        return f.name
+
+    def test_both_articles_extracted(self):
+        path = self._write_mediawiki()
+        try:
+            result = FileParser.extract_text(path)
+        finally:
+            os.unlink(path)
+        self.assertIn("Art1", result)
+        self.assertIn("Content one", result)
+        self.assertIn("Art2", result)
+        self.assertIn("Content two", result)
+
+    def test_title_used_as_section_header(self):
+        path = self._write_mediawiki(title1="Python (language)")
+        try:
+            result = FileParser.extract_text(path)
+        finally:
+            os.unlink(path)
+        self.assertIn("=== Python (language) ===", result)
+
+    def test_empty_text_page_skipped(self):
+        path = self._write_mediawiki(title2="EmptyPage", text2="")
+        try:
+            result = FileParser.extract_text(path)
+        finally:
+            os.unlink(path)
+        self.assertNotIn("EmptyPage", result)
+
+    def test_multiple_pages_separated(self):
+        path = self._write_mediawiki(
+            title1="A", text1="alpha",
+            title2="B", text2="beta",
+        )
+        try:
+            result = FileParser.extract_text(path)
+        finally:
+            os.unlink(path)
+        idx_a = result.index("alpha")
+        idx_b = result.index("beta")
+        self.assertLess(idx_a, idx_b)
+
+
+class TestXmlInSupportedExtensions(unittest.TestCase):
+    def test_xml_in_supported_extensions(self):
+        self.assertIn(".xml", FileParser.SUPPORTED_EXTENSIONS)
+
+    def test_unsupported_extension_raises(self):
+        f = tempfile.NamedTemporaryFile(suffix=".xyz", delete=False)
+        f.close()
+        try:
+            with self.assertRaises(ValueError):
+                FileParser.extract_text(f.name)
+        finally:
+            os.unlink(f.name)
+
+    def test_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            FileParser.extract_text("/nonexistent/path/file.xml")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -125,7 +125,7 @@
             <div class="console-section">
               <div class="console-header">
                 <span class="console-label">01 / 现实种子</span>
-                <span class="console-meta">支持格式: PDF, MD, TXT</span>
+                <span class="console-meta">支持格式: PDF, MD, TXT, XML</span>
               </div>
               
               <div 
@@ -140,7 +140,7 @@
                   ref="fileInput"
                   type="file"
                   multiple
-                  accept=".pdf,.md,.txt"
+                  accept=".pdf,.md,.txt,.xml"
                   @change="handleFileSelect"
                   style="display: none"
                   :disabled="loading"
@@ -270,7 +270,7 @@ const handleDrop = (e) => {
 const addFiles = (newFiles) => {
   const validFiles = newFiles.filter(file => {
     const ext = file.name.split('.').pop().toLowerCase()
-    return ['pdf', 'md', 'txt'].includes(ext)
+    return ['pdf', 'md', 'txt', 'xml'].includes(ext)
   })
   files.value.push(...validFiles)
 }


### PR DESCRIPTION
## Summary

- Add XML parsing to `FileParser` with streaming support for MediaWiki/Wikipedia dumps and a generic XML fallback for all other XML files
- Add `.xml` to `ALLOWED_EXTENSIONS` in config
- Update frontend file accept filter and validation to include `.xml`
- Add unit tests covering generic XML, MediaWiki XML, and edge cases (12/12 passing)

## Test plan

- [x] Run `backend/tests/test_file_parser_xml.py` unit tests (12/12 passed)
- [x] Upload a generic `.xml` file via the UI and verify text is extracted correctly
- [x] Upload a MediaWiki XML dump and verify article titles and content are extracted
- [x] Verify unsupported file extensions are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)