### PR TITLE
feat(backend): Add Azure OpenAI provider and LLM provider switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,19 @@
-# LLM API配置（支持 OpenAI SDK 格式的任意 LLM API）
-# 推荐使用阿里百炼平台qwen-plus模型：https://bailian.console.aliyun.com/
-# 注意消耗较大，可先进行小于40轮的模拟尝试
+# LLM 提供商配置
+# 可选值: openai (默认), azure_openai
+LLM_PROVIDER=openai
+
+# ===== OpenAI SDK 配置 (Provider=openai) =====
+# 推荐使用阿里百炼 qwen-plus：https://bailian.console.aliyun.com/ 或 OpenAI 官方
 LLM_API_KEY=your_api_key_here
 LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 LLM_MODEL_NAME=qwen-plus
+
+# ===== Azure OpenAI 配置 (Provider=azure_openai) =====
+# AZURE_OPENAI_BASE_URL 或 AZURE_OPENAI_ENDPOINT 二选一；BASE_URL 需含 /openai/v1，ENDPOINT 会自动加 /openai/v1
+# AZURE_OPENAI_BASE_URL=https://your-resource.openai.azure.com/openai/v1
+# AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+# AZURE_OPENAI_API_KEY=your_azure_api_key_here
+# AZURE_OPENAI_DEPLOYMENT=your-deployment-name
 
 # ===== ZEP记忆图谱配置 =====
 # 每月免费额度即可支撑简单使用：https://app.getzep.com/

--- a/README-EN.md
+++ b/README-EN.md
@@ -114,13 +114,23 @@ cp .env.example .env
 
 **Required Environment Variables:**
 
+The backend supports two LLM providers, switched via `LLM_PROVIDER` (`openai` or `azure_openai`). This feature uses existing dependencies only—**no changes to `pyproject.toml` or `uv.lock` are required**.
+
 ```env
-# LLM API Configuration (supports any LLM API with OpenAI SDK format)
-# Recommended: Alibaba Qwen-plus model via Bailian Platform: https://bailian.console.aliyun.com/
+# LLM provider: openai (default) or azure_openai
+LLM_PROVIDER=openai
+
+# OpenAI-compatible API (when Provider=openai)
+# Recommended: Alibaba Qwen-plus via Bailian: https://bailian.console.aliyun.com/
 # High consumption, try simulations with fewer than 40 rounds first
 LLM_API_KEY=your_api_key
 LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 LLM_MODEL_NAME=qwen-plus
+
+# Azure OpenAI (when Provider=azure_openai)
+# Use either AZURE_OPENAI_BASE_URL or AZURE_OPENAI_ENDPOINT
+# AZURE_OPENAI_API_KEY=your_azure_key
+# AZURE_OPENAI_DEPLOYMENT=your-deployment-name
 
 # Zep Cloud Configuration
 # Free monthly quota is sufficient for simple usage: https://app.getzep.com/

--- a/README.md
+++ b/README.md
@@ -114,13 +114,23 @@ cp .env.example .env
 
 **必需的环境变量：**
 
+后端支持两种 LLM 提供商，通过 `LLM_PROVIDER` 切换（`openai` 或 `azure_openai`）。本功能仅使用现有依赖，**无需修改 `pyproject.toml` 或 `uv.lock`**。
+
 ```env
-# LLM API配置（支持 OpenAI SDK 格式的任意 LLM API）
-# 推荐使用阿里百炼平台qwen-plus模型：https://bailian.console.aliyun.com/
+# LLM 提供商：openai（默认）或 azure_openai
+LLM_PROVIDER=openai
+
+# OpenAI 兼容 API（Provider=openai 时使用）
+# 推荐使用阿里百炼平台 qwen-plus：https://bailian.console.aliyun.com/
 # 注意消耗较大，可先进行小于40轮的模拟尝试
 LLM_API_KEY=your_api_key
 LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 LLM_MODEL_NAME=qwen-plus
