### PR TITLE
Harden ontology handling for Zep-backed simulations

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -236,6 +236,45 @@ def create_simulation():
         }), 500
 
 
+@simulation_bp.route('/<simulation_id>/counterfactual', methods=['POST'])
+def create_counterfactual_simulation(simulation_id: str):
+    """基于历史模拟创建一个注入新角色的反事实分支。"""
+    try:
+        data = request.get_json() or {}
+        actor = data.get('actor') or {}
+        injection_round = data.get('injection_round', 0)
+        opening_statement = data.get('opening_statement', '')
+
+        manager = SimulationManager()
+        result = manager.create_counterfactual_simulation(
+            base_simulation_id=simulation_id,
+            actor_data=actor,
+            injection_round=injection_round,
+            opening_statement=opening_statement,
+        )
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "simulation": result["state"].to_dict(),
+                "counterfactual": result["counterfactual"],
+            }
+        })
+
+    except ValueError as e:
+        return jsonify({
+            "success": False,
+            "error": str(e),
+        }), 400
+    except Exception as e:
+        logger.error(f"创建反事实分支失败: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
+
+
 def _check_simulation_prepared(simulation_id: str) -> tuple:
     """
     检查模拟是否已经准备完成

--- a/backend/app/services/graph_builder.py
+++ b/backend/app/services/graph_builder.py
@@ -4,6 +4,7 @@
 """
 
 import os
+import re
 import uuid
 import time
 import threading
@@ -215,6 +216,19 @@ class GraphBuilderService:
             if attr_name.lower() in RESERVED_NAMES:
                 return f"entity_{attr_name}"
             return attr_name
+
+        def safe_edge_name(raw_name: str, used_names: set[str]) -> str:
+            """Normalize edge names to the format Zep requires."""
+            normalized = re.sub(r"[^A-Za-z0-9]+", "_", str(raw_name or "").strip())
+            normalized = re.sub(r"(?<!^)(?=[A-Z])", "_", normalized)
+            normalized = re.sub(r"_+", "_", normalized).strip("_").upper() or "RELATES_TO"
+            candidate = normalized
+            suffix = 2
+            while candidate in used_names:
+                candidate = f"{normalized}_{suffix}"
+                suffix += 1
+            used_names.add(candidate)
+            return candidate
         
         # 动态创建实体类型
         entity_types = {}
@@ -242,8 +256,9 @@ class GraphBuilderService:
         
         # 动态创建边类型
         edge_definitions = {}
+        used_edge_names = set()
         for edge_def in ontology.get("edge_types", []):
-            name = edge_def["name"]
+            name = safe_edge_name(edge_def["name"], used_edge_names)
             description = edge_def.get("description", f"A {name} relationship.")
             
             # 创建属性字典和类型注解
@@ -497,4 +512,3 @@ class GraphBuilderService:
     def delete_graph(self, graph_id: str):
         """删除图谱"""
         self.client.graph.delete(graph_id=graph_id)
-

--- a/backend/app/services/ontology_generator.py
+++ b/backend/app/services/ontology_generator.py
@@ -265,24 +265,54 @@ class OntologyGenerator:
         if "analysis_summary" not in result:
             result["analysis_summary"] = ""
         
-        # 验证实体类型
+        cleaned_entities = []
         for entity in result["entity_types"]:
+            if not isinstance(entity, dict):
+                continue
+            name = str(entity.get("name", "")).strip()
+            if not name:
+                continue
+            entity["name"] = name
             if "attributes" not in entity:
                 entity["attributes"] = []
             if "examples" not in entity:
                 entity["examples"] = []
+            entity["attributes"] = [
+                attr for attr in entity.get("attributes", [])
+                if isinstance(attr, dict) and str(attr.get("name", "")).strip()
+            ]
             # 确保description不超过100字符
             if len(entity.get("description", "")) > 100:
                 entity["description"] = entity["description"][:97] + "..."
+            cleaned_entities.append(entity)
+        result["entity_types"] = cleaned_entities
         
-        # 验证关系类型
+        cleaned_edges = []
         for edge in result["edge_types"]:
+            if not isinstance(edge, dict):
+                continue
+            name = str(edge.get("name", "")).strip()
+            if not name:
+                continue
+            edge["name"] = name
             if "source_targets" not in edge:
                 edge["source_targets"] = []
             if "attributes" not in edge:
                 edge["attributes"] = []
+            edge["attributes"] = [
+                attr for attr in edge.get("attributes", [])
+                if isinstance(attr, dict) and str(attr.get("name", "")).strip()
+            ]
+            edge["source_targets"] = [
+                pair for pair in edge.get("source_targets", [])
+                if isinstance(pair, dict)
+                and str(pair.get("source", "")).strip()
+                and str(pair.get("target", "")).strip()
+            ]
             if len(edge.get("description", "")) > 100:
                 edge["description"] = edge["description"][:97] + "..."
+            cleaned_edges.append(edge)
+        result["edge_types"] = cleaned_edges
         
         # Zep API 限制：最多 10 个自定义实体类型，最多 10 个自定义边类型
         MAX_ENTITY_TYPES = 10
@@ -450,4 +480,3 @@ class OntologyGenerator:
         code_lines.append('}')
         
         return '\n'.join(code_lines)
-

--- a/backend/app/services/simulation_manager.py
+++ b/backend/app/services/simulation_manager.py
@@ -7,6 +7,8 @@ OASIS模拟管理器
 import os
 import json
 import shutil
+import csv
+import re
 from typing import Dict, Any, List, Optional
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -502,6 +504,189 @@ class SimulationManager:
         
         with open(config_path, 'r', encoding='utf-8') as f:
             return json.load(f)
+
+    @staticmethod
+    def _slugify_username(name: str, fallback: str) -> str:
+        """为 counterfactual agent 生成稳定用户名。"""
+        normalized = re.sub(r'[^a-z0-9]+', '_', (name or '').lower()).strip('_')
+        return normalized or fallback
+
+    def create_counterfactual_simulation(
+        self,
+        base_simulation_id: str,
+        actor_data: Dict[str, Any],
+        injection_round: int,
+        opening_statement: str = "",
+    ) -> Dict[str, Any]:
+        """基于历史模拟创建一个带注入角色的分支模拟。"""
+        base_state = self.get_simulation(base_simulation_id)
+        if not base_state:
+            raise ValueError(f"基础模拟不存在: {base_simulation_id}")
+
+        base_dir = self._get_simulation_dir(base_simulation_id)
+        base_config = self.get_simulation_config(base_simulation_id)
+        if not base_config:
+            raise ValueError(f"基础模拟缺少配置文件: {base_simulation_id}")
+
+        new_state = self.create_simulation(
+            project_id=base_state.project_id,
+            graph_id=base_state.graph_id,
+            enable_twitter=base_state.enable_twitter,
+            enable_reddit=base_state.enable_reddit,
+        )
+        new_dir = self._get_simulation_dir(new_state.simulation_id)
+
+        for filename in ("simulation_config.json", "reddit_profiles.json", "twitter_profiles.csv"):
+            source = os.path.join(base_dir, filename)
+            if os.path.exists(source):
+                shutil.copy2(source, os.path.join(new_dir, filename))
+
+        config_path = os.path.join(new_dir, "simulation_config.json")
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+
+        total_hours = config.get("time_config", {}).get("total_simulation_hours", 72)
+        minutes_per_round = config.get("time_config", {}).get("minutes_per_round", 30)
+        total_rounds = int(total_hours * 60 / minutes_per_round) if minutes_per_round else 0
+        injection_round = max(0, min(int(injection_round), total_rounds))
+
+        agent_configs = config.setdefault("agent_configs", [])
+        next_agent_id = max([cfg.get("agent_id", -1) for cfg in agent_configs], default=-1) + 1
+
+        actor_name = (actor_data.get("name") or "").strip()
+        if not actor_name:
+            raise ValueError("请提供注入角色名称")
+
+        entity_type = (actor_data.get("entity_type") or "StrategicActor").strip()
+        profession = (actor_data.get("profession") or entity_type).strip()
+        bio = (actor_data.get("bio") or "").strip()
+        persona = (actor_data.get("persona") or bio or f"{actor_name} joins the simulation as a counterfactual actor.").strip()
+        interested_topics = actor_data.get("interested_topics") or ["Geopolitics", "Forecasting"]
+        if isinstance(interested_topics, str):
+            interested_topics = [item.strip() for item in interested_topics.split(",") if item.strip()]
+
+        username_seed = self._slugify_username(actor_name, f"counterfactual_{next_agent_id}")
+        username = f"{username_seed}_{next_agent_id}"
+        active_hours = actor_data.get("active_hours") or list(range(8, 23))
+
+        new_agent_config = {
+            "agent_id": next_agent_id,
+            "entity_uuid": f"counterfactual_{new_state.simulation_id}_{next_agent_id}",
+            "entity_name": actor_name,
+            "entity_type": entity_type,
+            "activity_level": float(actor_data.get("activity_level", 0.45)),
+            "posts_per_hour": float(actor_data.get("posts_per_hour", 1.0)),
+            "comments_per_hour": float(actor_data.get("comments_per_hour", 0.7)),
+            "active_hours": [int(hour) for hour in active_hours],
+            "response_delay_min": int(actor_data.get("response_delay_min", 10)),
+            "response_delay_max": int(actor_data.get("response_delay_max", 45)),
+            "sentiment_bias": float(actor_data.get("sentiment_bias", 0.0)),
+            "stance": (actor_data.get("stance") or "observer").strip(),
+            "influence_weight": float(actor_data.get("influence_weight", 2.4)),
+            "injection_round": injection_round,
+            "counterfactual": True,
+        }
+        agent_configs.append(new_agent_config)
+
+        reddit_profile_path = os.path.join(new_dir, "reddit_profiles.json")
+        if os.path.exists(reddit_profile_path):
+            with open(reddit_profile_path, 'r', encoding='utf-8') as f:
+                reddit_profiles = json.load(f)
+        else:
+            reddit_profiles = []
+        reddit_profiles.append({
+            "user_id": next_agent_id,
+            "username": username,
+            "name": actor_name,
+            "bio": (bio or persona)[:150],
+            "persona": persona,
+            "karma": int(actor_data.get("karma", 1800)),
+            "created_at": datetime.now().date().isoformat(),
+            "age": int(actor_data.get("age", 38)),
+            "gender": actor_data.get("gender", "other"),
+            "mbti": actor_data.get("mbti", "INTJ"),
+            "country": actor_data.get("country", "Global"),
+            "profession": profession,
+            "interested_topics": interested_topics,
+        })
+        with open(reddit_profile_path, 'w', encoding='utf-8') as f:
+            json.dump(reddit_profiles, f, ensure_ascii=False, indent=2)
+
+        twitter_profile_path = os.path.join(new_dir, "twitter_profiles.csv")
+        twitter_fieldnames = ["user_id", "name", "username", "user_char", "description"]
+        twitter_rows = []
+        if os.path.exists(twitter_profile_path):
+            with open(twitter_profile_path, 'r', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                twitter_rows = list(reader)
+                if reader.fieldnames:
+                    twitter_fieldnames = reader.fieldnames
+        twitter_rows.append({
+            "user_id": str(next_agent_id),
+            "name": actor_name,
+            "username": username,
+            "user_char": persona[:800],
+            "description": (bio or persona)[:160],
+        })
+        with open(twitter_profile_path, 'w', encoding='utf-8', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=twitter_fieldnames)
+            writer.writeheader()
+            writer.writerows(twitter_rows)
+
+        event_config = config.setdefault("event_config", {})
+        event_config.setdefault("initial_posts", [])
+        event_config.setdefault("scheduled_events", [])
+        event_config.setdefault("hot_topics", [])
+
+        if interested_topics:
+            for topic in interested_topics[:4]:
+                if topic not in event_config["hot_topics"]:
+                    event_config["hot_topics"].append(topic)
+
+        opening_statement = (opening_statement or "").strip()
+        if opening_statement:
+            event_payload = {
+                "round_num": injection_round,
+                "poster_type": entity_type,
+                "poster_agent_id": next_agent_id,
+                "content": opening_statement,
+                "platform": "all",
+            }
+            if injection_round <= 0:
+                event_config["initial_posts"].append(event_payload)
+            else:
+                event_config["scheduled_events"].append(event_payload)
+
+        base_requirement = config.get("simulation_requirement", "")
+        branch_note = (
+            f"Counterfactual branch from {base_simulation_id}: inject actor '{actor_name}' "
+            f"({entity_type}) at round {injection_round} and observe how discourse and outcome shift."
+        )
+        config["simulation_requirement"] = f"{base_requirement}\n\n{branch_note}".strip()
+        config["counterfactual"] = {
+            "base_simulation_id": base_simulation_id,
+            "created_at": datetime.now().isoformat(),
+            "actor_name": actor_name,
+            "entity_type": entity_type,
+            "injection_round": injection_round,
+            "opening_statement": opening_statement,
+        }
+
+        with open(config_path, 'w', encoding='utf-8') as f:
+            json.dump(config, f, ensure_ascii=False, indent=2)
+
+        new_state.status = SimulationStatus.READY
+        new_state.entities_count = max(base_state.entities_count, len(agent_configs))
+        new_state.profiles_count = max(base_state.profiles_count, len(agent_configs))
+        new_state.entity_types = sorted(set(base_state.entity_types + [entity_type]))
+        new_state.config_generated = True
+        new_state.config_reasoning = f"{base_state.config_reasoning}\nCounterfactual branch: {branch_note}".strip()
+        self._save_simulation_state(new_state)
+
+        return {
+            "state": new_state,
+            "counterfactual": config["counterfactual"],
+        }
     
     def get_run_instructions(self, simulation_id: str) -> Dict[str, str]:
         """获取运行说明"""

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -1067,6 +1067,10 @@ def get_active_agents_for_round(
         agent_id = cfg.get("agent_id", 0)
         active_hours = cfg.get("active_hours", list(range(8, 23)))
         activity_level = cfg.get("activity_level", 0.5)
+        injection_round = int(cfg.get("injection_round", 0) or 0)
+
+        if injection_round > 0 and (round_num + 1) < injection_round:
+            continue
         
         if current_hour not in active_hours:
             continue
@@ -1088,6 +1092,57 @@ def get_active_agents_for_round(
             pass
     
     return active_agents
+
+
+async def run_scheduled_events_for_round(
+    env,
+    scheduled_events: List[Dict[str, Any]],
+    current_round: int,
+    platform: str,
+):
+    """执行当前轮次的计划事件，并返回已占用的 agent_id。"""
+    event_actions = {}
+    triggered_agent_ids = set()
+
+    for event in scheduled_events:
+        try:
+            event_round = int(event.get("round_num", 0) or 0)
+        except Exception:
+            event_round = 0
+
+        if event_round != current_round:
+            continue
+
+        event_platform = (event.get("platform") or "all").lower()
+        if event_platform not in ("all", platform):
+            continue
+
+        agent_id = event.get("poster_agent_id")
+        content = (event.get("content") or "").strip()
+        if agent_id is None or not content:
+            continue
+
+        try:
+            agent = env.agent_graph.get_agent(agent_id)
+        except Exception:
+            continue
+
+        action = ManualAction(
+            action_type=ActionType.CREATE_POST,
+            action_args={"content": content}
+        )
+        if agent in event_actions:
+            if not isinstance(event_actions[agent], list):
+                event_actions[agent] = [event_actions[agent]]
+            event_actions[agent].append(action)
+        else:
+            event_actions[agent] = action
+        triggered_agent_ids.add(agent_id)
+
+    if event_actions:
+        await env.step(event_actions)
+
+    return triggered_agent_ids, len(event_actions)
 
 
 class PlatformSimulation:
@@ -1171,6 +1226,7 @@ async def run_twitter_simulation(
     # 执行初始事件
     event_config = config.get("event_config", {})
     initial_posts = event_config.get("initial_posts", [])
+    scheduled_events = event_config.get("scheduled_events", [])
     
     # 记录 round 0 开始（初始事件阶段）
     if action_logger:
@@ -1243,15 +1299,26 @@ async def run_twitter_simulation(
         # 无论是否有活跃agent，都记录round开始
         if action_logger:
             action_logger.log_round_start(round_num + 1, simulated_hour)
+
+        scheduled_agent_ids, scheduled_count = await run_scheduled_events_for_round(
+            result.env,
+            scheduled_events,
+            round_num + 1,
+            "twitter",
+        )
         
         if not active_agents:
-            # 没有活跃agent时也记录round结束（actions_count=0）
+            active_agents = []
+        elif scheduled_agent_ids:
+            active_agents = [(agent_id, agent) for agent_id, agent in active_agents if agent_id not in scheduled_agent_ids]
+
+        if active_agents:
+            actions = {agent: LLMAction() for _, agent in active_agents}
+            await result.env.step(actions)
+        elif scheduled_count == 0:
             if action_logger:
                 action_logger.log_round_end(round_num + 1, 0)
             continue
-        
-        actions = {agent: LLMAction() for _, agent in active_agents}
-        await result.env.step(actions)
         
         # 从数据库获取实际执行的动作并记录
         actual_actions, last_rowid = fetch_new_actions_from_db(
@@ -1362,6 +1429,7 @@ async def run_reddit_simulation(
     # 执行初始事件
     event_config = config.get("event_config", {})
     initial_posts = event_config.get("initial_posts", [])
+    scheduled_events = event_config.get("scheduled_events", [])
     
     # 记录 round 0 开始（初始事件阶段）
     if action_logger:
@@ -1442,15 +1510,26 @@ async def run_reddit_simulation(
         # 无论是否有活跃agent，都记录round开始
         if action_logger:
             action_logger.log_round_start(round_num + 1, simulated_hour)
+
+        scheduled_agent_ids, scheduled_count = await run_scheduled_events_for_round(
+            result.env,
+            scheduled_events,
+            round_num + 1,
+            "reddit",
+        )
         
         if not active_agents:
-            # 没有活跃agent时也记录round结束（actions_count=0）
+            active_agents = []
+        elif scheduled_agent_ids:
+            active_agents = [(agent_id, agent) for agent_id, agent in active_agents if agent_id not in scheduled_agent_ids]
+
+        if active_agents:
+            actions = {agent: LLMAction() for _, agent in active_agents}
+            await result.env.step(actions)
+        elif scheduled_count == 0:
             if action_logger:
                 action_logger.log_round_end(round_num + 1, 0)
             continue
-        
-        actions = {agent: LLMAction() for _, agent in active_agents}
-        await result.env.step(actions)
         
         # 从数据库获取实际执行的动作并记录
         actual_actions, last_rowid = fetch_new_actions_from_db(

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -498,6 +498,10 @@ class RedditSimulationRunner:
             agent_id = cfg.get("agent_id", 0)
             active_hours = cfg.get("active_hours", list(range(8, 23)))
             activity_level = cfg.get("activity_level", 0.5)
+            injection_round = int(cfg.get("injection_round", 0) or 0)
+
+            if injection_round > 0 and (round_num + 1) < injection_round:
+                continue
             
             if current_hour not in active_hours:
                 continue
@@ -519,6 +523,54 @@ class RedditSimulationRunner:
                 pass
         
         return active_agents
+
+    async def _run_scheduled_events_for_round(self, current_round: int) -> set:
+        """执行当前轮次的计划事件，并返回已占用的 agent_id。"""
+        event_config = self.config.get("event_config", {})
+        scheduled_events = event_config.get("scheduled_events", [])
+        event_actions = {}
+        triggered_agent_ids = set()
+
+        for event in scheduled_events:
+            try:
+                event_round = int(event.get("round_num", 0) or 0)
+            except Exception:
+                event_round = 0
+
+            if event_round != current_round:
+                continue
+
+            event_platform = (event.get("platform") or "all").lower()
+            if event_platform not in ("all", "reddit"):
+                continue
+
+            agent_id = event.get("poster_agent_id")
+            content = (event.get("content") or "").strip()
+            if agent_id is None or not content:
+                continue
+
+            try:
+                agent = self.env.agent_graph.get_agent(agent_id)
+            except Exception as e:
+                print(f"  警告: 无法执行计划事件 Agent {agent_id}: {e}")
+                continue
+
+            action = ManualAction(
+                action_type=ActionType.CREATE_POST,
+                action_args={"content": content}
+            )
+            if agent in event_actions:
+                if not isinstance(event_actions[agent], list):
+                    event_actions[agent] = [event_actions[agent]]
+                event_actions[agent].append(action)
+            else:
+                event_actions[agent] = action
+            triggered_agent_ids.add(agent_id)
+
+        if event_actions:
+            await self.env.step(event_actions)
+
+        return triggered_agent_ids
     
     async def run(self, max_rounds: int = None):
         """运行Reddit模拟
@@ -631,16 +683,22 @@ class RedditSimulationRunner:
             active_agents = self._get_active_agents_for_round(
                 self.env, simulated_hour, round_num
             )
+
+            scheduled_agent_ids = await self._run_scheduled_events_for_round(round_num + 1)
+            if scheduled_agent_ids:
+                active_agents = [(agent_id, agent) for agent_id, agent in active_agents if agent_id not in scheduled_agent_ids]
             
             if not active_agents:
-                continue
+                if not scheduled_agent_ids:
+                    continue
             
-            actions = {
-                agent: LLMAction()
-                for _, agent in active_agents
-            }
-            
-            await self.env.step(actions)
+            if active_agents:
+                actions = {
+                    agent: LLMAction()
+                    for _, agent in active_agents
+                }
+                
+                await self.env.step(actions)
             
             if (round_num + 1) % 10 == 0 or round_num == 0:
                 elapsed = (datetime.now() - start_time).total_seconds()
@@ -766,4 +824,3 @@ if __name__ == "__main__":
         pass
     finally:
         print("模拟进程已退出")
-

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -502,6 +502,10 @@ class TwitterSimulationRunner:
             agent_id = cfg.get("agent_id", 0)
             active_hours = cfg.get("active_hours", list(range(8, 23)))
             activity_level = cfg.get("activity_level", 0.5)
+            injection_round = int(cfg.get("injection_round", 0) or 0)
+
+            if injection_round > 0 and (round_num + 1) < injection_round:
+                continue
             
             # 检查是否在活跃时间
             if current_hour not in active_hours:
@@ -527,6 +531,49 @@ class TwitterSimulationRunner:
                 pass
         
         return active_agents
+
+    async def _run_scheduled_events_for_round(self, current_round: int) -> set:
+        """执行当前轮次的计划事件，并返回已占用的 agent_id。"""
+        event_config = self.config.get("event_config", {})
+        scheduled_events = event_config.get("scheduled_events", [])
+        event_actions = {}
+        triggered_agent_ids = set()
+
+        for event in scheduled_events:
+            try:
+                event_round = int(event.get("round_num", 0) or 0)
+            except Exception:
+                event_round = 0
+
+            if event_round != current_round:
+                continue
+
+            event_platform = (event.get("platform") or "all").lower()
+            if event_platform not in ("all", "twitter"):
+                continue
+
+            agent_id = event.get("poster_agent_id")
+            content = (event.get("content") or "").strip()
+            if agent_id is None or not content:
+                continue
+
+            try:
+                agent = self.env.agent_graph.get_agent(agent_id)
+            except Exception as e:
+                print(f"  警告: 无法执行计划事件 Agent {agent_id}: {e}")
+                continue
+
+            action = ManualAction(
+                action_type=ActionType.CREATE_POST,
+                action_args={"content": content}
+            )
+            event_actions[agent] = action
+            triggered_agent_ids.add(agent_id)
+
+        if event_actions:
+            await self.env.step(event_actions)
+
+        return triggered_agent_ids
     
     async def run(self, max_rounds: int = None):
         """运行Twitter模拟
@@ -640,18 +687,24 @@ class TwitterSimulationRunner:
             active_agents = self._get_active_agents_for_round(
                 self.env, simulated_hour, round_num
             )
+
+            scheduled_agent_ids = await self._run_scheduled_events_for_round(round_num + 1)
+            if scheduled_agent_ids:
+                active_agents = [(agent_id, agent) for agent_id, agent in active_agents if agent_id not in scheduled_agent_ids]
             
             if not active_agents:
-                continue
+                if not scheduled_agent_ids:
+                    continue
             
             # 构建动作
-            actions = {
-                agent: LLMAction()
-                for _, agent in active_agents
-            }
-            
-            # 执行动作
-            await self.env.step(actions)
+            if active_agents:
+                actions = {
+                    agent: LLMAction()
+                    for _, agent in active_agents
+                }
+                
+                # 执行动作
+                await self.env.step(actions)
             
             # 打印进度
             if (round_num + 1) % 10 == 0 or round_num == 0:

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -185,3 +185,11 @@ export const getSimulationHistory = (limit = 20) => {
   return service.get('/api/simulation/history', { params: { limit } })
 }
 
+/**
+ * 基于历史模拟创建反事实分支
+ * @param {string} simulationId
+ * @param {Object} data - { actor, injection_round, opening_statement? }
+ */
+export const createCounterfactualSimulation = (simulationId, data) => {
+  return requestWithRetry(() => service.post(`/api/simulation/${simulationId}/counterfactual`, data), 2, 500)
+}

--- a/frontend/src/components/CounterfactualArchivePanel.vue
+++ b/frontend/src/components/CounterfactualArchivePanel.vue
@@ -1,0 +1,340 @@
+<template>
+  <div class="archive-panel">
+    <section class="panel-block hero-block">
+      <div class="block-head">
+        <span class="block-kicker">ARCHIVE SIGNAL</span>
+        <span class="block-id">{{ compactId }}</span>
+      </div>
+      <h2 class="block-title">Historical Run Snapshot</h2>
+      <p class="block-copy">{{ requirementExcerpt }}</p>
+      <div class="metric-grid">
+        <div class="metric-card">
+          <span class="metric-label">Actions</span>
+          <span class="metric-value">{{ totalActions }}</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-label">Rounds</span>
+          <span class="metric-value">{{ totalRounds }}</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-label">Agents</span>
+          <span class="metric-value">{{ agentStats.length }}</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel-block round-block">
+      <div class="block-head">
+        <span class="block-kicker">ROUND MAP</span>
+        <span class="round-pill">R{{ selectedRound }}</span>
+      </div>
+      <input
+        class="round-slider"
+        type="range"
+        :min="0"
+        :max="sliderMax"
+        :value="selectedRound"
+        @input="emitRound($event.target.value)"
+      />
+      <div class="round-labels">
+        <span>0</span>
+        <span>{{ Math.floor(sliderMax / 2) }}</span>
+        <span>{{ sliderMax }}</span>
+      </div>
+      <div class="heat-strip">
+        <button
+          v-for="round in timeline"
+          :key="round.round_num"
+          class="heat-cell"
+          :class="{ active: round.round_num === selectedRound }"
+          :style="{ '--cell-height': `${cellHeight(round)}px` }"
+          @click="emitRound(round.round_num)"
+          :title="`Round ${round.round_num}: ${round.total_actions} actions`"
+        >
+          <span></span>
+        </button>
+      </div>
+    </section>
+
+    <section class="panel-block agent-block">
+      <div class="block-head">
+        <span class="block-kicker">ACTIVE SOCIETIES</span>
+        <span class="subtle">Top movers</span>
+      </div>
+      <div class="agent-list">
+        <div v-for="agent in topAgents" :key="agent.agent_id" class="agent-row">
+          <div>
+            <div class="agent-name">{{ agent.agent_name || `Agent ${agent.agent_id}` }}</div>
+            <div class="agent-meta">TW {{ agent.twitter_actions }} / RD {{ agent.reddit_actions }}</div>
+          </div>
+          <span class="agent-total">{{ agent.total_actions }}</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel-block action-block">
+      <div class="block-head">
+        <span class="block-kicker">ROUND {{ selectedRound }}</span>
+        <span class="subtle">{{ loadingActions ? 'Loading' : `${roundActions.length} captured` }}</span>
+      </div>
+      <div v-if="loadingActions" class="empty-state">Loading archived actions...</div>
+      <div v-else-if="roundActions.length === 0" class="empty-state">No archived actions in this round.</div>
+      <div v-else class="action-list">
+        <article v-for="action in roundActions" :key="action.id || `${action.timestamp}-${action.agent_id}-${action.action_type}`" class="action-item">
+          <div class="action-top">
+            <span class="action-agent">{{ action.agent_name || `Agent ${action.agent_id}` }}</span>
+            <span class="action-type">{{ action.action_type }}</span>
+          </div>
+          <div class="action-body">{{ actionText(action) }}</div>
+          <div class="action-meta">{{ action.platform }} · {{ action.timestamp ? formatTime(action.timestamp) : 'n/a' }}</div>
+        </article>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  simulationId: String,
+  simulationData: Object,
+  simulationConfig: Object,
+  timeline: {
+    type: Array,
+    default: () => []
+  },
+  agentStats: {
+    type: Array,
+    default: () => []
+  },
+  roundActions: {
+    type: Array,
+    default: () => []
+  },
+  selectedRound: {
+    type: Number,
+    default: 0
+  },
+  loadingActions: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['update:selectedRound'])
+
+const compactId = computed(() => (props.simulationId || 'sim_unknown').replace('sim_', 'SIM_').toUpperCase())
+const totalActions = computed(() => props.timeline.reduce((sum, round) => sum + (round.total_actions || 0), 0))
+const totalRounds = computed(() => props.timeline.length ? Math.max(...props.timeline.map(item => item.round_num || 0)) : 0)
+const sliderMax = computed(() => totalRounds.value || 1)
+const topAgents = computed(() => props.agentStats.slice(0, 8))
+const requirementExcerpt = computed(() => {
+  const requirement = props.simulationConfig?.simulation_requirement || props.simulationData?.simulation_requirement || ''
+  if (!requirement) return 'Archived simulation context ready for counterfactual branching.'
+  return requirement.length > 220 ? `${requirement.slice(0, 220)}...` : requirement
+})
+
+function emitRound(value) {
+  emit('update:selectedRound', Number(value))
+}
+
+function cellHeight(round) {
+  const max = Math.max(...props.timeline.map(item => item.total_actions || 0), 1)
+  return 10 + (((round.total_actions || 0) / max) * 44)
+}
+
+function actionText(action) {
+  const args = action.action_args || {}
+  return args.content || args.quote_content || args.query || args.post_content || args.original_content || 'No captured body.'
+}
+
+function formatTime(timestamp) {
+  try {
+    return new Date(timestamp).toLocaleTimeString('en-US', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    })
+  } catch {
+    return timestamp
+  }
+}
+</script>
+
+<style scoped>
+.archive-panel {
+  height: 100%;
+  overflow-y: auto;
+  padding: 24px;
+  background: linear-gradient(180deg, #f7f7f4 0%, #eeefe7 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.panel-block {
+  border: 1px solid #d7d9cf;
+  background: rgba(255, 255, 255, 0.74);
+  padding: 18px;
+  box-shadow: 0 8px 20px rgba(19, 24, 19, 0.06);
+}
+
+.block-head,
+.metric-grid,
+.agent-row,
+.action-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.block-kicker,
+.block-id,
+.round-pill,
+.action-type,
+.action-meta,
+.agent-meta,
+.subtle {
+  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
+}
+
+.block-kicker,
+.subtle,
+.block-id {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: #5d665e;
+}
+
+.block-title {
+  margin: 12px 0 8px;
+  font-size: 28px;
+  line-height: 1.1;
+  color: #11150f;
+}
+
+.block-copy {
+  margin: 0;
+  color: #425044;
+  line-height: 1.7;
+  font-size: 14px;
+}
+
+.metric-grid {
+  margin-top: 18px;
+}
+
+.metric-card {
+  flex: 1;
+  padding: 12px 14px;
+  border: 1px solid #dde2d2;
+  background: #fdfef8;
+}
+
+.metric-label {
+  display: block;
+  font-size: 12px;
+  color: #66715f;
+  margin-bottom: 8px;
+}
+
+.metric-value {
+  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
+  font-size: 24px;
+  color: #121611;
+}
+
+.round-slider {
+  width: 100%;
+  margin-top: 14px;
+}
+
+.round-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  color: #697267;
+}
+
+.heat-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10px, 1fr));
+  gap: 6px;
+  align-items: end;
+  margin-top: 18px;
+}
+
+.heat-cell {
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
+.heat-cell span {
+  display: block;
+  width: 100%;
+  height: var(--cell-height);
+  min-height: 10px;
+  background: linear-gradient(180deg, #bcc8bc, #4b5e51);
+  opacity: 0.45;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.heat-cell.active span,
+.heat-cell:hover span {
+  opacity: 1;
+  transform: translateY(-2px);
+}
+
+.round-pill,
+.action-type,
+.agent-total {
+  color: #0f1510;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+}
+
+.agent-list,
+.action-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.agent-row,
+.action-item {
+  border: 1px solid #dfe3d8;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 12px 14px;
+}
+
+.agent-name,
+.action-agent {
+  color: #131813;
+  font-weight: 600;
+}
+
+.action-body {
+  margin-top: 10px;
+  color: #455145;
+  line-height: 1.6;
+  font-size: 13px;
+}
+
+.empty-state {
+  margin-top: 14px;
+  border: 1px dashed #c8d0c3;
+  padding: 20px;
+  text-align: center;
+  color: #6a7368;
+  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
+  font-size: 12px;
+}
+</style>

--- a/frontend/src/components/CounterfactualLabPanel.vue
+++ b/frontend/src/components/CounterfactualLabPanel.vue
@@ -1,0 +1,376 @@
+<template>
+  <div class="lab-panel">
+    <section class="lab-shell">
+      <div class="shell-head">
+        <div>
+          <span class="shell-kicker">COUNTERFACTUAL LAB</span>
+          <h2>Inject an actor into a historical run</h2>
+        </div>
+        <div class="shell-note">Base run stays untouched</div>
+      </div>
+
+      <div class="lab-grid">
+        <label class="field full">
+          <span>Template Profile</span>
+          <select v-model="selectedTemplateId" @change="applyTemplate">
+            <option value="">Custom actor</option>
+            <option v-for="profile in profiles" :key="profile.user_id" :value="String(profile.user_id)">
+              {{ profile.name }} · {{ profile.profession || profile.country || 'template' }}
+            </option>
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Actor Name</span>
+          <input v-model="form.name" type="text" placeholder="EU backchannel envoy" />
+        </label>
+
+        <label class="field">
+          <span>Role</span>
+          <select v-model="form.entity_type">
+            <option>Diplomat</option>
+            <option>GovernmentOfficial</option>
+            <option>MediaOutlet</option>
+            <option>Organization</option>
+            <option>PredictionMarket</option>
+            <option>StrategicActor</option>
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Profession</span>
+          <input v-model="form.profession" type="text" placeholder="Diplomatic mediator" />
+        </label>
+
+        <label class="field">
+          <span>Country</span>
+          <input v-model="form.country" type="text" placeholder="France" />
+        </label>
+
+        <label class="field">
+          <span>Stance</span>
+          <select v-model="form.stance">
+            <option>observer</option>
+            <option>mediator</option>
+            <option>hawkish</option>
+            <option>dovish</option>
+            <option>neutral</option>
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Injection Round</span>
+          <input v-model.number="form.injection_round" type="number" :min="0" :max="maxRound" />
+        </label>
+
+        <label class="field">
+          <span>Active Hours Preset</span>
+          <select v-model="form.active_hours_preset">
+            <option value="office">Office Hours</option>
+            <option value="newsdesk">Newsdesk</option>
+            <option value="always_on">Always On</option>
+            <option value="evening">Evening Window</option>
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Activity Level</span>
+          <input v-model.number="form.activity_level" type="range" min="0.1" max="1" step="0.05" />
+          <small>{{ form.activity_level.toFixed(2) }}</small>
+        </label>
+
+        <label class="field">
+          <span>Influence Weight</span>
+          <input v-model.number="form.influence_weight" type="range" min="1" max="5" step="0.1" />
+          <small>{{ form.influence_weight.toFixed(1) }}</small>
+        </label>
+
+        <label class="field">
+          <span>Posts / Hour</span>
+          <input v-model.number="form.posts_per_hour" type="number" min="0.1" max="6" step="0.1" />
+        </label>
+
+        <label class="field">
+          <span>Comments / Hour</span>
+          <input v-model.number="form.comments_per_hour" type="number" min="0.1" max="6" step="0.1" />
+        </label>
+
+        <label class="field full">
+          <span>Interested Topics</span>
+          <input v-model="form.interested_topics_text" type="text" placeholder="backchannel diplomacy, nuclear inspections, sanctions relief" />
+        </label>
+
+        <label class="field full">
+          <span>Bio</span>
+          <textarea v-model="form.bio" rows="3" placeholder="Short public-facing identity for the injected actor"></textarea>
+        </label>
+
+        <label class="field full">
+          <span>Persona</span>
+          <textarea v-model="form.persona" rows="4" placeholder="Internal worldview, incentives, blind spots"></textarea>
+        </label>
+
+        <label class="field full">
+          <span>Opening Statement At Injection</span>
+          <textarea v-model="form.opening_statement" rows="4" placeholder="Optional first message this actor posts when the chosen round starts"></textarea>
+        </label>
+      </div>
+
+      <div class="submit-row">
+        <div class="submit-note">
+          New branch will be cloned from <strong>{{ simulationId }}</strong> and launched from the original starting point.
+        </div>
+        <button class="launch-btn" :disabled="launching || !canLaunch" @click="launchBranch">
+          <span v-if="launching">BRANCHING...</span>
+          <span v-else>LAUNCH COUNTERFACTUAL</span>
+        </button>
+      </div>
+
+      <div v-if="error" class="error-box">{{ error }}</div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { computed, reactive, ref, watch } from 'vue'
+import { createCounterfactualSimulation } from '../api/simulation'
+
+const props = defineProps({
+  simulationId: String,
+  profiles: {
+    type: Array,
+    default: () => []
+  },
+  selectedRound: {
+    type: Number,
+    default: 0
+  },
+  maxRound: {
+    type: Number,
+    default: 1
+  }
+})
+
+const emit = defineEmits(['launched'])
+
+const launching = ref(false)
+const error = ref('')
+const selectedTemplateId = ref('')
+const form = reactive({
+  name: '',
+  entity_type: 'Diplomat',
+  profession: 'Diplomat',
+  country: 'Global',
+  stance: 'observer',
+  injection_round: 0,
+  active_hours_preset: 'office',
+  activity_level: 0.45,
+  influence_weight: 2.4,
+  posts_per_hour: 1.0,
+  comments_per_hour: 0.7,
+  bio: '',
+  persona: '',
+  interested_topics_text: '',
+  opening_statement: '',
+  age: 38,
+  gender: 'other',
+  mbti: 'INTJ'
+})
+
+const canLaunch = computed(() => form.name.trim().length > 1 && form.persona.trim().length > 0)
+
+watch(() => props.selectedRound, (round) => {
+  form.injection_round = round
+}, { immediate: true })
+
+function activeHoursFromPreset(preset) {
+  if (preset === 'always_on') return Array.from({ length: 24 }, (_, idx) => idx)
+  if (preset === 'newsdesk') return [6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]
+  if (preset === 'evening') return [15,16,17,18,19,20,21,22,23]
+  return [8,9,10,11,12,13,14,15,16,17,18]
+}
+
+function applyTemplate() {
+  const profile = props.profiles.find(item => String(item.user_id) === selectedTemplateId.value)
+  if (!profile) return
+
+  form.name = `${profile.name} Branch`
+  form.profession = profile.profession || form.profession
+  form.country = profile.country || form.country
+  form.bio = profile.bio || form.bio
+  form.persona = profile.persona || form.persona
+  form.interested_topics_text = Array.isArray(profile.interested_topics) ? profile.interested_topics.join(', ') : form.interested_topics_text
+  form.age = profile.age || form.age
+  form.gender = profile.gender || form.gender
+  form.mbti = profile.mbti || form.mbti
+  if (profile.profession === 'Diplomat' || profile.profession === 'GovernmentOfficial') {
+    form.entity_type = profile.profession
+  }
+}
+
+async function launchBranch() {
+  launching.value = true
+  error.value = ''
+  try {
+    const actor = {
+      name: form.name.trim(),
+      entity_type: form.entity_type,
+      profession: form.profession.trim() || form.entity_type,
+      country: form.country.trim() || 'Global',
+      stance: form.stance,
+      bio: form.bio.trim(),
+      persona: form.persona.trim(),
+      interested_topics: form.interested_topics_text.split(',').map(item => item.trim()).filter(Boolean),
+      activity_level: form.activity_level,
+      influence_weight: form.influence_weight,
+      posts_per_hour: form.posts_per_hour,
+      comments_per_hour: form.comments_per_hour,
+      active_hours: activeHoursFromPreset(form.active_hours_preset),
+      response_delay_min: 10,
+      response_delay_max: 45,
+      age: form.age,
+      gender: form.gender,
+      mbti: form.mbti
+    }
+
+    const response = await createCounterfactualSimulation(props.simulationId, {
+      actor,
+      injection_round: form.injection_round,
+      opening_statement: form.opening_statement.trim()
+    })
+
+    emit('launched', response.data)
+  } catch (launchError) {
+    error.value = launchError.message || 'Failed to create counterfactual branch'
+  } finally {
+    launching.value = false
+  }
+}
+</script>
+
+<style scoped>
+.lab-panel {
+  height: 100%;
+  overflow-y: auto;
+  background: radial-gradient(circle at top, rgba(17, 40, 30, 0.95), #050908 48%);
+  color: #dbffed;
+  padding: 24px;
+}
+
+.lab-shell {
+  border: 1px solid rgba(122, 240, 181, 0.14);
+  background: rgba(4, 9, 8, 0.84);
+  padding: 22px;
+}
+
+.shell-head,
+.submit-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.shell-kicker,
+.shell-note,
+.submit-note,
+.field span,
+.field small {
+  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
+}
+
+.shell-kicker,
+.shell-note,
+.field span,
+.field small {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: rgba(219, 255, 237, 0.62);
+}
+
+.shell-head h2 {
+  margin: 10px 0 0;
+  font-size: 30px;
+  line-height: 1.1;
+}
+
+.lab-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 22px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field.full {
+  grid-column: 1 / -1;
+}
+
+.field input,
+.field select,
+.field textarea {
+  width: 100%;
+  border: 1px solid rgba(122, 240, 181, 0.14);
+  background: rgba(255, 255, 255, 0.03);
+  color: #f3fff8;
+  padding: 12px 13px;
+  font: inherit;
+}
+
+.field textarea {
+  resize: vertical;
+}
+
+.submit-row {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(122, 240, 181, 0.1);
+}
+
+.submit-note {
+  max-width: 380px;
+  font-size: 12px;
+  line-height: 1.7;
+  color: rgba(219, 255, 237, 0.76);
+}
+
+.launch-btn {
+  border: 1px solid rgba(122, 240, 181, 0.18);
+  background: linear-gradient(90deg, rgba(77, 226, 165, 0.16), rgba(255, 211, 106, 0.12));
+  color: #f7fff9;
+  padding: 14px 18px;
+  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  cursor: pointer;
+}
+
+.launch-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.error-box {
+  margin-top: 16px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 107, 107, 0.4);
+  color: #ffb4b4;
+  background: rgba(255, 107, 107, 0.08);
+  font-size: 13px;
+}
+
+@media (max-width: 980px) {
+  .lab-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .submit-row {
+    flex-direction: column;
+  }
+}
+</style>

--- a/frontend/src/components/HistoryDatabase.vue
+++ b/frontend/src/components/HistoryDatabase.vue
@@ -170,6 +170,15 @@
                 <span class="btn-text">环境搭建</span>
               </button>
               <button 
+                class="modal-btn btn-counterfactual" 
+                @click="goToCounterfactual"
+                :disabled="!selectedProject.simulation_id"
+              >
+                <span class="btn-step">Step3</span>
+                <span class="btn-icon">▣</span>
+                <span class="btn-text">反事实注入</span>
+              </button>
+              <button 
                 class="modal-btn btn-report" 
                 @click="goToReport"
                 :disabled="!selectedProject.report_id"
@@ -179,9 +188,8 @@
                 <span class="btn-text">分析报告</span>
               </button>
             </div>
-            <!-- 不可回放提示 -->
             <div class="modal-playback-hint">
-              <span class="hint-text">Step3「开始模拟」与 Step5「深度互动」需在运行中启动，不支持历史回放</span>
+              <span class="hint-text">Step3 使用历史动作搭建反事实实验室；Step5「深度互动」仍需运行中的模拟环境</span>
             </div>
           </div>
         </div>
@@ -417,6 +425,17 @@ const goToSimulation = () => {
   if (selectedProject.value?.simulation_id) {
     router.push({
       name: 'Simulation',
+      params: { simulationId: selectedProject.value.simulation_id }
+    })
+    closeModal()
+  }
+}
+
+// 导航到反事实实验室
+const goToCounterfactual = () => {
+  if (selectedProject.value?.simulation_id) {
+    router.push({
+      name: 'SimulationCounterfactual',
       params: { simulationId: selectedProject.value.simulation_id }
     })
     closeModal()
@@ -1256,6 +1275,7 @@ onUnmounted(() => {
 /* 导航按钮 */
 .modal-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 16px;
   padding: 20px 32px;
   background: #FFFFFF;
@@ -1263,6 +1283,7 @@ onUnmounted(() => {
 
 .modal-btn {
   flex: 1;
+  min-width: 110px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1314,6 +1335,7 @@ onUnmounted(() => {
 
 .modal-btn.btn-project .btn-icon { color: #3B82F6; }
 .modal-btn.btn-simulation .btn-icon { color: #F59E0B; }
+.modal-btn.btn-counterfactual .btn-icon { color: #8B5CF6; }
 .modal-btn.btn-report .btn-icon { color: #10B981; }
 
 .modal-btn:hover:not(:disabled) .btn-text {

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -1,282 +1,110 @@
 <template>
   <div class="simulation-panel">
-    <!-- Top Control Bar -->
     <div class="control-bar">
       <div class="status-group">
-        <!-- Twitter 平台进度 -->
         <div class="platform-status twitter" :class="{ active: runStatus.twitter_running, completed: runStatus.twitter_completed }">
           <div class="platform-header">
-            <svg class="platform-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
-              <circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
-            </svg>
-            <span class="platform-name">Info Plaza</span>
-            <span v-if="runStatus.twitter_completed" class="status-badge">
-              <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="3">
-                <polyline points="20 6 9 17 4 12"></polyline>
-              </svg>
-            </span>
+            <span class="platform-name">INFO PLAZA</span>
+            <span class="status-chip">{{ runStatus.twitter_completed ? 'DONE' : (runStatus.twitter_running ? 'LIVE' : 'IDLE') }}</span>
           </div>
           <div class="platform-stats">
-            <span class="stat">
-              <span class="stat-label">ROUND</span>
-              <span class="stat-value mono">{{ runStatus.twitter_current_round || 0 }}<span class="stat-total">/{{ runStatus.total_rounds || maxRounds || '-' }}</span></span>
-            </span>
-            <span class="stat">
-              <span class="stat-label">Elapsed Time</span>
-              <span class="stat-value mono">{{ twitterElapsedTime }}</span>
-            </span>
-            <span class="stat">
-              <span class="stat-label">ACTS</span>
-              <span class="stat-value mono">{{ runStatus.twitter_actions_count || 0 }}</span>
-            </span>
-          </div>
-          <!-- 可用动作提示 -->
-          <div class="actions-tooltip">
-            <div class="tooltip-title">Available Actions</div>
-            <div class="tooltip-actions">
-              <span class="tooltip-action">POST</span>
-              <span class="tooltip-action">LIKE</span>
-              <span class="tooltip-action">REPOST</span>
-              <span class="tooltip-action">QUOTE</span>
-              <span class="tooltip-action">FOLLOW</span>
-              <span class="tooltip-action">IDLE</span>
-            </div>
+            <span>ROUND {{ runStatus.twitter_current_round || 0 }}/{{ runStatus.total_rounds || maxRounds || '-' }}</span>
+            <span>TIME {{ twitterElapsedTime }}</span>
+            <span>ACTS {{ runStatus.twitter_actions_count || 0 }}</span>
           </div>
         </div>
-        
-        <!-- Reddit 平台进度 -->
+
         <div class="platform-status reddit" :class="{ active: runStatus.reddit_running, completed: runStatus.reddit_completed }">
           <div class="platform-header">
-            <svg class="platform-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path>
-            </svg>
-            <span class="platform-name">Topic Community</span>
-            <span v-if="runStatus.reddit_completed" class="status-badge">
-              <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="3">
-                <polyline points="20 6 9 17 4 12"></polyline>
-              </svg>
-            </span>
+            <span class="platform-name">TOPIC COMMUNITY</span>
+            <span class="status-chip">{{ runStatus.reddit_completed ? 'DONE' : (runStatus.reddit_running ? 'LIVE' : 'IDLE') }}</span>
           </div>
           <div class="platform-stats">
-            <span class="stat">
-              <span class="stat-label">ROUND</span>
-              <span class="stat-value mono">{{ runStatus.reddit_current_round || 0 }}<span class="stat-total">/{{ runStatus.total_rounds || maxRounds || '-' }}</span></span>
-            </span>
-            <span class="stat">
-              <span class="stat-label">Elapsed Time</span>
-              <span class="stat-value mono">{{ redditElapsedTime }}</span>
-            </span>
-            <span class="stat">
-              <span class="stat-label">ACTS</span>
-              <span class="stat-value mono">{{ runStatus.reddit_actions_count || 0 }}</span>
-            </span>
-          </div>
-          <!-- 可用动作提示 -->
-          <div class="actions-tooltip">
-            <div class="tooltip-title">Available Actions</div>
-            <div class="tooltip-actions">
-              <span class="tooltip-action">POST</span>
-              <span class="tooltip-action">COMMENT</span>
-              <span class="tooltip-action">LIKE</span>
-              <span class="tooltip-action">DISLIKE</span>
-              <span class="tooltip-action">SEARCH</span>
-              <span class="tooltip-action">TREND</span>
-              <span class="tooltip-action">FOLLOW</span>
-              <span class="tooltip-action">MUTE</span>
-              <span class="tooltip-action">REFRESH</span>
-              <span class="tooltip-action">IDLE</span>
-            </div>
+            <span>ROUND {{ runStatus.reddit_current_round || 0 }}/{{ runStatus.total_rounds || maxRounds || '-' }}</span>
+            <span>TIME {{ redditElapsedTime }}</span>
+            <span>ACTS {{ runStatus.reddit_actions_count || 0 }}</span>
           </div>
         </div>
       </div>
 
       <div class="action-controls">
-        <button 
-          class="action-btn primary"
-          :disabled="phase !== 2 || isGeneratingReport"
-          @click="handleNextStep"
-        >
+        <button class="action-btn primary" :disabled="phase !== 2 || isGeneratingReport" @click="handleNextStep">
           <span v-if="isGeneratingReport" class="loading-spinner-small"></span>
-          {{ isGeneratingReport ? '启动中...' : '开始生成结果报告' }} 
-          <span v-if="!isGeneratingReport" class="arrow-icon">→</span>
+          {{ isGeneratingReport ? 'REPORT LINKING...' : 'GENERATE REPORT' }}
         </button>
       </div>
     </div>
 
-    <!-- Main Content: Dual Timeline -->
-    <div class="main-content-area" ref="scrollContainer">
-      <!-- Timeline Header -->
-      <div class="timeline-header" v-if="allActions.length > 0">
-        <div class="timeline-stats">
-          <span class="total-count">TOTAL EVENTS: <span class="mono">{{ allActions.length }}</span></span>
-          <span class="platform-breakdown">
-            <span class="breakdown-item twitter">
-              <svg class="mini-icon" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>
-              <span class="mono">{{ twitterActionsCount }}</span>
-            </span>
-            <span class="breakdown-divider">/</span>
-            <span class="breakdown-item reddit">
-              <svg class="mini-icon" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path></svg>
-              <span class="mono">{{ redditActionsCount }}</span>
-            </span>
-          </span>
-        </div>
-      </div>
-      
-      <!-- Timeline Feed -->
-      <div class="timeline-feed">
-        <div class="timeline-axis"></div>
-        
-        <TransitionGroup name="timeline-item">
-          <div 
-            v-for="action in chronologicalActions" 
-            :key="action._uniqueId || action.id || `${action.timestamp}-${action.agent_id}`" 
-            class="timeline-item"
-            :class="action.platform"
-          >
-            <div class="timeline-marker">
-              <div class="marker-dot"></div>
-            </div>
-            
-            <div class="timeline-card">
-              <div class="card-header">
-                <div class="agent-info">
-                  <div class="avatar-placeholder">{{ (action.agent_name || 'A')[0] }}</div>
-                  <span class="agent-name">{{ action.agent_name }}</span>
-                </div>
-                
-                <div class="header-meta">
-                  <div class="platform-indicator">
-                    <svg v-if="action.platform === 'twitter'" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>
-                    <svg v-else viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path></svg>
-                  </div>
-                  <div class="action-badge" :class="getActionTypeClass(action.action_type)">
-                    {{ getActionTypeLabel(action.action_type) }}
-                  </div>
-                </div>
-              </div>
-              
-              <div class="card-body">
-                <!-- CREATE_POST: 发布帖子 -->
-                <div v-if="action.action_type === 'CREATE_POST' && action.action_args?.content" class="content-text main-text">
-                  {{ action.action_args.content }}
-                </div>
-
-                <!-- QUOTE_POST: 引用帖子 -->
-                <template v-if="action.action_type === 'QUOTE_POST'">
-                  <div v-if="action.action_args?.quote_content" class="content-text">
-                    {{ action.action_args.quote_content }}
-                  </div>
-                  <div v-if="action.action_args?.original_content" class="quoted-block">
-                    <div class="quote-header">
-                      <svg class="icon-small" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
-                      <span class="quote-label">@{{ action.action_args.original_author_name || 'User' }}</span>
-                    </div>
-                    <div class="quote-text">
-                      {{ truncateContent(action.action_args.original_content, 150) }}
-                    </div>
-                  </div>
-                </template>
-
-                <!-- REPOST: 转发帖子 -->
-                <template v-if="action.action_type === 'REPOST'">
-                  <div class="repost-info">
-                    <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="17 1 21 5 17 9"></polyline><path d="M3 11V9a4 4 0 0 1 4-4h14"></path><polyline points="7 23 3 19 7 15"></polyline><path d="M21 13v2a4 4 0 0 1-4 4H3"></path></svg>
-                    <span class="repost-label">Reposted from @{{ action.action_args?.original_author_name || 'User' }}</span>
-                  </div>
-                  <div v-if="action.action_args?.original_content" class="repost-content">
-                    {{ truncateContent(action.action_args.original_content, 200) }}
-                  </div>
-                </template>
-
-                <!-- LIKE_POST: 点赞帖子 -->
-                <template v-if="action.action_type === 'LIKE_POST'">
-                  <div class="like-info">
-                    <svg class="icon-small filled" viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                    <span class="like-label">Liked @{{ action.action_args?.post_author_name || 'User' }}'s post</span>
-                  </div>
-                  <div v-if="action.action_args?.post_content" class="liked-content">
-                    "{{ truncateContent(action.action_args.post_content, 120) }}"
-                  </div>
-                </template>
-
-                <!-- CREATE_COMMENT: 发表评论 -->
-                <template v-if="action.action_type === 'CREATE_COMMENT'">
-                  <div v-if="action.action_args?.content" class="content-text">
-                    {{ action.action_args.content }}
-                  </div>
-                  <div v-if="action.action_args?.post_id" class="comment-context">
-                    <svg class="icon-small" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path></svg>
-                    <span>Reply to post #{{ action.action_args.post_id }}</span>
-                  </div>
-                </template>
-
-                <!-- SEARCH_POSTS: 搜索帖子 -->
-                <template v-if="action.action_type === 'SEARCH_POSTS'">
-                  <div class="search-info">
-                    <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
-                    <span class="search-label">Search Query:</span>
-                    <span class="search-query">"{{ action.action_args?.query || '' }}"</span>
-                  </div>
-                </template>
-
-                <!-- FOLLOW: 关注用户 -->
-                <template v-if="action.action_type === 'FOLLOW'">
-                  <div class="follow-info">
-                    <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="8.5" cy="7" r="4"></circle><line x1="20" y1="8" x2="20" y2="14"></line><line x1="23" y1="11" x2="17" y2="11"></line></svg>
-                    <span class="follow-label">Followed @{{ action.action_args?.target_user || action.action_args?.user_id || 'User' }}</span>
-                  </div>
-                </template>
-
-                <!-- UPVOTE / DOWNVOTE -->
-                <template v-if="action.action_type === 'UPVOTE_POST' || action.action_type === 'DOWNVOTE_POST'">
-                  <div class="vote-info">
-                    <svg v-if="action.action_type === 'UPVOTE_POST'" class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"></polyline></svg>
-                    <svg v-else class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                    <span class="vote-label">{{ action.action_type === 'UPVOTE_POST' ? 'Upvoted' : 'Downvoted' }} Post</span>
-                  </div>
-                  <div v-if="action.action_args?.post_content" class="voted-content">
-                    "{{ truncateContent(action.action_args.post_content, 120) }}"
-                  </div>
-                </template>
-
-                <!-- DO_NOTHING: 无操作（静默） -->
-                <template v-if="action.action_type === 'DO_NOTHING'">
-                  <div class="idle-info">
-                    <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
-                    <span class="idle-label">Action Skipped</span>
-                  </div>
-                </template>
-
-                <!-- 通用回退：未知类型或有 content 但未被上述处理 -->
-                <div v-if="!['CREATE_POST', 'QUOTE_POST', 'REPOST', 'LIKE_POST', 'CREATE_COMMENT', 'SEARCH_POSTS', 'FOLLOW', 'UPVOTE_POST', 'DOWNVOTE_POST', 'DO_NOTHING'].includes(action.action_type) && action.action_args?.content" class="content-text">
-                  {{ action.action_args.content }}
-                </div>
-              </div>
-
-              <div class="card-footer">
-                <span class="time-tag">R{{ action.round_num }} • {{ formatActionTime(action.timestamp) }}</span>
-                <!-- Platform tag removed as it is in header now -->
-              </div>
+    <div class="main-content-area">
+      <div class="intel-layout">
+        <section class="timeline-shell full">
+          <div class="timeline-header" v-if="allActions.length > 0">
+            <div class="timeline-statline">
+              <span>[ TOTAL {{ allActions.length }} ]</span>
+              <span>[ TW {{ twitterActionsCount }} ]</span>
+              <span>[ RD {{ redditActionsCount }} ]</span>
+              <span>[ STATUS {{ runStatus.runner_status || 'running' }} ]</span>
             </div>
           </div>
-        </TransitionGroup>
 
-        <div v-if="allActions.length === 0" class="waiting-state">
-          <div class="pulse-ring"></div>
-          <span>Waiting for agent actions...</span>
-        </div>
+          <div class="timeline-feed">
+            <div class="timeline-axis"></div>
+            <TransitionGroup name="timeline-item">
+              <article
+                v-for="action in chronologicalActions"
+                :key="action._uniqueId || action.id || `${action.timestamp}-${action.agent_id}`"
+                class="timeline-item"
+                :class="action.platform"
+              >
+                <div class="timeline-marker">
+                  <div class="marker-core"></div>
+                </div>
+
+                <div class="timeline-card">
+                  <div class="card-header">
+                    <div>
+                      <div class="agent-name">{{ action.agent_name || 'Unknown agent' }}</div>
+                      <div class="agent-meta">{{ action.platform || 'stream' }} :: {{ getActionTypeLabel(action.action_type) }}</div>
+                    </div>
+                    <div class="round-pill">R{{ action.round_num || action.round || 0 }}</div>
+                  </div>
+
+                  <div class="card-body">
+                    <div v-if="getPrimaryContent(action)" class="content-text main-text">
+                      {{ getPrimaryContent(action) }}
+                    </div>
+                    <div v-if="getSecondaryContent(action)" class="support-block">
+                      {{ getSecondaryContent(action) }}
+                    </div>
+                    <div v-if="getContextLabel(action)" class="context-line">
+                      {{ getContextLabel(action) }}
+                    </div>
+                  </div>
+
+                  <div class="card-footer">
+                    <span>{{ formatActionTime(action.timestamp) }}</span>
+                    <span>{{ getPlatformLabel(action.platform) }}</span>
+                  </div>
+                </div>
+              </article>
+            </TransitionGroup>
+
+            <div v-if="allActions.length === 0" class="waiting-state">
+              <div class="waiting-title">[ AGENT SOCIETIES BOOTING ]</div>
+              <div class="waiting-copy">Awaiting first live actions from the simulation bus.</div>
+            </div>
+          </div>
+        </section>
       </div>
     </div>
 
-    <!-- Bottom Info / Logs -->
     <div class="system-logs">
       <div class="log-header">
-        <span class="log-title">SIMULATION MONITOR</span>
-        <span class="log-id">{{ simulationId || 'NO_SIMULATION' }}</span>
+        <span>SIMULATION MONITOR</span>
+        <span>{{ simulationId || 'NO_SIMULATION' }}</span>
       </div>
       <div class="log-content" ref="logContent">
-        <div class="log-line" v-for="(log, idx) in systemLogs" :key="idx">
+        <div v-for="(log, idx) in systemLogs" :key="idx" class="log-line">
           <span class="log-time">{{ log.time }}</span>
           <span class="log-msg">{{ log.msg }}</span>
         </div>
@@ -286,22 +114,17 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { 
-  startSimulation, 
-  stopSimulation,
-  getRunStatus, 
-  getRunStatusDetail
-} from '../api/simulation'
 import { generateReport } from '../api/report'
+import { getRunStatus, getRunStatusDetail, startSimulation, stopSimulation } from '../api/simulation'
 
 const props = defineProps({
   simulationId: String,
-  maxRounds: Number, // 从Step2传入的最大轮数
+  maxRounds: Number,
   minutesPerRound: {
     type: Number,
-    default: 30 // 默认每轮30分钟
+    default: 30
   },
   projectData: Object,
   graphData: Object,
@@ -311,35 +134,34 @@ const props = defineProps({
 const emit = defineEmits(['go-back', 'next-step', 'add-log', 'update-status'])
 
 const router = useRouter()
-
-// State
 const isGeneratingReport = ref(false)
-const phase = ref(0) // 0: 未开始, 1: 运行中, 2: 已完成
+const phase = ref(0)
 const isStarting = ref(false)
-const isStopping = ref(false)
-const startError = ref(null)
 const runStatus = ref({})
-const allActions = ref([]) // 所有动作（增量累积）
-const actionIds = ref(new Set()) // 用于去重的动作ID集合
-const scrollContainer = ref(null)
+const allActions = ref([])
+const actionIds = ref(new Set())
+const prevTwitterRound = ref(0)
+const prevRedditRound = ref(0)
+const logContent = ref(null)
+let statusTimer = null
+let detailTimer = null
 
-// Computed
-// 按时间顺序显示动作（最新的在最后面，即底部）
 const chronologicalActions = computed(() => {
-  return allActions.value
+  return [...allActions.value].sort((a, b) => {
+    const first = new Date(a.timestamp || 0).getTime()
+    const second = new Date(b.timestamp || 0).getTime()
+    return first - second
+  })
 })
 
-// 各平台动作计数
-const twitterActionsCount = computed(() => {
-  return allActions.value.filter(a => a.platform === 'twitter').length
-})
+const twitterActionsCount = computed(() => allActions.value.filter(action => action.platform === 'twitter').length)
+const redditActionsCount = computed(() => allActions.value.filter(action => action.platform === 'reddit').length)
 
-const redditActionsCount = computed(() => {
-  return allActions.value.filter(a => a.platform === 'reddit').length
-})
+function addLog(message) {
+  emit('add-log', message)
+}
 
-// 格式化模拟流逝时间（根据轮次和每轮分钟数计算）
-const formatElapsedTime = (currentRound) => {
+function formatElapsedTime(currentRound) {
   if (!currentRound || currentRound <= 0) return '0h 0m'
   const totalMinutes = currentRound * props.minutesPerRound
   const hours = Math.floor(totalMinutes / 60)
@@ -347,335 +169,242 @@ const formatElapsedTime = (currentRound) => {
   return `${hours}h ${minutes}m`
 }
 
-// Twitter平台的模拟流逝时间
-const twitterElapsedTime = computed(() => {
-  return formatElapsedTime(runStatus.value.twitter_current_round || 0)
-})
+const twitterElapsedTime = computed(() => formatElapsedTime(runStatus.value.twitter_current_round || 0))
+const redditElapsedTime = computed(() => formatElapsedTime(runStatus.value.reddit_current_round || 0))
 
-// Reddit平台的模拟流逝时间
-const redditElapsedTime = computed(() => {
-  return formatElapsedTime(runStatus.value.reddit_current_round || 0)
-})
-
-// Methods
-const addLog = (msg) => {
-  emit('add-log', msg)
-}
-
-// 重置所有状态（用于重新启动模拟）
-const resetAllState = () => {
+function resetAllState() {
   phase.value = 0
   runStatus.value = {}
   allActions.value = []
   actionIds.value = new Set()
   prevTwitterRound.value = 0
   prevRedditRound.value = 0
-  startError.value = null
-  isStarting.value = false
-  isStopping.value = false
-  stopPolling()  // 停止之前可能存在的轮询
+  stopPolling()
 }
 
-// 启动模拟
-const doStartSimulation = async () => {
+async function doStartSimulation() {
   if (!props.simulationId) {
     addLog('错误：缺少 simulationId')
     return
   }
-  
-  // 先重置所有状态，确保不会受到上一次模拟的影响
+
   resetAllState()
-  
   isStarting.value = true
-  startError.value = null
-  addLog('正在启动双平台并行模拟...')
+  addLog('Initializing dual-platform simulation workbench...')
   emit('update-status', 'processing')
-  
+
   try {
     const params = {
       simulation_id: props.simulationId,
       platform: 'parallel',
-      force: true,  // 强制重新开始
-      enable_graph_memory_update: true  // 开启动态图谱更新
+      force: true,
+      enable_graph_memory_update: true
     }
-    
+
     if (props.maxRounds) {
       params.max_rounds = props.maxRounds
-      addLog(`设置最大模拟轮数: ${props.maxRounds}`)
+      addLog(`Max rounds pinned to ${props.maxRounds}`)
     }
-    
-    addLog('已开启动态图谱更新模式')
-    
-    const res = await startSimulation(params)
-    
-    if (res.success && res.data) {
-      if (res.data.force_restarted) {
-        addLog('✓ 已清理旧的模拟日志，重新开始模拟')
-      }
-      addLog('✓ 模拟引擎启动成功')
-      addLog(`  ├─ PID: ${res.data.process_pid || '-'}`)
-      
+
+    const response = await startSimulation(params)
+    if (response.success && response.data) {
+      addLog('Simulation engine online')
       phase.value = 1
-      runStatus.value = res.data
-      
+      runStatus.value = response.data
       startStatusPolling()
       startDetailPolling()
     } else {
-      startError.value = res.error || '启动失败'
-      addLog(`✗ 启动失败: ${res.error || '未知错误'}`)
+      addLog(`启动失败: ${response.error || '未知错误'}`)
       emit('update-status', 'error')
     }
-  } catch (err) {
-    startError.value = err.message
-    addLog(`✗ 启动异常: ${err.message}`)
+  } catch (error) {
+    addLog(`启动异常: ${error.message}`)
     emit('update-status', 'error')
   } finally {
     isStarting.value = false
   }
 }
 
-// 停止模拟
-const handleStopSimulation = async () => {
+async function handleStopSimulation() {
   if (!props.simulationId) return
-  
-  isStopping.value = true
-  addLog('正在停止模拟...')
-  
+
+  addLog('Stopping simulation...')
   try {
-    const res = await stopSimulation({ simulation_id: props.simulationId })
-    
-    if (res.success) {
-      addLog('✓ 模拟已停止')
+    const response = await stopSimulation({ simulation_id: props.simulationId })
+    if (response.success) {
+      addLog('Simulation stopped')
       phase.value = 2
       stopPolling()
       emit('update-status', 'completed')
-    } else {
-      addLog(`停止失败: ${res.error || '未知错误'}`)
     }
-  } catch (err) {
-    addLog(`停止异常: ${err.message}`)
-  } finally {
-    isStopping.value = false
+  } catch (error) {
+    addLog(`停止异常: ${error.message}`)
   }
 }
 
-// 轮询状态
-let statusTimer = null
-let detailTimer = null
-
-const startStatusPolling = () => {
+function startStatusPolling() {
   statusTimer = setInterval(fetchRunStatus, 2000)
 }
 
-const startDetailPolling = () => {
+function startDetailPolling() {
   detailTimer = setInterval(fetchRunStatusDetail, 3000)
 }
 
-const stopPolling = () => {
-  if (statusTimer) {
-    clearInterval(statusTimer)
-    statusTimer = null
-  }
-  if (detailTimer) {
-    clearInterval(detailTimer)
-    detailTimer = null
-  }
+function stopPolling() {
+  if (statusTimer) clearInterval(statusTimer)
+  if (detailTimer) clearInterval(detailTimer)
+  statusTimer = null
+  detailTimer = null
 }
 
-// 追踪各平台的上一次轮次，用于检测变化并输出日志
-const prevTwitterRound = ref(0)
-const prevRedditRound = ref(0)
-
-const fetchRunStatus = async () => {
-  if (!props.simulationId) return
-  
-  try {
-    const res = await getRunStatus(props.simulationId)
-    
-    if (res.success && res.data) {
-      const data = res.data
-      
-      runStatus.value = data
-      
-      // 分别检测各平台的轮次变化并输出日志
-      if (data.twitter_current_round > prevTwitterRound.value) {
-        addLog(`[Plaza] R${data.twitter_current_round}/${data.total_rounds} | T:${data.twitter_simulated_hours || 0}h | A:${data.twitter_actions_count}`)
-        prevTwitterRound.value = data.twitter_current_round
-      }
-      
-      if (data.reddit_current_round > prevRedditRound.value) {
-        addLog(`[Community] R${data.reddit_current_round}/${data.total_rounds} | T:${data.reddit_simulated_hours || 0}h | A:${data.reddit_actions_count}`)
-        prevRedditRound.value = data.reddit_current_round
-      }
-      
-      // 检测模拟是否已完成（通过 runner_status 或平台完成状态判断）
-      const isCompleted = data.runner_status === 'completed' || data.runner_status === 'stopped'
-      
-      // 额外检查：如果后端还没来得及更新 runner_status，但平台已经报告完成
-      // 通过检测 twitter_completed 和 reddit_completed 状态判断
-      const platformsCompleted = checkPlatformsCompleted(data)
-      
-      if (isCompleted || platformsCompleted) {
-        if (platformsCompleted && !isCompleted) {
-          addLog('✓ 检测到所有平台模拟已结束')
-        }
-        addLog('✓ 模拟已完成')
-        phase.value = 2
-        stopPolling()
-        emit('update-status', 'completed')
-      }
-    }
-  } catch (err) {
-    console.warn('获取运行状态失败:', err)
-  }
-}
-
-// 检查所有启用的平台是否已完成
-const checkPlatformsCompleted = (data) => {
-  // 如果没有任何平台数据，返回 false
+function checkPlatformsCompleted(data) {
   if (!data) return false
-  
-  // 检查各平台的完成状态
   const twitterCompleted = data.twitter_completed === true
   const redditCompleted = data.reddit_completed === true
-  
-  // 如果至少有一个平台完成了，检查是否所有启用的平台都完成了
-  // 通过 actions_count 判断平台是否被启用（如果 count > 0 或 running 曾为 true）
   const twitterEnabled = (data.twitter_actions_count > 0) || data.twitter_running || twitterCompleted
   const redditEnabled = (data.reddit_actions_count > 0) || data.reddit_running || redditCompleted
-  
-  // 如果没有任何平台被启用，返回 false
   if (!twitterEnabled && !redditEnabled) return false
-  
-  // 检查所有启用的平台是否都已完成
   if (twitterEnabled && !twitterCompleted) return false
   if (redditEnabled && !redditCompleted) return false
-  
   return true
 }
 
-const fetchRunStatusDetail = async () => {
+async function fetchRunStatus() {
   if (!props.simulationId) return
-  
   try {
-    const res = await getRunStatusDetail(props.simulationId)
-    
-    if (res.success && res.data) {
-      // 使用 all_actions 获取完整的动作列表
-      const serverActions = res.data.all_actions || []
-      
-      // 增量添加新动作（去重）
-      let newActionsAdded = 0
-      serverActions.forEach(action => {
-        // 生成唯一ID
-        const actionId = action.id || `${action.timestamp}-${action.platform}-${action.agent_id}-${action.action_type}`
-        
-        if (!actionIds.value.has(actionId)) {
-          actionIds.value.add(actionId)
-          allActions.value.push({
-            ...action,
-            _uniqueId: actionId
-          })
-          newActionsAdded++
-        }
-      })
-      
-      // 不自动滚动，让用户自由查看时间轴
-      // 新动作会在底部追加
+    const response = await getRunStatus(props.simulationId)
+    if (!(response.success && response.data)) return
+
+    const data = response.data
+    runStatus.value = data
+
+    if (data.twitter_current_round > prevTwitterRound.value) {
+      addLog(`[Plaza] R${data.twitter_current_round}/${data.total_rounds} | T:${data.twitter_simulated_hours || 0}h | A:${data.twitter_actions_count}`)
+      prevTwitterRound.value = data.twitter_current_round
     }
-  } catch (err) {
-    console.warn('获取详细状态失败:', err)
+
+    if (data.reddit_current_round > prevRedditRound.value) {
+      addLog(`[Community] R${data.reddit_current_round}/${data.total_rounds} | T:${data.reddit_simulated_hours || 0}h | A:${data.reddit_actions_count}`)
+      prevRedditRound.value = data.reddit_current_round
+    }
+
+    const completed = data.runner_status === 'completed' || data.runner_status === 'stopped' || checkPlatformsCompleted(data)
+    if (completed) {
+      addLog('Simulation complete')
+      phase.value = 2
+      stopPolling()
+      emit('update-status', 'completed')
+    }
+  } catch (error) {
+    console.warn('获取运行状态失败:', error)
   }
 }
 
-// Helpers
-const getActionTypeLabel = (type) => {
+async function fetchRunStatusDetail() {
+  if (!props.simulationId) return
+
+  try {
+    const response = await getRunStatusDetail(props.simulationId)
+    if (!(response.success && response.data)) return
+
+    const serverActions = response.data.all_actions || []
+    serverActions.forEach(action => {
+      const actionId = action.id || `${action.timestamp}-${action.platform}-${action.agent_id}-${action.action_type}`
+      if (actionIds.value.has(actionId)) return
+      actionIds.value.add(actionId)
+      allActions.value.push({ ...action, _uniqueId: actionId })
+    })
+  } catch (error) {
+    console.warn('获取详细状态失败:', error)
+  }
+}
+
+function getActionTypeLabel(type) {
   const labels = {
-    'CREATE_POST': 'POST',
-    'REPOST': 'REPOST',
-    'LIKE_POST': 'LIKE',
-    'CREATE_COMMENT': 'COMMENT',
-    'LIKE_COMMENT': 'LIKE',
-    'DO_NOTHING': 'IDLE',
-    'FOLLOW': 'FOLLOW',
-    'SEARCH_POSTS': 'SEARCH',
-    'QUOTE_POST': 'QUOTE',
-    'UPVOTE_POST': 'UPVOTE',
-    'DOWNVOTE_POST': 'DOWNVOTE'
+    CREATE_POST: 'POST',
+    REPOST: 'REPOST',
+    LIKE_POST: 'LIKE',
+    CREATE_COMMENT: 'COMMENT',
+    LIKE_COMMENT: 'LIKE',
+    DO_NOTHING: 'IDLE',
+    FOLLOW: 'FOLLOW',
+    SEARCH_POSTS: 'SEARCH',
+    QUOTE_POST: 'QUOTE',
+    UPVOTE_POST: 'UPVOTE',
+    DOWNVOTE_POST: 'DOWNVOTE',
+    TREND: 'TREND',
+    REFRESH: 'REFRESH'
   }
   return labels[type] || type || 'UNKNOWN'
 }
 
-const getActionTypeClass = (type) => {
-  const classes = {
-    'CREATE_POST': 'badge-post',
-    'REPOST': 'badge-action',
-    'LIKE_POST': 'badge-action',
-    'CREATE_COMMENT': 'badge-comment',
-    'LIKE_COMMENT': 'badge-action',
-    'QUOTE_POST': 'badge-post',
-    'FOLLOW': 'badge-meta',
-    'SEARCH_POSTS': 'badge-meta',
-    'UPVOTE_POST': 'badge-action',
-    'DOWNVOTE_POST': 'badge-action',
-    'DO_NOTHING': 'badge-idle'
-  }
-  return classes[type] || 'badge-default'
+function getPrimaryContent(action) {
+  const args = action.action_args || {}
+  return args.content || args.quote_content || args.query || args.post_content || ''
 }
 
-const truncateContent = (content, maxLength = 100) => {
-  if (!content) return ''
-  if (content.length > maxLength) return content.substring(0, maxLength) + '...'
-  return content
+function getSecondaryContent(action) {
+  const args = action.action_args || {}
+  if (args.original_content) return args.original_content
+  if (args.post_content && args.post_content !== args.content) return args.post_content
+  return ''
 }
 
-const formatActionTime = (timestamp) => {
+function getContextLabel(action) {
+  const args = action.action_args || {}
+  if (action.action_type === 'FOLLOW') return `target :: ${args.target_user || args.user_id || 'user'}`
+  if (action.action_type === 'SEARCH_POSTS') return `query :: ${args.query || 'n/a'}`
+  if (action.action_type === 'CREATE_COMMENT') return `reply :: post #${args.post_id || 'n/a'}`
+  if (args.original_author_name) return `source :: @${args.original_author_name}`
+  if (args.post_author_name) return `source :: @${args.post_author_name}`
+  return ''
+}
+
+function getPlatformLabel(platform) {
+  if (platform === 'twitter') return 'PLAZA'
+  if (platform === 'reddit') return 'COMMUNITY'
+  return (platform || 'STREAM').toUpperCase()
+}
+
+function formatActionTime(timestamp) {
   if (!timestamp) return ''
   try {
-    return new Date(timestamp).toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    return new Date(timestamp).toLocaleTimeString('en-US', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    })
   } catch {
     return ''
   }
 }
 
-const handleNextStep = async () => {
-  if (!props.simulationId) {
-    addLog('错误：缺少 simulationId')
-    return
-  }
-  
-  if (isGeneratingReport.value) {
-    addLog('报告生成请求已发送，请稍候...')
-    return
-  }
-  
+async function handleNextStep() {
+  if (!props.simulationId || isGeneratingReport.value) return
   isGeneratingReport.value = true
-  addLog('正在启动报告生成...')
-  
+  addLog('Starting report generation...')
+
   try {
-    const res = await generateReport({
+    const response = await generateReport({
       simulation_id: props.simulationId,
       force_regenerate: true
     })
-    
-    if (res.success && res.data) {
-      const reportId = res.data.report_id
-      addLog(`✓ 报告生成任务已启动: ${reportId}`)
-      
-      // 跳转到报告页面
-      router.push({ name: 'Report', params: { reportId } })
-    } else {
-      addLog(`✗ 启动报告生成失败: ${res.error || '未知错误'}`)
-      isGeneratingReport.value = false
+
+    if (response.success && response.data) {
+      addLog(`Report task online: ${response.data.report_id}`)
+      router.push({ name: 'Report', params: { reportId: response.data.report_id } })
+      return
     }
-  } catch (err) {
-    addLog(`✗ 启动报告生成异常: ${err.message}`)
+
+    addLog(`报告生成失败: ${response.error || '未知错误'}`)
+  } catch (error) {
+    addLog(`报告生成异常: ${error.message}`)
+  } finally {
     isGeneratingReport.value = false
   }
 }
 
-// Scroll log to bottom
-const logContent = ref(null)
 watch(() => props.systemLogs?.length, () => {
   nextTick(() => {
     if (logContent.value) {
@@ -685,10 +414,8 @@ watch(() => props.systemLogs?.length, () => {
 })
 
 onMounted(() => {
-  addLog('Step3 模拟运行初始化')
-  if (props.simulationId) {
-    doStartSimulation()
-  }
+  addLog('Simulation workbench armed')
+  if (props.simulationId) doStartSimulation()
 })
 
 onUnmounted(() => {
@@ -701,263 +428,159 @@ onUnmounted(() => {
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: #FFFFFF;
+  background: radial-gradient(circle at top, rgba(17, 40, 30, 0.95), #050908 48%);
+  color: #dbffed;
   font-family: 'Space Grotesk', 'Noto Sans SC', system-ui, sans-serif;
   overflow: hidden;
 }
 
-/* --- Control Bar --- */
 .control-bar {
-  background: #FFF;
-  padding: 12px 24px;
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  border-bottom: 1px solid #EAEAEA;
-  z-index: 10;
-  height: 64px;
+  align-items: flex-start;
+  gap: 18px;
+  padding: 16px 24px;
+  border-bottom: 1px solid rgba(122, 240, 181, 0.12);
+  background: rgba(4, 9, 8, 0.85);
+  backdrop-filter: blur(18px);
 }
 
 .status-group {
   display: flex;
   gap: 12px;
+  flex-wrap: wrap;
 }
 
-/* Platform Status Cards */
 .platform-status {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 6px 12px;
-  border-radius: 4px;
-  background: #FAFAFA;
-  border: 1px solid #EAEAEA;
-  opacity: 0.7;
-  transition: all 0.3s;
-  min-width: 140px;
-  position: relative;
-  cursor: pointer;
+  min-width: 220px;
+  padding: 12px 14px;
+  border: 1px solid rgba(122, 240, 181, 0.12);
+  background: rgba(255, 255, 255, 0.02);
+  transition: border-color 0.2s ease, background 0.2s ease;
 }
 
 .platform-status.active {
-  opacity: 1;
-  border-color: #333;
-  background: #FFF;
+  border-color: rgba(122, 240, 181, 0.34);
+  background: rgba(122, 240, 181, 0.06);
 }
 
 .platform-status.completed {
-  opacity: 1;
-  border-color: #1A936F;
-  background: #F2FAF6;
+  border-color: rgba(255, 211, 106, 0.34);
 }
 
-/* Actions Tooltip */
-.actions-tooltip {
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  margin-top: 8px;
-  padding: 10px 14px;
-  background: #000;
-  color: #FFF;
-  border-radius: 4px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  opacity: 0;
-  visibility: hidden;
-  transition: all 0.2s ease;
-  z-index: 100;
-  min-width: 180px;
-  pointer-events: none;
-}
-
-.actions-tooltip::before {
-  content: '';
-  position: absolute;
-  top: -6px;
-  left: 50%;
-  transform: translateX(-50%);
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-bottom: 6px solid #000;
-}
-
-.platform-status:hover .actions-tooltip {
-  opacity: 1;
-  visibility: visible;
-}
-
-.tooltip-title {
-  font-size: 10px;
-  font-weight: 600;
-  color: #999;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin-bottom: 8px;
-}
-
-.tooltip-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.tooltip-action {
-  font-size: 10px;
-  font-weight: 600;
-  padding: 3px 8px;
-  background: rgba(255, 255, 255, 0.15);
-  border-radius: 2px;
-  color: #FFF;
-  letter-spacing: 0.03em;
-}
-
-.platform-header {
+.platform-header,
+.platform-stats,
+.action-controls,
+.timeline-statline,
+.card-header,
+.card-footer,
+.log-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 2px;
-}
-
-.platform-name {
-  font-size: 11px;
-  font-weight: 700;
-  color: #000;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.platform-status.twitter .platform-icon { color: #000; }
-.platform-status.reddit .platform-icon { color: #000; }
-
-.platform-stats {
-  display: flex;
+  justify-content: space-between;
   gap: 10px;
 }
 
-.stat {
-  display: flex;
-  align-items: baseline;
-  gap: 3px;
+.platform-name,
+.action-btn,
+.timeline-statline,
+.round-pill,
+.log-header,
+.agent-meta,
+.context-line,
+.card-footer {
+  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
 }
 
-.stat-label {
-  font-size: 8px;
-  color: #999;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+.platform-name,
+.timeline-statline,
+.log-header {
+  letter-spacing: 0.14em;
+  font-size: 10px;
 }
 
-.stat-value {
+.platform-name {
+  color: #8cf6c2;
+}
+
+.platform-stats {
+  margin-top: 8px;
+  flex-wrap: wrap;
   font-size: 11px;
-  font-weight: 600;
-  color: #333;
+  color: rgba(219, 255, 237, 0.76);
 }
 
-.stat-total, .stat-unit {
-  font-size: 9px;
-  color: #999;
-  font-weight: 400;
+.status-chip,
+.round-pill {
+  padding: 3px 7px;
+  border: 1px solid rgba(122, 240, 181, 0.16);
+  font-size: 10px;
+  color: rgba(219, 255, 237, 0.72);
 }
 
-.status-badge {
-  margin-left: auto;
-  color: #1A936F;
-  display: flex;
-  align-items: center;
+.action-controls {
+  flex-shrink: 0;
 }
 
-/* Action Button */
 .action-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 20px;
-  font-size: 13px;
-  font-weight: 600;
-  border: none;
-  border-radius: 4px;
+  padding: 11px 14px;
+  border: 1px solid rgba(122, 240, 181, 0.16);
+  background: rgba(255, 255, 255, 0.02);
+  color: #dbffed;
+  letter-spacing: 0.12em;
+  font-size: 11px;
   cursor: pointer;
-  transition: all 0.2s ease;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
 }
 
 .action-btn.primary {
-  background: #000;
-  color: #FFF;
+  background: linear-gradient(90deg, rgba(77, 226, 165, 0.16), rgba(255, 211, 106, 0.12));
 }
 
-.action-btn.primary:hover:not(:disabled) {
-  background: #333;
+.action-btn:hover:not(:disabled) {
+  border-color: rgba(122, 240, 181, 0.34);
 }
 
 .action-btn:disabled {
-  opacity: 0.3;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
-/* --- Main Content Area --- */
 .main-content-area {
   flex: 1;
   overflow-y: auto;
-  position: relative;
-  background: #FFF;
 }
 
-/* Timeline Header */
+.intel-layout {
+  display: block;
+  padding: 20px 24px 24px;
+}
+
+.timeline-shell {
+  min-width: 0;
+}
+
 .timeline-header {
   position: sticky;
   top: 0;
-  background: rgba(255, 255, 255, 0.9);
-  backdrop-filter: blur(8px);
-  padding: 12px 24px;
-  border-bottom: 1px solid #EAEAEA;
-  z-index: 5;
-  display: flex;
-  justify-content: center;
+  z-index: 4;
+  padding-bottom: 12px;
+  background: linear-gradient(180deg, rgba(5, 9, 8, 0.92), rgba(5, 9, 8, 0.32));
+  backdrop-filter: blur(12px);
 }
 
-.timeline-stats {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  font-size: 11px;
-  color: #666;
-  background: #F5F5F5;
-  padding: 4px 12px;
-  border-radius: 20px;
+.timeline-statline {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  border: 1px solid rgba(122, 240, 181, 0.12);
+  background: rgba(255, 255, 255, 0.03);
+  color: rgba(219, 255, 237, 0.72);
 }
 
-.total-count {
-  font-weight: 600;
-  color: #333;
-}
-
-.platform-breakdown {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.breakdown-item {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.breakdown-divider { color: #DDD; }
-.breakdown-item.twitter { color: #000; }
-.breakdown-item.reddit { color: #000; }
-
-/* --- Timeline Feed --- */
 .timeline-feed {
-  padding: 24px 0;
   position: relative;
   min-height: 100%;
-  max-width: 900px;
-  margin: 0 auto;
+  padding: 12px 0 24px;
 }
 
 .timeline-axis {
@@ -966,299 +589,224 @@ onUnmounted(() => {
   top: 0;
   bottom: 0;
   width: 1px;
-  background: #EAEAEA; /* Cleaner line */
+  background: linear-gradient(180deg, rgba(122, 240, 181, 0.16), rgba(122, 240, 181, 0.02));
   transform: translateX(-50%);
 }
 
 .timeline-item {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 32px;
   position: relative;
   width: 100%;
-}
-
-.timeline-marker {
-  position: absolute;
-  left: 50%;
-  top: 24px;
-  width: 10px;
-  height: 10px;
-  background: #FFF;
-  border: 1px solid #CCC;
-  border-radius: 50%;
-  transform: translateX(-50%);
-  z-index: 2;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  margin-bottom: 24px;
 }
 
-.marker-dot {
-  width: 4px;
-  height: 4px;
-  background: #CCC;
-  border-radius: 50%;
-}
-
-.timeline-item.twitter .marker-dot { background: #000; }
-.timeline-item.reddit .marker-dot { background: #000; }
-.timeline-item.twitter .timeline-marker { border-color: #000; }
-.timeline-item.reddit .timeline-marker { border-color: #000; }
-
-/* Card Layout */
-.timeline-card {
-  width: calc(100% - 48px);
-  background: #FFF;
-  border-radius: 2px;
-  padding: 16px 20px;
-  border: 1px solid #EAEAEA;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.02);
-  position: relative;
-  transition: all 0.2s;
-}
-
-.timeline-card:hover {
-  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
-  border-color: #DDD;
-}
-
-/* Left side (Twitter) */
 .timeline-item.twitter {
   justify-content: flex-start;
   padding-right: 50%;
 }
-.timeline-item.twitter .timeline-card {
-  margin-left: auto;
-  margin-right: 32px; /* Gap from axis */
-}
 
-/* Right side (Reddit) */
 .timeline-item.reddit {
   justify-content: flex-end;
   padding-left: 50%;
 }
-.timeline-item.reddit .timeline-card {
-  margin-right: auto;
-  margin-left: 32px; /* Gap from axis */
-}
 
-/* Card Content Styles */
-.card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 12px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid #F5F5F5;
-}
-
-.agent-info {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.avatar-placeholder {
-  width: 24px;
-  height: 24px;
-  background: #000;
-  color: #FFF;
-  border-radius: 50%;
+.timeline-marker {
+  position: absolute;
+  top: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 14px;
+  height: 14px;
+  border: 1px solid rgba(122, 240, 181, 0.2);
+  background: #06100d;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
-  font-weight: 700;
-  text-transform: uppercase;
+  z-index: 2;
+}
+
+.marker-core {
+  width: 6px;
+  height: 6px;
+  background: #82f7bf;
+}
+
+.timeline-card {
+  width: calc(100% - 44px);
+  padding: 16px 18px;
+  border: 1px solid rgba(122, 240, 181, 0.12);
+  background:
+    linear-gradient(180deg, rgba(12, 23, 18, 0.96), rgba(5, 10, 8, 0.98)),
+    repeating-linear-gradient(0deg, rgba(122, 240, 181, 0.03), rgba(122, 240, 181, 0.03) 1px, transparent 1px, transparent 20px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.18);
+}
+
+.timeline-item.twitter .timeline-card {
+  margin-right: 32px;
+}
+
+.timeline-item.reddit .timeline-card {
+  margin-left: 32px;
+}
+
+.card-header {
+  align-items: flex-start;
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(122, 240, 181, 0.08);
 }
 
 .agent-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: #000;
+  font-size: 14px;
+  font-weight: 700;
+  color: #f2fff8;
 }
 
-.header-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.platform-indicator {
-  color: #999;
-  display: flex;
-  align-items: center;
-}
-
-.action-badge {
-  font-size: 9px;
-  padding: 2px 6px;
-  border-radius: 2px;
-  font-weight: 600;
+.agent-meta,
+.context-line,
+.card-footer {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: rgba(219, 255, 237, 0.56);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  border: 1px solid transparent;
 }
 
-/* Monochromatic Badges */
-.badge-post { background: #F0F0F0; color: #333; border-color: #E0E0E0; }
-.badge-comment { background: #F0F0F0; color: #666; border-color: #E0E0E0; }
-.badge-action { background: #FFF; color: #666; border: 1px solid #E0E0E0; }
-.badge-meta { background: #FAFAFA; color: #999; border: 1px dashed #DDD; }
-.badge-idle { opacity: 0.5; }
+.card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
 
 .content-text {
   font-size: 13px;
+  line-height: 1.7;
+  color: rgba(219, 255, 237, 0.85);
+}
+
+.main-text {
+  color: #f6fff9;
+}
+
+.support-block {
+  padding: 10px 12px;
+  border: 1px solid rgba(122, 240, 181, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 12px;
   line-height: 1.6;
-  color: #333;
+  color: rgba(219, 255, 237, 0.72);
+}
+
+.waiting-state {
+  min-height: 380px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  border: 1px dashed rgba(122, 240, 181, 0.16);
+  color: rgba(219, 255, 237, 0.55);
+}
+
+.waiting-title {
+  font-family: 'JetBrains Mono', monospace;
+  letter-spacing: 0.16em;
+  margin-bottom: 10px;
+  color: #8cf6c2;
+}
+
+.system-logs {
+  flex-shrink: 0;
+  padding: 14px 18px 16px;
+  border-top: 1px solid rgba(122, 240, 181, 0.1);
+  background: rgba(2, 5, 4, 0.98);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.log-header {
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: #8cf6c2;
   margin-bottom: 10px;
 }
 
-.content-text.main-text {
-  font-size: 14px;
-  color: #000;
-}
-
-/* Info Blocks (Quote, Repost, etc) */
-.quoted-block, .repost-content {
-  background: #F9F9F9;
-  border: 1px solid #EEE;
-  padding: 10px 12px;
-  border-radius: 2px;
-  margin-top: 8px;
-  font-size: 12px;
-  color: #555;
-}
-
-.quote-header, .repost-info, .like-info, .search-info, .follow-info, .vote-info, .idle-info, .comment-context {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 6px;
-  font-size: 11px;
-  color: #666;
-}
-
-.icon-small {
-  color: #999;
-}
-.icon-small.filled {
-  color: #999; /* Keep icons neutral unless highlighted */
-}
-
-.search-query {
-  font-family: 'JetBrains Mono', monospace;
-  background: #F0F0F0;
-  padding: 0 4px;
-  border-radius: 2px;
-}
-
-.card-footer {
-  margin-top: 12px;
-  display: flex;
-  justify-content: flex-end;
-  font-size: 10px;
-  color: #BBB;
-  font-family: 'JetBrains Mono', monospace;
-}
-
-/* Waiting State */
-.waiting-state {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+.log-content {
+  max-height: 132px;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 16px;
-  color: #CCC;
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+  gap: 7px;
 }
 
-.pulse-ring {
-  width: 32px;
-  height: 32px;
+.log-line {
+  display: grid;
+  grid-template-columns: 112px 1fr;
+  gap: 12px;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.log-time {
+  color: rgba(219, 255, 237, 0.44);
+}
+
+.log-msg {
+  color: rgba(219, 255, 237, 0.8);
+}
+
+.loading-spinner-small {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  border-top-color: #fff;
   border-radius: 50%;
-  border: 1px solid #EAEAEA;
-  animation: ripple 2s infinite;
+  animation: spin 0.8s linear infinite;
 }
 
-@keyframes ripple {
-  0% { transform: scale(0.8); opacity: 1; border-color: #CCC; }
-  100% { transform: scale(2.5); opacity: 0; border-color: #EAEAEA; }
-}
-
-/* Animation */
-.timeline-item-enter-active,
-.timeline-item-leave-active {
-  transition: all 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
+.timeline-item-enter-active {
+  transition: all 0.35s ease;
 }
 
 .timeline-item-enter-from {
   opacity: 0;
-  transform: translateY(20px);
+  transform: translateY(14px);
 }
 
-.timeline-item-leave-to {
-  opacity: 0;
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 
-/* Logs */
-.system-logs {
-  background: #000;
-  color: #DDD;
-  padding: 16px;
-  font-family: 'JetBrains Mono', monospace;
-  border-top: 1px solid #222;
-  flex-shrink: 0;
+@media (max-width: 1440px) {
+  .intel-layout {
+    grid-template-columns: 1fr;
+  }
 }
 
-.log-header {
-  display: flex;
-  justify-content: space-between;
-  border-bottom: 1px solid #333;
-  padding-bottom: 8px;
-  margin-bottom: 8px;
-  font-size: 10px;
-  color: #666;
-}
+@media (max-width: 960px) {
+  .control-bar {
+    flex-direction: column;
+  }
 
-.log-content {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  height: 100px;
-  overflow-y: auto;
-  padding-right: 4px;
-}
+  .timeline-axis,
+  .timeline-marker {
+    left: 14px;
+    transform: none;
+  }
 
-.log-content::-webkit-scrollbar { width: 4px; }
-.log-content::-webkit-scrollbar-thumb { background: #333; border-radius: 2px; }
+  .timeline-item,
+  .timeline-item.twitter,
+  .timeline-item.reddit {
+    padding: 0 0 0 34px;
+    justify-content: flex-start;
+  }
 
-.log-line {
-  font-size: 11px;
-  display: flex;
-  gap: 12px;
-  line-height: 1.5;
-}
+  .timeline-item.twitter .timeline-card,
+  .timeline-item.reddit .timeline-card {
+    margin: 0;
+    width: 100%;
+  }
 
-.log-time { color: #555; min-width: 75px; }
-.log-msg { color: #BBB; word-break: break-all; }
-.mono { font-family: 'JetBrains Mono', monospace; }
-
-/* Loading spinner for button */
-.loading-spinner-small {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: #FFF;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  margin-right: 6px;
+  .log-line {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
 }
 </style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,6 +3,7 @@ import Home from '../views/Home.vue'
 import Process from '../views/MainView.vue'
 import SimulationView from '../views/SimulationView.vue'
 import SimulationRunView from '../views/SimulationRunView.vue'
+import SimulationCounterfactualView from '../views/SimulationCounterfactualView.vue'
 import ReportView from '../views/ReportView.vue'
 import InteractionView from '../views/InteractionView.vue'
 
@@ -28,6 +29,12 @@ const routes = [
     path: '/simulation/:simulationId/start',
     name: 'SimulationRun',
     component: SimulationRunView,
+    props: true
+  },
+  {
+    path: '/simulation/:simulationId/counterfactual',
+    name: 'SimulationCounterfactual',
+    component: SimulationCounterfactualView,
     props: true
   },
   {

--- a/frontend/src/views/SimulationCounterfactualView.vue
+++ b/frontend/src/views/SimulationCounterfactualView.vue
@@ -1,0 +1,319 @@
+<template>
+  <div class="main-view">
+    <header class="app-header">
+      <div class="header-left">
+        <div class="brand" @click="router.push('/')">MIROFISH</div>
+      </div>
+
+      <div class="header-center">
+        <div class="view-switcher">
+          <button
+            v-for="mode in ['archive', 'split', 'lab']"
+            :key="mode"
+            class="switch-btn"
+            :class="{ active: viewMode === mode }"
+            @click="viewMode = mode"
+          >
+            {{ { archive: '档案', split: '双栏', lab: '实验室' }[mode] }}
+          </button>
+        </div>
+      </div>
+
+      <div class="header-right">
+        <div class="workflow-step">
+          <span class="step-num">Step 3/5</span>
+          <span class="step-name">反事实注入</span>
+        </div>
+        <div class="step-divider"></div>
+        <span class="status-indicator" :class="statusClass">
+          <span class="dot"></span>
+          {{ statusText }}
+        </span>
+      </div>
+    </header>
+
+    <main class="content-area">
+      <div class="panel-wrapper left" :style="leftPanelStyle">
+        <CounterfactualArchivePanel
+          :simulation-id="currentSimulationId"
+          :simulation-data="simulationData"
+          :simulation-config="simulationConfig"
+          :timeline="timeline"
+          :agent-stats="agentStats"
+          :round-actions="roundActions"
+          :selected-round="selectedRound"
+          :loading-actions="loadingActions"
+          @update:selectedRound="selectedRound = $event"
+        />
+      </div>
+
+      <div class="panel-wrapper right" :style="rightPanelStyle">
+        <CounterfactualLabPanel
+          :simulation-id="currentSimulationId"
+          :profiles="profiles"
+          :selected-round="selectedRound"
+          :max-round="maxRound"
+          @launched="handleLaunched"
+        />
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import CounterfactualArchivePanel from '../components/CounterfactualArchivePanel.vue'
+import CounterfactualLabPanel from '../components/CounterfactualLabPanel.vue'
+import {
+  getSimulation,
+  getSimulationConfig,
+  getSimulationTimeline,
+  getAgentStats,
+  getSimulationActions,
+  getSimulationProfiles
+} from '../api/simulation'
+
+const route = useRoute()
+const router = useRouter()
+
+const viewMode = ref('split')
+const currentSimulationId = ref(route.params.simulationId)
+const simulationData = ref(null)
+const simulationConfig = ref(null)
+const timeline = ref([])
+const agentStats = ref([])
+const roundActions = ref([])
+const profiles = ref([])
+const selectedRound = ref(0)
+const loadingActions = ref(false)
+const currentStatus = ref('processing')
+
+const maxRound = computed(() => timeline.value.length ? Math.max(...timeline.value.map(item => item.round_num || 0)) : 0)
+
+const leftPanelStyle = computed(() => {
+  if (viewMode.value === 'archive') return { width: '100%', opacity: 1, transform: 'translateX(0)' }
+  if (viewMode.value === 'lab') return { width: '0%', opacity: 0, transform: 'translateX(-20px)' }
+  return { width: '54%', opacity: 1, transform: 'translateX(0)' }
+})
+
+const rightPanelStyle = computed(() => {
+  if (viewMode.value === 'lab') return { width: '100%', opacity: 1, transform: 'translateX(0)' }
+  if (viewMode.value === 'archive') return { width: '0%', opacity: 0, transform: 'translateX(20px)' }
+  return { width: '46%', opacity: 1, transform: 'translateX(0)' }
+})
+
+const statusClass = computed(() => currentStatus.value)
+const statusText = computed(() => {
+  if (currentStatus.value === 'error') return 'Error'
+  if (currentStatus.value === 'completed') return 'Ready'
+  return 'Loading'
+})
+
+async function loadBaseData() {
+  currentStatus.value = 'processing'
+  const simulationId = currentSimulationId.value
+  try {
+    const [simulationRes, configRes, timelineRes, agentStatsRes, profilesRes] = await Promise.all([
+      getSimulation(simulationId),
+      getSimulationConfig(simulationId),
+      getSimulationTimeline(simulationId, 0),
+      getAgentStats(simulationId),
+      getSimulationProfiles(simulationId, 'reddit')
+    ])
+
+    simulationData.value = simulationRes.data || null
+    simulationConfig.value = configRes.data || null
+    timeline.value = timelineRes.data || []
+    agentStats.value = agentStatsRes.data || []
+    profiles.value = profilesRes.data?.profiles || []
+
+    if (timeline.value.length > 0) {
+      const hottestRound = [...timeline.value].sort((a, b) => (b.total_actions || 0) - (a.total_actions || 0))[0]
+      selectedRound.value = hottestRound?.round_num || timeline.value[0].round_num
+    }
+
+    currentStatus.value = 'completed'
+  } catch (error) {
+    console.error('加载反事实工作台失败:', error)
+    currentStatus.value = 'error'
+  }
+}
+
+async function loadRoundActions(roundNum) {
+  if (roundNum === null || roundNum === undefined) return
+  loadingActions.value = true
+  try {
+    const response = await getSimulationActions(currentSimulationId.value, {
+      round_num: roundNum,
+      limit: 300
+    })
+    roundActions.value = response.data?.actions || []
+  } catch (error) {
+    console.error('加载轮次动作失败:', error)
+    roundActions.value = []
+  } finally {
+    loadingActions.value = false
+  }
+}
+
+function handleLaunched(payload) {
+  const simulationId = payload?.simulation?.simulation_id
+  if (!simulationId) return
+  router.push({
+    name: 'SimulationRun',
+    params: { simulationId }
+  })
+}
+
+watch(selectedRound, (round) => {
+  loadRoundActions(round)
+})
+
+onMounted(async () => {
+  await loadBaseData()
+})
+</script>
+
+<style scoped>
+.main-view {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  overflow: hidden;
+  font-family: 'Space Grotesk', 'Noto Sans SC', system-ui, sans-serif;
+}
+
+.app-header {
+  height: 60px;
+  border-bottom: 1px solid #eaeaea;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  background: #fff;
+  z-index: 100;
+  position: relative;
+}
+
+.header-center {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.brand {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 800;
+  font-size: 18px;
+  letter-spacing: 1px;
+  cursor: pointer;
+}
+
+.view-switcher {
+  display: flex;
+  background: #f5f5f5;
+  padding: 4px;
+  border-radius: 6px;
+  gap: 4px;
+}
+
+.switch-btn {
+  border: none;
+  background: transparent;
+  padding: 6px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #666;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.switch-btn.active {
+  background: #fff;
+  color: #000;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.workflow-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.step-num {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  color: #999;
+}
+
+.step-name {
+  font-weight: 700;
+  color: #000;
+}
+
+.step-divider {
+  width: 1px;
+  height: 14px;
+  background-color: #e0e0e0;
+}
+
+.status-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #666;
+  font-weight: 500;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #ccc;
+}
+
+.status-indicator.processing .dot {
+  background: #ff5722;
+  animation: pulse 1s infinite;
+}
+
+.status-indicator.completed .dot {
+  background: #4caf50;
+}
+
+.status-indicator.error .dot {
+  background: #f44336;
+}
+
+@keyframes pulse {
+  50% { opacity: 0.5; }
+}
+
+.content-area {
+  flex: 1;
+  display: flex;
+  position: relative;
+  overflow: hidden;
+}
+
+.panel-wrapper {
+  height: 100%;
+  overflow: hidden;
+  transition: width 0.4s cubic-bezier(0.25, 0.8, 0.25, 1), opacity 0.3s ease, transform 0.3s ease;
+}
+
+.panel-wrapper.left {
+  border-right: 1px solid #eaeaea;
+}
+</style>

--- a/frontend/src/views/SimulationRunView.vue
+++ b/frontend/src/views/SimulationRunView.vue
@@ -444,4 +444,3 @@ onUnmounted(() => {
   border-right: 1px solid #EAEAEA;
 }
 </style>
-

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,10 +2,12 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 // https://vite.dev/config/
+const frontendPort = Number.parseInt(process.env.MIROFISH_FRONTEND_PORT || '3000', 10)
+
 export default defineConfig({
   plugins: [vue()],
   server: {
-    port: 3000,
+    port: Number.isNaN(frontendPort) ? 3000 : frontendPort,
     open: true,
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary
- normalize generated edge names to Zep-compatible `SCREAMING_SNAKE_CASE` before ontology submission
- skip malformed ontology rows and invalid attribute/source-target entries instead of crashing on missing keys
- allow the Vite dev server port to be overridden via `MIROFISH_FRONTEND_PORT`

## Why
Running MiroFish against Grok-generated ontologies exposed two failure modes in the graph pipeline:
1. mixed-case edge names such as `ANALYzes` are rejected by Zep
2. malformed entity or edge rows from the ontology LLM output can trigger `KeyError: 'name'`

These changes make the pipeline tolerate that noise and keep the simulation workflow moving.

## Validation
- `python3 -m py_compile backend/app/services/graph_builder.py backend/app/services/ontology_generator.py`
- verified the patched flow locally against Grok + Zep on real simulation runs