+
+# Azure OpenAI（Provider=azure_openai 时使用）
+# 二选一：AZURE_OPENAI_BASE_URL 或 AZURE_OPENAI_ENDPOINT
+# AZURE_OPENAI_API_KEY=your_azure_key
+# AZURE_OPENAI_DEPLOYMENT=your-deployment-name
 
 # Zep Cloud 配置
 # 每月免费额度即可支撑简单使用：https://app.getzep.com/

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,10 +27,19 @@ class Config:
     # JSON配置 - 禁用ASCII转义，让中文直接显示（而不是 \uXXXX 格式）
     JSON_AS_ASCII = False
     
-    # LLM配置（统一使用OpenAI格式）
+    # LLM 提供商配置（可选值: openai, azure_openai）
+    LLM_PROVIDER = os.environ.get('LLM_PROVIDER', 'openai')
+
+    # OpenAI 配置（Provider=openai）
     LLM_API_KEY = os.environ.get('LLM_API_KEY')
     LLM_BASE_URL = os.environ.get('LLM_BASE_URL', 'https://api.openai.com/v1')
     LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'gpt-4o-mini')
+
+    # Azure OpenAI 配置（Provider=azure_openai）
+    AZURE_OPENAI_API_KEY = os.environ.get('AZURE_OPENAI_API_KEY')
+    AZURE_OPENAI_BASE_URL = os.environ.get('AZURE_OPENAI_BASE_URL')
+    AZURE_OPENAI_ENDPOINT = (os.environ.get('AZURE_OPENAI_ENDPOINT') or '').rstrip('/')
+    AZURE_OPENAI_DEPLOYMENT = os.environ.get('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o')
     
     # Zep配置
     ZEP_API_KEY = os.environ.get('ZEP_API_KEY')
@@ -67,8 +76,13 @@ class Config:
     def validate(cls):
         """验证必要配置"""
         errors = []
-        if not cls.LLM_API_KEY:
-            errors.append("LLM_API_KEY 未配置")
+        if cls.LLM_PROVIDER == 'openai' and not cls.LLM_API_KEY:
+            errors.append("LLM_API_KEY 未配置 (OpenAI)")
+        elif cls.LLM_PROVIDER == 'azure_openai':
+            if not cls.AZURE_OPENAI_API_KEY:
+                errors.append("AZURE_OPENAI_API_KEY 未配置 (Azure OpenAI)")
+            if not cls.AZURE_OPENAI_BASE_URL and not cls.AZURE_OPENAI_ENDPOINT:
+                errors.append("AZURE_OPENAI_BASE_URL 或 AZURE_OPENAI_ENDPOINT 未配置 (Azure OpenAI)")
         if not cls.ZEP_API_KEY:
             errors.append("ZEP_API_KEY 未配置")
         return errors

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -1,6 +1,6 @@
 """
 LLM客户端封装
-统一使用OpenAI格式调用
+统一使用 OpenAI 格式 API；支持多提供商切换（openai / azure_openai）。
 """
 
 import json
@@ -9,10 +9,21 @@ from typing import Optional, Dict, Any, List
 from openai import OpenAI
 
 from ..config import Config
+from .logger import get_logger
+
+logger = get_logger("mirofish.llm_client")
+
+
+def _azure_openai_base_url() -> Optional[str]:
+    if Config.AZURE_OPENAI_BASE_URL:
+        return Config.AZURE_OPENAI_BASE_URL.rstrip("/")
+    if Config.AZURE_OPENAI_ENDPOINT:
+        return f"{Config.AZURE_OPENAI_ENDPOINT}/openai/v1"
+    return None
 
 
 class LLMClient:
-    """LLM客户端"""
+    """LLM 客户端（支持 OpenAI 与 Azure OpenAI，由 LLM_PROVIDER=openai|azure_openai 切换）"""
     
     def __init__(
         self,
@@ -20,18 +31,35 @@ class LLMClient:
         base_url: Optional[str] = None,
         model: Optional[str] = None
     ):
-        self.api_key = api_key or Config.LLM_API_KEY
-        self.base_url = base_url or Config.LLM_BASE_URL
-        self.model = model or Config.LLM_MODEL_NAME
-        
-        if not self.api_key:
-            raise ValueError("LLM_API_KEY 未配置")
-        
+        self.provider = Config.LLM_PROVIDER
+
+        if self.provider == 'azure_openai':
+            self.api_key = api_key or Config.AZURE_OPENAI_API_KEY
+            self.base_url = base_url or _azure_openai_base_url()
+            self.model = model or Config.AZURE_OPENAI_DEPLOYMENT
+            if not self.api_key:
+                raise ValueError("AZURE_OPENAI_API_KEY 未配置")
+            if not self.base_url:
+                raise ValueError("Azure OpenAI 需设置 AZURE_OPENAI_BASE_URL 或 AZURE_OPENAI_ENDPOINT")
+        else:
+            self.api_key = api_key or Config.LLM_API_KEY
+            self.base_url = base_url or Config.LLM_BASE_URL
+            self.model = model or Config.LLM_MODEL_NAME
+            if not self.api_key:
+                raise ValueError("LLM_API_KEY 未配置")
+
         self.client = OpenAI(
             api_key=self.api_key,
             base_url=self.base_url
         )
-    
+        _url = self.base_url or ""
+        logger.info(
+            "LLMClient 初始化: provider=%s, base_url=%s, model=%s",
+            self.provider,
+            _url[:60] + "..." if len(_url) > 60 else _url,
+            self.model,
+        )
+
     def chat(
         self,
         messages: List[Dict[str, str]],
@@ -51,21 +79,31 @@ class LLMClient:
         Returns:
             模型响应文本
         """
-        kwargs = {
+        kwargs: Dict[str, Any] = {
             "model": self.model,
             "messages": messages,
             "temperature": temperature,
-            "max_tokens": max_tokens,
         }
-        
+        # Azure OpenAI (e.g. gpt-5.2) uses max_completion_tokens; others use max_tokens
+        if self.provider == 'azure_openai':
+            kwargs["max_completion_tokens"] = max_tokens
+        else:
+            kwargs["max_tokens"] = max_tokens
+
         if response_format:
             kwargs["response_format"] = response_format
-        
-        response = self.client.chat.completions.create(**kwargs)
-        content = response.choices[0].message.content
-        # 部分模型（如MiniMax M2.5）会在content中包含<think>思考内容，需要移除
-        content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
-        return content
+
+        logger.debug("LLM chat 请求: model=%s, messages=%s, max_tokens=%s", self.model, len(messages), max_tokens)
+        try:
+            response = self.client.chat.completions.create(**kwargs)
+            content = response.choices[0].message.content
+            # 部分模型（如MiniMax M2.5）会在content中包含<think>思考内容，需要移除
+            content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
+            logger.info("LLM chat 成功: model=%s, response_len=%s", self.model, len(content or ""))
+            return content
+        except Exception as e:
+            logger.exception("LLM chat 失败: model=%s, base_url=%s, error=%s", self.model, self.base_url, e)
+            raise
     
     def chat_json(
         self,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1331,7 +1331,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1809,7 +1808,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1943,7 +1941,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -2018,7 +2015,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",


### PR DESCRIPTION
## Summary
Adds support for Azure OpenAI as a second LLM provider alongside the existing OpenAI-compatible API. Backend selects the provider via `LLM_PROVIDER` (`openai` or `azure_openai`).

## Changes
- **Config**: `LLM_PROVIDER`, Azure env vars (`AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_BASE_URL` or `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT`)
- **LLMClient**: Uses Azure config when `provider=azure_openai`; sends `max_completion_tokens` for Azure (replaces `max_tokens` for compatibility)
- **Logging**: Request/response and exception logging in `llm_client` for easier debugging
- **Docs**: `.env.example` and README (zh/en) updated with provider options and env examples. No new Python dependencies; `pyproject.toml` and `uv.lock` unchanged.

Made with [Cursor](https://cursor.com)