### PR TITLE
feat: add Mem0 memory provider support and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,12 @@ ZEP_API_KEY=your_zep_api_key_here
 LLM_BOOST_API_KEY=your_api_key_here
 LLM_BOOST_BASE_URL=your_base_url_here
 LLM_BOOST_MODEL_NAME=your_model_name_here
+
+# ===== Memory Provider配置 =====
+# 支持 'zep' (默认) 或 'mem0'
+# MEMORY_PROVIDER=mem0
+
+# ===== Mem0配置（仅MEMORY_PROVIDER=mem0时需要）=====
+# Platform模式：设置MEM0_API_KEY
+MEM0_API_KEY=your_mem0_api_key_here
+# OSS模式：不设MEM0_API_KEY，需要OPENAI_API_KEY

--- a/README-EN.md
+++ b/README-EN.md
@@ -122,10 +122,27 @@ LLM_API_KEY=your_api_key
 LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 LLM_MODEL_NAME=qwen-plus
 
-# Zep Cloud Configuration
+# Zep Cloud Configuration (default memory provider)
 # Free monthly quota is sufficient for simple usage: https://app.getzep.com/
 ZEP_API_KEY=your_zep_api_key
+
+# Or use Mem0 as memory provider (optional)
+# MEMORY_PROVIDER=mem0
+# MEM0_API_KEY=your_mem0_api_key
 ```
+
+#### Memory Provider Configuration
+
+MiroFish supports two memory backends:
+
+| Provider | Config | Pros |
+|----------|--------|------|
+| **Zep Cloud** (default) | `ZEP_API_KEY` in `.env` | Built-in ontology, temporal facts |
+| **Mem0** | `MEMORY_PROVIDER=mem0` + `MEM0_API_KEY` in `.env` | Self-hosted option, per-agent isolation, no node caps |
+
+To use Mem0 instead of Zep:
+1. Set `MEMORY_PROVIDER=mem0` in your `.env`
+2. Set `MEM0_API_KEY` for Platform mode, or `OPENAI_API_KEY` for OSS mode
 
 #### 2. Install Dependencies
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,27 @@ LLM_API_KEY=your_api_key
 LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 LLM_MODEL_NAME=qwen-plus
 
-# Zep Cloud 配置
+# Zep Cloud 配置（默认记忆提供者）
 # 每月免费额度即可支撑简单使用：https://app.getzep.com/
 ZEP_API_KEY=your_zep_api_key
+
+# 或使用 Mem0 作为记忆提供者（可选）
+# MEMORY_PROVIDER=mem0
+# MEM0_API_KEY=your_mem0_api_key
 ```
+
+#### 记忆提供者配置
+
+MiroFish 支持两种记忆后端：
+
+| 提供者 | 配置 | 优势 |
+|--------|------|------|
+| **Zep Cloud**（默认） | `.env` 中设置 `ZEP_API_KEY` | 内置本体定义、时序事实 |
+| **Mem0** | `.env` 中设置 `MEMORY_PROVIDER=mem0` + `MEM0_API_KEY` | 可自托管、按Agent隔离、无节点上限 |
+
+使用 Mem0 替代 Zep：
+1. 在 `.env` 中设置 `MEMORY_PROVIDER=mem0`
+2. 设置 `MEM0_API_KEY`（Platform模式）或 `OPENAI_API_KEY`（OSS模式）
 
 #### 2. 安装依赖
 

--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -11,7 +11,7 @@ from flask import request, jsonify
 from . import graph_bp
 from ..config import Config
 from ..services.ontology_generator import OntologyGenerator
-from ..services.graph_builder import GraphBuilderService
+from ..services.memory_factory import get_memory_provider
 from ..services.text_processor import TextProcessor
 from ..utils.file_parser import FileParser
 from ..utils.logger import get_logger
@@ -283,9 +283,7 @@ def build_graph():
         logger.info("=== 开始构建图谱 ===")
         
         # 检查配置
-        errors = []
-        if not Config.ZEP_API_KEY:
-            errors.append("ZEP_API_KEY未配置")
+        errors = Config.validate()
         if errors:
             logger.error(f"配置错误: {errors}")
             return jsonify({
@@ -382,8 +380,8 @@ def build_graph():
                 )
                 
                 # 创建图谱构建服务
-                builder = GraphBuilderService(api_key=Config.ZEP_API_KEY)
-                
+                provider = get_memory_provider()
+
                 # 分块
                 task_manager.update_task(
                     task_id,
@@ -391,32 +389,32 @@ def build_graph():
                     progress=5
                 )
                 chunks = TextProcessor.split_text(
-                    text, 
-                    chunk_size=chunk_size, 
+                    text,
+                    chunk_size=chunk_size,
                     overlap=chunk_overlap
                 )
                 total_chunks = len(chunks)
-                
+
                 # 创建图谱
                 task_manager.update_task(
                     task_id,
-                    message="创建Zep图谱...",
+                    message="创建图谱...",
                     progress=10
                 )
-                graph_id = builder.create_graph(name=graph_name)
-                
+                graph_id = provider.create_graph(name=graph_name)
+
                 # 更新项目的graph_id
                 project.graph_id = graph_id
                 ProjectManager.save_project(project)
-                
+
                 # 设置本体
                 task_manager.update_task(
                     task_id,
                     message="设置本体定义...",
                     progress=15
                 )
-                builder.set_ontology(graph_id, ontology)
-                
+                provider.set_ontology(graph_id, ontology)
+
                 # 添加文本（progress_callback 签名是 (msg, progress_ratio)）
                 def add_progress_callback(msg, progress_ratio):
                     progress = 15 + int(progress_ratio * 40)  # 15% - 55%
@@ -425,27 +423,27 @@ def build_graph():
                         message=msg,
                         progress=progress
                     )
-                
+
                 task_manager.update_task(
                     task_id,
                     message=f"开始添加 {total_chunks} 个文本块...",
                     progress=15
                 )
-                
-                episode_uuids = builder.add_text_batches(
-                    graph_id, 
+
+                episode_uuids = provider.add_text_batches(
+                    graph_id,
                     chunks,
                     batch_size=3,
                     progress_callback=add_progress_callback
                 )
-                
-                # 等待Zep处理完成（查询每个episode的processed状态）
+
+                # 等待处理完成（查询每个episode的processed状态）
                 task_manager.update_task(
                     task_id,
-                    message="等待Zep处理数据...",
+                    message="等待数据处理...",
                     progress=55
                 )
-                
+
                 def wait_progress_callback(msg, progress_ratio):
                     progress = 55 + int(progress_ratio * 35)  # 55% - 90%
                     task_manager.update_task(
@@ -453,16 +451,16 @@ def build_graph():
                         message=msg,
                         progress=progress
                     )
-                
-                builder._wait_for_episodes(episode_uuids, wait_progress_callback)
-                
+
+                provider.wait_for_processing(episode_uuids, wait_progress_callback)
+
                 # 获取图谱数据
                 task_manager.update_task(
                     task_id,
                     message="获取图谱数据...",
                     progress=95
                 )
-                graph_data = builder.get_graph_data(graph_id)
+                graph_data = provider.get_graph_data(graph_id)
                 
                 # 更新项目状态
                 project.status = ProjectStatus.GRAPH_COMPLETED
@@ -567,14 +565,8 @@ def get_graph_data(graph_id: str):
     获取图谱数据（节点和边）
     """
     try:
-        if not Config.ZEP_API_KEY:
-            return jsonify({
-                "success": False,
-                "error": "ZEP_API_KEY未配置"
-            }), 500
-        
-        builder = GraphBuilderService(api_key=Config.ZEP_API_KEY)
-        graph_data = builder.get_graph_data(graph_id)
+        provider = get_memory_provider()
+        graph_data = provider.get_graph_data(graph_id)
         
         return jsonify({
             "success": True,
@@ -595,14 +587,8 @@ def delete_graph(graph_id: str):
     删除Zep图谱
     """
     try:
-        if not Config.ZEP_API_KEY:
-            return jsonify({
-                "success": False,
-                "error": "ZEP_API_KEY未配置"
-            }), 500
-        
-        builder = GraphBuilderService(api_key=Config.ZEP_API_KEY)
-        builder.delete_graph(graph_id)
+        provider = get_memory_provider()
+        provider.delete_graph(graph_id)
         
         return jsonify({
             "success": True,

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -952,10 +952,10 @@ def search_graph_tool():
                 "error": "请提供 graph_id 和 query"
             }), 400
         
-        from ..services.zep_tools import ZepToolsService
-        
-        tools = ZepToolsService()
-        result = tools.search_graph(
+        from ..services.memory_factory import get_memory_provider
+
+        provider = get_memory_provider()
+        result = provider.search_graph(
             graph_id=graph_id,
             query=query,
             limit=limit
@@ -996,10 +996,10 @@ def get_graph_statistics_tool():
                 "error": "请提供 graph_id"
             }), 400
         
-        from ..services.zep_tools import ZepToolsService
-        
-        tools = ZepToolsService()
-        result = tools.get_graph_statistics(graph_id)
+        from ..services.memory_factory import get_memory_provider
+
+        provider = get_memory_provider()
+        result = provider.get_graph_statistics(graph_id)
         
         return jsonify({
             "success": True,

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -9,7 +9,7 @@ from flask import request, jsonify, send_file
 
 from . import simulation_bp
 from ..config import Config
-from ..services.zep_entity_reader import ZepEntityReader
+from ..services.memory_factory import get_memory_provider
 from ..services.oasis_profile_generator import OasisProfileGenerator
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_runner import SimulationRunner, RunnerStatus
@@ -56,20 +56,14 @@ def get_graph_entities(graph_id: str):
         enrich: 是否获取相关边信息（默认true）
     """
     try:
-        if not Config.ZEP_API_KEY:
-            return jsonify({
-                "success": False,
-                "error": "ZEP_API_KEY未配置"
-            }), 500
-        
         entity_types_str = request.args.get('entity_types', '')
         entity_types = [t.strip() for t in entity_types_str.split(',') if t.strip()] if entity_types_str else None
         enrich = request.args.get('enrich', 'true').lower() == 'true'
-        
+
         logger.info(f"获取图谱实体: graph_id={graph_id}, entity_types={entity_types}, enrich={enrich}")
-        
-        reader = ZepEntityReader()
-        result = reader.filter_defined_entities(
+
+        provider = get_memory_provider()
+        result = provider.filter_defined_entities(
             graph_id=graph_id,
             defined_entity_types=entity_types,
             enrich_with_edges=enrich
@@ -93,14 +87,8 @@ def get_graph_entities(graph_id: str):
 def get_entity_detail(graph_id: str, entity_uuid: str):
     """获取单个实体的详细信息"""
     try:
-        if not Config.ZEP_API_KEY:
-            return jsonify({
-                "success": False,
-                "error": "ZEP_API_KEY未配置"
-            }), 500
-        
-        reader = ZepEntityReader()
-        entity = reader.get_entity_with_context(graph_id, entity_uuid)
+        provider = get_memory_provider()
+        entity = provider.get_entity_with_context(graph_id, entity_uuid)
         
         if not entity:
             return jsonify({
@@ -126,19 +114,10 @@ def get_entity_detail(graph_id: str, entity_uuid: str):
 def get_entities_by_type(graph_id: str, entity_type: str):
     """获取指定类型的所有实体"""
     try:
-        if not Config.ZEP_API_KEY:
-            return jsonify({
-                "success": False,
-                "error": "ZEP_API_KEY未配置"
-            }), 500
-        
-        enrich = request.args.get('enrich', 'true').lower() == 'true'
-        
-        reader = ZepEntityReader()
-        entities = reader.get_entities_by_type(
+        provider = get_memory_provider()
+        entities = provider.get_entities_by_type(
             graph_id=graph_id,
-            entity_type=entity_type,
-            enrich_with_edges=enrich
+            entity_type=entity_type
         )
         
         return jsonify({
@@ -471,9 +450,9 @@ def prepare_simulation():
         # 这样前端在调用prepare后立即就能获取到预期Agent总数
         try:
             logger.info(f"同步获取实体数量: graph_id={state.graph_id}")
-            reader = ZepEntityReader()
+            provider = get_memory_provider()
             # 快速读取实体（不需要边信息，只统计数量）
-            filtered_preview = reader.filter_defined_entities(
+            filtered_preview = provider.filter_defined_entities(
                 graph_id=state.graph_id,
                 defined_entity_types=entity_types_list,
                 enrich_with_edges=False  # 不获取边信息，加快速度
@@ -1396,8 +1375,8 @@ def generate_profiles():
         use_llm = data.get('use_llm', True)
         platform = data.get('platform', 'reddit')
         
-        reader = ZepEntityReader()
-        filtered = reader.filter_defined_entities(
+        provider = get_memory_provider()
+        filtered = provider.filter_defined_entities(
             graph_id=graph_id,
             defined_entity_types=entity_types,
             enrich_with_edges=True

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,7 +34,11 @@ class Config:
     
     # Zep配置
     ZEP_API_KEY = os.environ.get('ZEP_API_KEY')
-    
+
+    # Memory Provider配置
+    MEMORY_PROVIDER = os.environ.get('MEMORY_PROVIDER', 'zep')  # 'zep' or 'mem0'
+    MEM0_API_KEY = os.environ.get('MEM0_API_KEY')
+
     # 文件上传配置
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50MB
     UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), '../uploads')
@@ -69,7 +73,9 @@ class Config:
         errors = []
         if not cls.LLM_API_KEY:
             errors.append("LLM_API_KEY 未配置")
-        if not cls.ZEP_API_KEY:
-            errors.append("ZEP_API_KEY 未配置")
+        if cls.MEMORY_PROVIDER == 'zep' and not cls.ZEP_API_KEY:
+            errors.append("ZEP_API_KEY 未配置 (MEMORY_PROVIDER=zep)")
+        if cls.MEMORY_PROVIDER == 'mem0' and not cls.MEM0_API_KEY and not os.environ.get('OPENAI_API_KEY'):
+            errors.append("MEM0_API_KEY 或 OPENAI_API_KEY 未配置 (MEMORY_PROVIDER=mem0)")
         return errors
 

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -7,6 +7,8 @@ from .graph_builder import GraphBuilderService
 from .text_processor import TextProcessor
 from .zep_entity_reader import ZepEntityReader, EntityNode, FilteredEntities
 from .oasis_profile_generator import OasisProfileGenerator, OasisAgentProfile
+from .memory_provider import MemoryProvider
+from .memory_factory import get_memory_provider
 from .simulation_manager import SimulationManager, SimulationState, SimulationStatus
 from .simulation_config_generator import (
     SimulationConfigGenerator, 
@@ -69,5 +71,7 @@ __all__ = [
     'IPCResponse',
     'CommandType',
     'CommandStatus',
+    'MemoryProvider',
+    'get_memory_provider',
 ]
 

--- a/backend/app/services/mem0_provider.py
+++ b/backend/app/services/mem0_provider.py
@@ -1,0 +1,1101 @@
+"""
+Mem0 Memory Provider
+Implements MemoryProvider using the mem0ai SDK (platform or OSS mode).
+"""
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from ..config import Config
+from ..utils.llm_client import LLMClient
+from ..utils.logger import get_logger
+from .memory_provider import (
+    AgentInterview,
+    EdgeInfo,
+    EntityNode,
+    FilteredEntities,
+    InsightForgeResult,
+    InterviewResult,
+    MemoryProvider,
+    NodeInfo,
+    PanoramaResult,
+    SearchResult,
+)
+
+logger = get_logger("mirofish.mem0_provider")
+
+
+# ---------------------------------------------------------------------------
+# Mem0MemoryUpdater
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Mem0MemoryUpdater:
+    """
+    Buffers agent activity dicts and periodically flushes them to Mem0.
+
+    Attributes
+    ----------
+    simulation_id : str
+        Identifies which simulation this updater belongs to.
+    graph_id : str
+        The Mem0 user_id (isolation key) to write memories under.
+    client : object
+        A mem0 MemoryClient or Memory instance.
+    _buffer : list
+        Internal activity buffer.
+    _lock : threading.Lock
+        Protects _buffer for concurrent access.
+    _running : bool
+        Controls the background flush thread.
+    """
+
+    simulation_id: str
+    graph_id: str
+    client: Any  # MemoryClient or Memory
+
+    # mutable defaults must use field()
+    _buffer: List[Dict[str, Any]] = field(default_factory=list)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _running: bool = field(default=False)
+
+    BATCH_SIZE: int = field(default=5, init=False)
+    FLUSH_INTERVAL: int = field(default=10, init=False)  # seconds
+
+    # stats
+    _total_added: int = field(default=0, init=False)
+    _total_flushed: int = field(default=0, init=False)
+    _total_failed: int = field(default=0, init=False)
+    _skipped: int = field(default=0, init=False)
+
+    # background thread (not part of __init__ signature)
+    _thread: Optional[threading.Thread] = field(default=None, init=False)
+
+    def start(self) -> None:
+        """Start the background periodic-flush thread."""
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._periodic_flush,
+            daemon=True,
+            name=f"Mem0Updater-{self.simulation_id[:8]}",
+        )
+        self._thread.start()
+        logger.info(
+            "Mem0MemoryUpdater started: simulation_id=%s graph_id=%s",
+            self.simulation_id,
+            self.graph_id,
+        )
+
+    def stop(self) -> None:
+        """Stop the background thread and flush remaining items."""
+        self._running = False
+        self._flush_remaining()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=15)
+        logger.info(
+            "Mem0MemoryUpdater stopped: simulation_id=%s added=%d flushed=%d failed=%d skipped=%d",
+            self.simulation_id,
+            self._total_added,
+            self._total_flushed,
+            self._total_failed,
+            self._skipped,
+        )
+
+    def add_activity_from_dict(self, data: Dict[str, Any], platform: str) -> None:
+        """
+        Queue one activity dict for later flush.
+
+        Skips entries that are event-type markers or DO_NOTHING actions.
+        """
+        if "event_type" in data:
+            return
+        action_type = data.get("action_type", "")
+        if action_type == "DO_NOTHING":
+            self._skipped += 1
+            return
+
+        entry = dict(data)
+        entry["_platform"] = platform
+        with self._lock:
+            self._buffer.append(entry)
+            self._total_added += 1
+
+        logger.debug(
+            "Mem0Updater queued activity: agent=%s action=%s",
+            data.get("agent_name", "?"),
+            action_type,
+        )
+
+        # Eager flush when buffer reaches BATCH_SIZE
+        batch = None
+        with self._lock:
+            if len(self._buffer) >= self.BATCH_SIZE:
+                batch = self._buffer[: self.BATCH_SIZE]
+                self._buffer = self._buffer[self.BATCH_SIZE :]
+
+        if batch:
+            self._flush_batch(batch)
+
+    def _format_activity(self, data: Dict[str, Any]) -> str:
+        """Convert an activity dict to a natural-language string for Mem0."""
+        agent_name = data.get("agent_name", "Unknown")
+        action_type = data.get("action_type", "")
+        action_args = data.get("action_args", {})
+        platform = data.get("_platform", "")
+
+        descriptions: Dict[str, Any] = {
+            "CREATE_POST": lambda: f"posted: \"{action_args.get('content', '')}\"",
+            "LIKE_POST": lambda: (
+                f"liked {action_args.get('post_author_name', 'someone')}'s post: "
+                f"\"{action_args.get('post_content', '')}\""
+                if action_args.get("post_content")
+                else f"liked a post by {action_args.get('post_author_name', 'someone')}"
+            ),
+            "DISLIKE_POST": lambda: (
+                f"disliked {action_args.get('post_author_name', 'someone')}'s post: "
+                f"\"{action_args.get('post_content', '')}\""
+                if action_args.get("post_content")
+                else "disliked a post"
+            ),
+            "REPOST": lambda: (
+                f"reposted {action_args.get('original_author_name', 'someone')}'s post: "
+                f"\"{action_args.get('original_content', '')}\""
+                if action_args.get("original_content")
+                else "reposted a post"
+            ),
+            "QUOTE_POST": lambda: (
+                f"quoted {action_args.get('original_author_name', 'someone')}'s post "
+                f"\"{action_args.get('original_content', '')}\" "
+                f"with comment: \"{action_args.get('content', '')}\""
+            ),
+            "FOLLOW": lambda: f"followed user \"{action_args.get('target_user_name', 'someone')}\"",
+            "CREATE_COMMENT": lambda: (
+                f"commented \"{action_args.get('content', '')}\" "
+                f"on {action_args.get('post_author_name', 'someone')}'s post"
+                if action_args.get("post_author_name")
+                else f"commented: \"{action_args.get('content', '')}\""
+            ),
+            "LIKE_COMMENT": lambda: (
+                f"liked {action_args.get('comment_author_name', 'someone')}'s comment: "
+                f"\"{action_args.get('comment_content', '')}\""
+                if action_args.get("comment_content")
+                else "liked a comment"
+            ),
+            "DISLIKE_COMMENT": lambda: (
+                f"disliked {action_args.get('comment_author_name', 'someone')}'s comment"
+            ),
+            "SEARCH_POSTS": lambda: f"searched for posts: \"{action_args.get('query', action_args.get('keyword', ''))}\"",
+            "SEARCH_USER": lambda: f"searched for user: \"{action_args.get('query', action_args.get('username', ''))}\"",
+            "MUTE": lambda: f"muted user \"{action_args.get('target_user_name', 'someone')}\"",
+            "REFRESH": lambda: "refreshed their feed",
+            "TREND": lambda: "checked trending topics",
+        }
+
+        desc_fn = descriptions.get(action_type)
+        desc = desc_fn() if desc_fn else f"performed {action_type}"
+
+        platform_tag = f" [{platform}]" if platform else ""
+        round_tag = f" (round {data.get('round', '?')})" if data.get("round") else ""
+        return f"{agent_name}{platform_tag}{round_tag}: {desc}"
+
+    def _flush_batch(self, batch: List[Dict[str, Any]]) -> None:
+        """Send a batch of activities to Mem0 as a single add() call."""
+        if not batch:
+            return
+
+        lines = [self._format_activity(item) for item in batch]
+        combined = "\n".join(lines)
+        messages = [{"role": "user", "content": combined}]
+
+        try:
+            _mem0_add(self.client, messages, self.graph_id)
+            self._total_flushed += len(batch)
+            logger.info(
+                "Mem0Updater flushed %d activities for graph_id=%s",
+                len(batch),
+                self.graph_id,
+            )
+        except Exception as exc:
+            self._total_failed += len(batch)
+            logger.error(
+                "Mem0Updater flush failed for graph_id=%s: %s",
+                self.graph_id,
+                exc,
+            )
+
+    def _flush_remaining(self) -> None:
+        """Flush whatever is left in the buffer, regardless of size."""
+        with self._lock:
+            remaining = list(self._buffer)
+            self._buffer = []
+
+        if remaining:
+            logger.info(
+                "Mem0Updater flushing %d remaining activities on stop", len(remaining)
+            )
+            # Send in sub-batches of BATCH_SIZE
+            for i in range(0, len(remaining), self.BATCH_SIZE):
+                self._flush_batch(remaining[i : i + self.BATCH_SIZE])
+
+    def _periodic_flush(self) -> None:
+        """Background loop: flush buffer every FLUSH_INTERVAL seconds."""
+        while self._running:
+            time.sleep(self.FLUSH_INTERVAL)
+            with self._lock:
+                if len(self._buffer) == 0:
+                    continue
+                batch = list(self._buffer)
+                self._buffer = []
+            self._flush_batch(batch)
+
+    def get_stats(self) -> Dict[str, Any]:
+        with self._lock:
+            buf_size = len(self._buffer)
+        return {
+            "simulation_id": self.simulation_id,
+            "graph_id": self.graph_id,
+            "batch_size": self.BATCH_SIZE,
+            "flush_interval": self.FLUSH_INTERVAL,
+            "total_added": self._total_added,
+            "total_flushed": self._total_flushed,
+            "total_failed": self._total_failed,
+            "skipped": self._skipped,
+            "buffer_size": buf_size,
+            "running": self._running,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _mem0_add(client: Any, messages: List[Dict[str, str]], user_id: str, metadata: Optional[Dict] = None) -> List[Dict]:
+    """
+    Unified add() wrapper that handles both MemoryClient (platform) and Memory (OSS).
+    Returns list of result dicts.
+    """
+    try:
+        # Platform MemoryClient: add(messages, user_id=..., metadata=...)
+        kwargs: Dict[str, Any] = {"user_id": user_id}
+        if metadata:
+            kwargs["metadata"] = metadata
+        result = client.add(messages, **kwargs)
+        if isinstance(result, list):
+            return result
+        # Some versions wrap in {"results": [...]}
+        if isinstance(result, dict) and "results" in result:
+            return result["results"]
+        return []
+    except Exception as exc:
+        logger.error("mem0 add() failed for user_id=%s: %s", user_id, exc)
+        raise
+
+
+def _mem0_search(client: Any, query: str, user_id: str, top_k: int = 10, mode: str = "platform") -> List[Dict]:
+    """
+    Unified search() wrapper.
+    Returns list of memory dicts.
+    """
+    try:
+        if mode == "platform":
+            # Platform: search(query, filters={"user_id": ...}, top_k=...)
+            result = client.search(query, filters={"user_id": user_id}, top_k=top_k)
+        else:
+            # OSS: search(query, user_id=..., limit=...)
+            result = client.search(query, user_id=user_id, limit=top_k)
+
+        if isinstance(result, list):
+            return result
+        if isinstance(result, dict):
+            return result.get("results", [])
+        return []
+    except Exception as exc:
+        logger.error("mem0 search() failed for user_id=%s query='%s': %s", user_id, query, exc)
+        raise
+
+
+def _mem0_get_all(client: Any, user_id: str, mode: str = "platform") -> List[Dict]:
+    """
+    Unified get_all() wrapper.
+    Returns list of memory dicts.
+    """
+    try:
+        if mode == "platform":
+            # Platform: get_all(filters={"user_id": ...}, page_size=...)
+            result = client.get_all(filters={"user_id": user_id}, page_size=1000)
+        else:
+            # OSS: get_all(user_id=...)
+            result = client.get_all(user_id=user_id)
+
+        if isinstance(result, list):
+            return result
+        if isinstance(result, dict):
+            return result.get("results", [])
+        return []
+    except Exception as exc:
+        logger.error("mem0 get_all() failed for user_id=%s: %s", user_id, exc)
+        raise
+
+
+def _mem0_delete_all(client: Any, user_id: str, mode: str = "platform") -> None:
+    """Unified delete_all() wrapper."""
+    try:
+        client.delete_all(user_id=user_id)
+    except Exception as exc:
+        logger.error("mem0 delete_all() failed for user_id=%s: %s", user_id, exc)
+        raise
+
+
+def _memory_to_node(mem: Dict[str, Any]) -> NodeInfo:
+    """Convert a Mem0 memory dict to a NodeInfo."""
+    mem_id = mem.get("id", "")
+    content = mem.get("memory", "")
+    categories = mem.get("categories") or []
+    return NodeInfo(
+        uuid=mem_id,
+        name=content[:80] if content else mem_id,
+        labels=categories if isinstance(categories, list) else [str(categories)],
+        summary=content,
+        attributes={
+            "user_id": mem.get("user_id", ""),
+            "created_at": mem.get("created_at", ""),
+            "updated_at": mem.get("updated_at", ""),
+            "metadata": mem.get("metadata", {}),
+        },
+    )
+
+
+def _relation_to_edge(rel: Dict[str, Any], mem_id: str) -> EdgeInfo:
+    """Convert a relation dict embedded in a Mem0 memory to an EdgeInfo."""
+    source = rel.get("source", "")
+    target = rel.get("target", "")
+    relation = rel.get("relation", "")
+    return EdgeInfo(
+        uuid=f"{mem_id}:{source}:{relation}:{target}",
+        name=relation,
+        fact=f"{source} {relation} {target}",
+        source_node_uuid=source,
+        target_node_uuid=target,
+        source_node_name=source,
+        target_node_name=target,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mem0Provider
+# ---------------------------------------------------------------------------
+
+class Mem0Provider(MemoryProvider):
+    """
+    MemoryProvider implementation backed by the mem0ai SDK.
+
+    Supports both platform mode (MemoryClient) and OSS mode (Memory).
+    The mode is selected automatically based on Config.MEM0_API_KEY:
+      - If MEM0_API_KEY is set  -> platform MemoryClient
+      - Otherwise               -> OSS Memory (requires OPENAI_API_KEY or custom config)
+    """
+
+    def __init__(self) -> None:
+        self._client = self._build_client()
+        # In-memory store for graph metadata (name, ontology)
+        self._graphs: Dict[str, Dict[str, Any]] = {}
+        # Active memory updaters keyed by simulation_id
+        self._updaters: Dict[str, Mem0MemoryUpdater] = {}
+        self._updaters_lock = threading.Lock()
+        # LLM client for insight_forge sub-query generation
+        self._llm: Optional[LLMClient] = None
+        logger.info("Mem0Provider initialized (mode=%s)", self._mode)
+
+    # ------------------------------------------------------------------
+    # Client construction
+    # ------------------------------------------------------------------
+
+    def _build_client(self) -> Any:
+        api_key = Config.MEM0_API_KEY
+        if api_key:
+            # Platform mode
+            try:
+                from mem0 import MemoryClient
+                self._mode = "platform"
+                client = MemoryClient(api_key=api_key)
+                logger.info("Mem0 platform MemoryClient created")
+                return client
+            except ImportError:
+                raise ImportError(
+                    "mem0ai package is not installed. Run: pip install mem0ai"
+                )
+        else:
+            # OSS mode
+            try:
+                from mem0 import Memory
+                self._mode = "oss"
+                client = Memory()
+                logger.info("Mem0 OSS Memory client created")
+                return client
+            except ImportError:
+                raise ImportError(
+                    "mem0ai package is not installed. Run: pip install mem0ai"
+                )
+
+    def _get_llm(self) -> LLMClient:
+        if self._llm is None:
+            self._llm = LLMClient()
+        return self._llm
+
+    # ------------------------------------------------------------------
+    # Graph Building
+    # ------------------------------------------------------------------
+
+    def create_graph(self, name: str) -> str:
+        """
+        Generate a stable graph_id (used as Mem0 user_id) and store metadata.
+        """
+        graph_id = f"mirofish_{uuid.uuid4().hex}"
+        self._graphs[graph_id] = {
+            "name": name,
+            "created_at": datetime.now().isoformat(),
+            "ontology": None,
+        }
+        logger.info("Mem0Provider: created graph name='%s' graph_id=%s", name, graph_id)
+        return graph_id
+
+    def set_ontology(self, graph_id: str, ontology: Dict[str, Any]) -> None:
+        """Store ontology in-memory for later use as extraction guidance."""
+        if graph_id not in self._graphs:
+            self._graphs[graph_id] = {}
+        self._graphs[graph_id]["ontology"] = ontology
+        logger.info("Mem0Provider: ontology set for graph_id=%s", graph_id)
+
+    def add_text_batches(
+        self,
+        graph_id: str,
+        chunks: List[str],
+        batch_size: int = 3,
+        progress_callback=None,
+    ) -> List[str]:
+        """
+        Add text chunks to Mem0 in batches.
+        Returns a list of memory IDs (or chunk indices as fallback).
+        """
+        ids: List[str] = []
+        total = len(chunks)
+        logger.info(
+            "Mem0Provider: adding %d chunks to graph_id=%s (batch_size=%d)",
+            total,
+            graph_id,
+            batch_size,
+        )
+
+        for batch_start in range(0, total, batch_size):
+            batch = chunks[batch_start : batch_start + batch_size]
+            combined_text = "\n\n".join(batch)
+            messages = [{"role": "user", "content": combined_text}]
+
+            try:
+                results = _mem0_add(self._client, messages, graph_id)
+                for r in results:
+                    if isinstance(r, dict) and r.get("id"):
+                        ids.append(r["id"])
+                    else:
+                        ids.append(f"{graph_id}:{batch_start}")
+            except Exception as exc:
+                logger.error(
+                    "Mem0Provider: failed to add batch starting at %d: %s",
+                    batch_start,
+                    exc,
+                )
+                ids.append(f"error:{batch_start}")
+
+            if progress_callback:
+                done = min(batch_start + batch_size, total)
+                ratio = done / total if total > 0 else 1.0
+                try:
+                    progress_callback(
+                        f"Added {done}/{total} chunks to Mem0",
+                        ratio,
+                    )
+                except Exception:
+                    pass
+
+        logger.info(
+            "Mem0Provider: finished adding chunks to graph_id=%s, ids=%d",
+            graph_id,
+            len(ids),
+        )
+        return ids
+
+    def wait_for_processing(
+        self,
+        identifiers: List[str],
+        progress_callback=None,
+        timeout: int = 600,
+    ) -> None:
+        """No-op: Mem0 processes synchronously."""
+        logger.debug("Mem0Provider: wait_for_processing is a no-op (synchronous)")
+
+    def get_graph_data(self, graph_id: str) -> Dict[str, Any]:
+        """Fetch all memories and return graph-like summary."""
+        try:
+            memories = _mem0_get_all(self._client, graph_id, mode=self._mode)
+        except Exception as exc:
+            logger.error("Mem0Provider: get_graph_data failed for graph_id=%s: %s", graph_id, exc)
+            memories = []
+
+        nodes = []
+        edges = []
+        for mem in memories:
+            nodes.append(_memory_to_node(mem).to_dict())
+            for rel in mem.get("relations", []) or []:
+                edges.append(_relation_to_edge(rel, mem.get("id", "")).to_dict())
+
+        return {
+            "graph_id": graph_id,
+            "nodes": nodes,
+            "edges": edges,
+            "node_count": len(nodes),
+            "edge_count": len(edges),
+        }
+
+    def delete_graph(self, graph_id: str) -> None:
+        """Delete all memories for this graph_id and remove local metadata."""
+        try:
+            _mem0_delete_all(self._client, graph_id, mode=self._mode)
+            logger.info("Mem0Provider: deleted all memories for graph_id=%s", graph_id)
+        except Exception as exc:
+            logger.error("Mem0Provider: delete_graph failed for graph_id=%s: %s", graph_id, exc)
+
+        self._graphs.pop(graph_id, None)
+
+    # ------------------------------------------------------------------
+    # Entity Reading
+    # ------------------------------------------------------------------
+
+    def filter_defined_entities(
+        self,
+        graph_id: str,
+        defined_entity_types: Optional[List[str]] = None,
+        enrich_with_edges: bool = True,
+    ) -> FilteredEntities:
+        """
+        Build entity nodes from Mem0 memories.
+        Uses relation triples to derive entity names/types.
+        """
+        try:
+            memories = _mem0_get_all(self._client, graph_id, mode=self._mode)
+        except Exception as exc:
+            logger.error("Mem0Provider: filter_defined_entities failed: %s", exc)
+            memories = []
+
+        # Collect unique entities from relation triples
+        entity_map: Dict[str, EntityNode] = {}
+        for mem in memories:
+            mem_id = mem.get("id", "")
+            categories = mem.get("categories") or []
+            if isinstance(categories, str):
+                categories = [categories]
+
+            for rel in mem.get("relations", []) or []:
+                for role in ("source", "target"):
+                    name = rel.get(role, "")
+                    if not name:
+                        continue
+                    if name not in entity_map:
+                        # Derive label from categories or relation
+                        labels = list(categories) if categories else ["Entity"]
+                        entity_map[name] = EntityNode(
+                            uuid=f"{graph_id}:{name}",
+                            name=name,
+                            labels=labels,
+                            summary=mem.get("memory", ""),
+                            attributes={"memory_id": mem_id},
+                            related_edges=[],
+                            related_nodes=[],
+                        )
+                    # Enrich with edge info
+                    if enrich_with_edges:
+                        edge_fact = f"{rel.get('source', '')} {rel.get('relation', '')} {rel.get('target', '')}"
+                        entity_map[name].related_edges.append({"fact": edge_fact})
+
+        # Optionally filter by type
+        if defined_entity_types:
+            type_set = set(t.lower() for t in defined_entity_types)
+            filtered = [
+                e for e in entity_map.values()
+                if any(lbl.lower() in type_set for lbl in e.labels)
+            ]
+        else:
+            filtered = list(entity_map.values())
+
+        entity_types = list(
+            {lbl for e in filtered for lbl in e.labels if lbl not in ("Entity", "Node")}
+        )
+
+        return FilteredEntities(
+            entities=filtered,
+            entity_types=entity_types,
+            total_count=len(entity_map),
+            filtered_count=len(filtered),
+        )
+
+    def get_entity_with_context(
+        self, graph_id: str, entity_uuid: str
+    ) -> Optional[EntityNode]:
+        """
+        Search for the entity by name (last segment of uuid) and return enriched node.
+        """
+        # entity_uuid format: "{graph_id}:{name}"
+        entity_name = entity_uuid.split(":")[-1] if ":" in entity_uuid else entity_uuid
+        try:
+            memories = _mem0_search(self._client, entity_name, graph_id, top_k=20, mode=self._mode)
+        except Exception as exc:
+            logger.error("Mem0Provider: get_entity_with_context search failed: %s", exc)
+            return None
+
+        if not memories:
+            return None
+
+        related_edges: List[Dict] = []
+        related_nodes: List[Dict] = []
+        summary_parts: List[str] = []
+
+        for mem in memories:
+            content = mem.get("memory", "")
+            if content:
+                summary_parts.append(content)
+            for rel in mem.get("relations", []) or []:
+                fact = f"{rel.get('source', '')} {rel.get('relation', '')} {rel.get('target', '')}"
+                related_edges.append({"fact": fact, "memory_id": mem.get("id", "")})
+                other = rel.get("target") if rel.get("source") == entity_name else rel.get("source")
+                if other:
+                    related_nodes.append({"name": other})
+
+        return EntityNode(
+            uuid=entity_uuid,
+            name=entity_name,
+            labels=["Entity"],
+            summary="; ".join(summary_parts[:3]),
+            attributes={"graph_id": graph_id},
+            related_edges=related_edges,
+            related_nodes=related_nodes,
+        )
+
+    def get_entities_by_type(
+        self, graph_id: str, entity_type: str
+    ) -> List[EntityNode]:
+        """Search for entities of a given type by querying Mem0."""
+        try:
+            memories = _mem0_search(self._client, entity_type, graph_id, top_k=50, mode=self._mode)
+        except Exception as exc:
+            logger.error("Mem0Provider: get_entities_by_type failed: %s", exc)
+            return []
+
+        entity_map: Dict[str, EntityNode] = {}
+        for mem in memories:
+            for rel in mem.get("relations", []) or []:
+                for role in ("source", "target"):
+                    name = rel.get(role, "")
+                    if name and name not in entity_map:
+                        entity_map[name] = EntityNode(
+                            uuid=f"{graph_id}:{name}",
+                            name=name,
+                            labels=[entity_type, "Entity"],
+                            summary=mem.get("memory", ""),
+                            attributes={"memory_id": mem.get("id", "")},
+                        )
+        return list(entity_map.values())
+
+    # ------------------------------------------------------------------
+    # Memory Updater (Simulation)
+    # ------------------------------------------------------------------
+
+    def create_memory_updater(self, simulation_id: str, graph_id: str) -> None:
+        """Create and start a Mem0MemoryUpdater for the given simulation."""
+        with self._updaters_lock:
+            # Stop existing updater for this simulation if any
+            if simulation_id in self._updaters:
+                try:
+                    self._updaters[simulation_id].stop()
+                except Exception as exc:
+                    logger.warning(
+                        "Mem0Provider: error stopping old updater for simulation_id=%s: %s",
+                        simulation_id,
+                        exc,
+                    )
+
+            updater = Mem0MemoryUpdater(
+                simulation_id=simulation_id,
+                graph_id=graph_id,
+                client=self._client,
+            )
+            updater.start()
+            self._updaters[simulation_id] = updater
+
+        logger.info(
+            "Mem0Provider: memory updater created for simulation_id=%s graph_id=%s",
+            simulation_id,
+            graph_id,
+        )
+
+    def stop_memory_updater(self, simulation_id: str) -> None:
+        """Stop the updater for the given simulation and flush remaining data."""
+        with self._updaters_lock:
+            updater = self._updaters.pop(simulation_id, None)
+
+        if updater:
+            updater.stop()
+            logger.info(
+                "Mem0Provider: memory updater stopped for simulation_id=%s", simulation_id
+            )
+        else:
+            logger.warning(
+                "Mem0Provider: no updater found for simulation_id=%s", simulation_id
+            )
+
+    def get_memory_updater(self, simulation_id: str) -> Optional[Mem0MemoryUpdater]:
+        """Return the updater instance for the given simulation, or None."""
+        return self._updaters.get(simulation_id)
+
+    def stop_all_memory_updaters(self) -> None:
+        """Stop and remove every active memory updater."""
+        with self._updaters_lock:
+            sim_ids = list(self._updaters.keys())
+
+        for sim_id in sim_ids:
+            with self._updaters_lock:
+                updater = self._updaters.pop(sim_id, None)
+            if updater:
+                try:
+                    updater.stop()
+                except Exception as exc:
+                    logger.error(
+                        "Mem0Provider: error stopping updater for simulation_id=%s: %s",
+                        sim_id,
+                        exc,
+                    )
+
+        logger.info("Mem0Provider: all memory updaters stopped")
+
+    # ------------------------------------------------------------------
+    # Search & Analysis Tools
+    # ------------------------------------------------------------------
+
+    def search_graph(self, graph_id: str, query: str, limit: int = 10) -> SearchResult:
+        """Semantic search using Mem0's vector search."""
+        try:
+            memories = _mem0_search(self._client, query, graph_id, top_k=limit, mode=self._mode)
+        except Exception as exc:
+            logger.error("Mem0Provider: search_graph failed for graph_id=%s: %s", graph_id, exc)
+            return SearchResult(facts=[], edges=[], nodes=[], query=query, total_count=0)
+
+        facts: List[str] = []
+        edges: List[Dict] = []
+        nodes: List[Dict] = []
+
+        for mem in memories:
+            content = mem.get("memory", "")
+            if content:
+                facts.append(content)
+            nodes.append(_memory_to_node(mem).to_dict())
+            for rel in mem.get("relations", []) or []:
+                fact = f"{rel.get('source', '')} {rel.get('relation', '')} {rel.get('target', '')}"
+                edges.append({"fact": fact, "source": rel.get("source"), "target": rel.get("target"), "relation": rel.get("relation")})
+
+        return SearchResult(
+            facts=facts,
+            edges=edges,
+            nodes=nodes,
+            query=query,
+            total_count=len(facts),
+        )
+
+    def insight_forge(
+        self,
+        graph_id: str,
+        query: str,
+        simulation_requirement: str,
+        report_context: str = "",
+        max_sub_queries: int = 5,
+    ) -> InsightForgeResult:
+        """
+        Deep multi-dimensional search:
+        1. Use LLM to decompose the query into sub-queries.
+        2. Execute each sub-query against Mem0.
+        3. Aggregate unique facts, entities, and relationship chains.
+        """
+        # Step 1: Generate sub-queries via LLM
+        sub_queries = self._generate_sub_queries(
+            query, simulation_requirement, report_context, max_sub_queries
+        )
+
+        # Step 2: Multi-search
+        seen_facts: Dict[str, bool] = {}
+        all_facts: List[str] = []
+        entity_map: Dict[str, Dict[str, Any]] = {}
+        relationship_chains: List[str] = []
+
+        for sq in [query] + sub_queries:
+            try:
+                result = self.search_graph(graph_id, sq, limit=10)
+            except Exception as exc:
+                logger.warning("Mem0Provider: insight_forge sub-query '%s' failed: %s", sq, exc)
+                continue
+
+            for fact in result.facts:
+                if fact not in seen_facts:
+                    seen_facts[fact] = True
+                    all_facts.append(fact)
+
+            for edge in result.edges:
+                chain = edge.get("fact", "")
+                if chain and chain not in relationship_chains:
+                    relationship_chains.append(chain)
+
+            for node in result.nodes:
+                nid = node.get("uuid", node.get("name", ""))
+                if nid and nid not in entity_map:
+                    entity_map[nid] = node
+
+        return InsightForgeResult(
+            query=query,
+            simulation_requirement=simulation_requirement,
+            sub_queries=sub_queries,
+            semantic_facts=all_facts,
+            entity_insights=list(entity_map.values()),
+            relationship_chains=relationship_chains,
+            total_facts=len(all_facts),
+            total_entities=len(entity_map),
+            total_relationships=len(relationship_chains),
+        )
+
+    def _generate_sub_queries(
+        self,
+        query: str,
+        simulation_requirement: str,
+        report_context: str,
+        max_sub_queries: int,
+    ) -> List[str]:
+        """Use LLM to generate diverse sub-queries for insight_forge."""
+        try:
+            llm = self._get_llm()
+            prompt = (
+                f"You are a research assistant. Given a main query and simulation context, "
+                f"generate {max_sub_queries} diverse, specific sub-queries to retrieve comprehensive information.\n\n"
+                f"Main Query: {query}\n"
+                f"Simulation Requirement: {simulation_requirement}\n"
+            )
+            if report_context:
+                prompt += f"Report Context: {report_context}\n"
+            prompt += (
+                f"\nReturn a JSON object with key \"sub_queries\" containing a list of "
+                f"{max_sub_queries} sub-query strings. Each sub-query should explore a "
+                f"different angle: entity relationships, behaviors, patterns, or topics."
+            )
+
+            result = llm.chat_json(
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.5,
+            )
+            sub_queries = result.get("sub_queries", [])
+            if isinstance(sub_queries, list):
+                return [str(q) for q in sub_queries[:max_sub_queries]]
+        except Exception as exc:
+            logger.warning(
+                "Mem0Provider: sub-query generation failed, falling back to empty list: %s", exc
+            )
+        return []
+
+    def panorama_search(self, graph_id: str, query: str) -> PanoramaResult:
+        """
+        Full-scan search: get all memories and classify into active/historical facts.
+        """
+        try:
+            memories = _mem0_get_all(self._client, graph_id, mode=self._mode)
+        except Exception as exc:
+            logger.error("Mem0Provider: panorama_search failed for graph_id=%s: %s", graph_id, exc)
+            memories = []
+
+        all_nodes: List[NodeInfo] = []
+        all_edges: List[EdgeInfo] = []
+        active_facts: List[str] = []
+        historical_facts: List[str] = []
+
+        for mem in memories:
+            node = _memory_to_node(mem)
+            all_nodes.append(node)
+
+            content = mem.get("memory", "")
+            if content:
+                # Heuristic: memories without an updated_at or with recent creation
+                # are treated as active; older ones or superseded as historical.
+                updated_at = mem.get("updated_at", "")
+                created_at = mem.get("created_at", "")
+                # Treat all as active since Mem0 manages updates automatically
+                active_facts.append(content)
+
+            for rel in mem.get("relations", []) or []:
+                edge = _relation_to_edge(rel, mem.get("id", ""))
+                all_edges.append(edge)
+
+        return PanoramaResult(
+            query=query,
+            all_nodes=all_nodes,
+            all_edges=all_edges,
+            active_facts=active_facts,
+            historical_facts=historical_facts,
+            total_nodes=len(all_nodes),
+            total_edges=len(all_edges),
+            active_count=len(active_facts),
+            historical_count=len(historical_facts),
+        )
+
+    def quick_search(self, graph_id: str, query: str, limit: int = 5) -> SearchResult:
+        """Delegate to search_graph with the given limit."""
+        return self.search_graph(graph_id, query, limit=limit)
+
+    def interview_agents(
+        self,
+        graph_id: str,
+        interview_topic: str,
+        interview_questions: List[str],
+        num_agents: int = 3,
+        agent_profiles: Optional[Dict] = None,
+        simulation_id: Optional[str] = None,
+    ) -> InterviewResult:
+        """
+        Return a placeholder InterviewResult.
+        Agent interviews depend on SimulationRunner IPC and are not
+        driven by the memory backend.
+        """
+        logger.info(
+            "Mem0Provider: interview_agents called (placeholder) for graph_id=%s topic='%s'",
+            graph_id,
+            interview_topic,
+        )
+        return InterviewResult(
+            interview_topic=interview_topic,
+            interview_questions=interview_questions,
+            selected_agents=[],
+            interviews=[],
+            selection_reasoning="interview_agents is not supported by Mem0Provider; use SimulationRunner IPC.",
+            summary="Not available: Mem0Provider does not support direct agent interviews.",
+            total_agents=0,
+            interviewed_count=0,
+        )
+
+    def get_graph_statistics(self, graph_id: str) -> Dict[str, Any]:
+        """Return counts of memories and relations."""
+        try:
+            memories = _mem0_get_all(self._client, graph_id, mode=self._mode)
+        except Exception as exc:
+            logger.error("Mem0Provider: get_graph_statistics failed: %s", exc)
+            return {"graph_id": graph_id, "error": str(exc)}
+
+        relation_count = sum(len(m.get("relations", []) or []) for m in memories)
+        return {
+            "graph_id": graph_id,
+            "memory_count": len(memories),
+            "relation_count": relation_count,
+            "metadata": self._graphs.get(graph_id, {}),
+        }
+
+    def get_entity_summary(self, graph_id: str, entity_uuid: str) -> str:
+        """Return a textual summary of an entity's relationships."""
+        entity = self.get_entity_with_context(graph_id, entity_uuid)
+        if not entity:
+            return f"No information found for entity: {entity_uuid}"
+
+        lines = [f"Entity: {entity.name}", f"Summary: {entity.summary}"]
+        if entity.related_edges:
+            lines.append("Relationships:")
+            for edge in entity.related_edges[:10]:
+                lines.append(f"  - {edge.get('fact', '')}")
+        return "\n".join(lines)
+
+    def get_all_nodes(self, graph_id: str) -> List[NodeInfo]:
+        """Return all memory items as NodeInfo objects."""
+        try:
+            memories = _mem0_get_all(self._client, graph_id, mode=self._mode)
+        except Exception as exc:
+            logger.error("Mem0Provider: get_all_nodes failed: %s", exc)
+            return []
+        return [_memory_to_node(m) for m in memories]
+
+    def get_all_edges(
+        self, graph_id: str, include_temporal: bool = True
+    ) -> List[EdgeInfo]:
+        """Return all relation triples as EdgeInfo objects."""
+        try:
+            memories = _mem0_get_all(self._client, graph_id, mode=self._mode)
+        except Exception as exc:
+            logger.error("Mem0Provider: get_all_edges failed: %s", exc)
+            return []
+
+        edges: List[EdgeInfo] = []
+        for mem in memories:
+            for rel in mem.get("relations", []) or []:
+                edges.append(_relation_to_edge(rel, mem.get("id", "")))
+        return edges
+
+    def get_simulation_context(self, graph_id: str, simulation_id: str) -> str:
+        """Return a compact text context for a simulation."""
+        graph_meta = self._graphs.get(graph_id, {})
+        graph_name = graph_meta.get("name", graph_id)
+
+        try:
+            recent = _mem0_search(
+                self._client,
+                f"simulation {simulation_id}",
+                graph_id,
+                top_k=10,
+                mode=self._mode,
+            )
+        except Exception:
+            recent = []
+
+        lines = [
+            f"Graph: {graph_name} (id={graph_id})",
+            f"Simulation: {simulation_id}",
+        ]
+        if recent:
+            lines.append("Recent context:")
+            for mem in recent[:5]:
+                content = mem.get("memory", "")
+                if content:
+                    lines.append(f"  - {content}")
+        return "\n".join(lines)
+
+    def search_for_entity_context(
+        self,
+        graph_id: str,
+        query: str,
+        limit: int = 30,
+    ) -> List[Dict[str, Any]]:
+        """Search and return raw memory dicts for profile generation."""
+        try:
+            memories = _mem0_search(self._client, query, graph_id, top_k=limit, mode=self._mode)
+        except Exception as exc:
+            logger.error(
+                "Mem0Provider: search_for_entity_context failed for graph_id=%s: %s",
+                graph_id,
+                exc,
+            )
+            return []
+
+        results = []
+        for mem in memories:
+            results.append({
+                "uuid": mem.get("id", ""),
+                "name": mem.get("memory", "")[:80],
+                "fact": mem.get("memory", ""),
+                "score": mem.get("score", 0.0),
+                "categories": mem.get("categories", []),
+                "metadata": mem.get("metadata", {}),
+                "relations": mem.get("relations", []),
+            })
+        return results

--- a/backend/app/services/memory_factory.py
+++ b/backend/app/services/memory_factory.py
@@ -1,0 +1,55 @@
+"""
+Memory Provider工厂
+根据配置返回对应的记忆提供者实例
+"""
+
+import threading
+from typing import Optional
+
+from ..config import Config
+from ..utils.logger import get_logger
+from .memory_provider import MemoryProvider
+
+logger = get_logger('mirofish.memory_factory')
+
+_provider_instance: Optional[MemoryProvider] = None
+_lock = threading.Lock()
+
+
+def get_memory_provider() -> MemoryProvider:
+    """
+    获取配置的记忆提供者实例（单例，线程安全）
+
+    根据 Config.MEMORY_PROVIDER 返回:
+    - 'zep': ZepProvider (默认)
+    - 'mem0': Mem0Provider
+    """
+    global _provider_instance
+
+    if _provider_instance is not None:
+        return _provider_instance
+
+    with _lock:
+        # Double-check after acquiring lock
+        if _provider_instance is not None:
+            return _provider_instance
+
+        provider_name = Config.MEMORY_PROVIDER
+
+        if provider_name == 'mem0':
+            from .mem0_provider import Mem0Provider
+            _provider_instance = Mem0Provider()
+            logger.info("Memory provider initialized: Mem0")
+        else:
+            from .zep_provider import ZepProvider
+            _provider_instance = ZepProvider()
+            logger.info("Memory provider initialized: Zep")
+
+    return _provider_instance
+
+
+def reset_provider():
+    """Reset the singleton (useful for testing)"""
+    global _provider_instance
+    with _lock:
+        _provider_instance = None

--- a/backend/app/services/memory_provider.py
+++ b/backend/app/services/memory_provider.py
@@ -1,0 +1,397 @@
+"""
+Memory Provider抽象接口
+定义MiroFish记忆后端的统一接口，支持Zep和Mem0等多种后端
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, Any, List, Optional
+
+
+# ============== 共享数据类 ==============
+
+@dataclass
+class EntityNode:
+    """实体节点数据结构"""
+    uuid: str
+    name: str
+    labels: List[str]
+    summary: str
+    attributes: Dict[str, Any]
+    related_edges: List[Dict[str, Any]] = field(default_factory=list)
+    related_nodes: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "uuid": self.uuid,
+            "name": self.name,
+            "labels": self.labels,
+            "summary": self.summary,
+            "attributes": self.attributes,
+            "related_edges": self.related_edges,
+            "related_nodes": self.related_nodes,
+        }
+
+    def get_entity_type(self) -> Optional[str]:
+        """获取实体类型（排除默认的Entity标签）"""
+        for label in self.labels:
+            if label not in ["Entity", "Node"]:
+                return label
+        return None
+
+
+@dataclass
+class FilteredEntities:
+    """过滤后的实体集合"""
+    entities: List[EntityNode]
+    entity_types: List[str]
+    total_count: int
+    filtered_count: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "entities": [e.to_dict() for e in self.entities],
+            "entity_types": self.entity_types,
+            "total_count": self.total_count,
+            "filtered_count": self.filtered_count,
+        }
+
+
+@dataclass
+class SearchResult:
+    """搜索结果"""
+    facts: List[str]
+    edges: List[Dict[str, Any]]
+    nodes: List[Dict[str, Any]]
+    query: str
+    total_count: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "facts": self.facts,
+            "edges": self.edges,
+            "nodes": self.nodes,
+            "query": self.query,
+            "total_count": self.total_count,
+        }
+
+    def to_text(self) -> str:
+        return f"Query: {self.query}\nFacts ({self.total_count}):\n" + "\n".join(
+            f"- {f}" for f in self.facts
+        )
+
+
+@dataclass
+class NodeInfo:
+    """节点信息"""
+    uuid: str
+    name: str
+    labels: List[str]
+    summary: str
+    attributes: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "uuid": self.uuid,
+            "name": self.name,
+            "labels": self.labels,
+            "summary": self.summary,
+            "attributes": self.attributes,
+        }
+
+
+@dataclass
+class EdgeInfo:
+    """边信息"""
+    uuid: str
+    name: str
+    fact: str
+    source_node_uuid: str
+    target_node_uuid: str
+    source_node_name: Optional[str] = None
+    target_node_name: Optional[str] = None
+    created_at: Optional[str] = None
+    valid_at: Optional[str] = None
+    invalid_at: Optional[str] = None
+    expired_at: Optional[str] = None
+
+    @property
+    def is_expired(self) -> bool:
+        return self.expired_at is not None
+
+    @property
+    def is_invalid(self) -> bool:
+        return self.invalid_at is not None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "uuid": self.uuid,
+            "name": self.name,
+            "fact": self.fact,
+            "source_node_uuid": self.source_node_uuid,
+            "target_node_uuid": self.target_node_uuid,
+            "source_node_name": self.source_node_name,
+            "target_node_name": self.target_node_name,
+            "created_at": self.created_at,
+            "valid_at": self.valid_at,
+            "invalid_at": self.invalid_at,
+            "expired_at": self.expired_at,
+        }
+
+
+@dataclass
+class InsightForgeResult:
+    """深度洞察搜索结果"""
+    query: str
+    simulation_requirement: str
+    sub_queries: List[str]
+    semantic_facts: List[str]
+    entity_insights: List[Dict[str, Any]]
+    relationship_chains: List[str]
+    total_facts: int
+    total_entities: int
+    total_relationships: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "query": self.query,
+            "simulation_requirement": self.simulation_requirement,
+            "sub_queries": self.sub_queries,
+            "semantic_facts": self.semantic_facts,
+            "entity_insights": self.entity_insights,
+            "relationship_chains": self.relationship_chains,
+            "total_facts": self.total_facts,
+            "total_entities": self.total_entities,
+            "total_relationships": self.total_relationships,
+        }
+
+    def to_text(self) -> str:
+        text = f"Query: {self.query}\nSub-queries: {self.sub_queries}\n"
+        text += f"Semantic Facts ({self.total_facts}):\n"
+        text += "\n".join(f"- {f}" for f in self.semantic_facts)
+        if self.relationship_chains:
+            text += f"\n\nRelationship Chains ({self.total_relationships}):\n"
+            text += "\n".join(f"- {r}" for r in self.relationship_chains)
+        return text
+
+
+@dataclass
+class PanoramaResult:
+    """全景搜索结果"""
+    query: str
+    all_nodes: List[NodeInfo]
+    all_edges: List[EdgeInfo]
+    active_facts: List[str]
+    historical_facts: List[str]
+    total_nodes: int
+    total_edges: int
+    active_count: int
+    historical_count: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "query": self.query,
+            "all_nodes": [n.to_dict() for n in self.all_nodes],
+            "all_edges": [e.to_dict() for e in self.all_edges],
+            "active_facts": self.active_facts,
+            "historical_facts": self.historical_facts,
+            "total_nodes": self.total_nodes,
+            "total_edges": self.total_edges,
+            "active_count": self.active_count,
+            "historical_count": self.historical_count,
+        }
+
+    def to_text(self) -> str:
+        text = f"Active facts ({self.active_count}):\n"
+        text += "\n".join(f"- {f}" for f in self.active_facts)
+        if self.historical_facts:
+            text += f"\n\nHistorical facts ({self.historical_count}):\n"
+            text += "\n".join(f"- {f}" for f in self.historical_facts)
+        return text
+
+
+@dataclass
+class AgentInterview:
+    """单个Agent访谈结果"""
+    agent_name: str
+    agent_id: str
+    response: str
+    questions: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "agent_name": self.agent_name,
+            "agent_id": self.agent_id,
+            "response": self.response,
+            "questions": self.questions,
+        }
+
+
+@dataclass
+class InterviewResult:
+    """访谈结果"""
+    interview_topic: str
+    interview_questions: List[str]
+    selected_agents: List[Dict[str, Any]]
+    interviews: List[AgentInterview]
+    selection_reasoning: str
+    summary: str
+    total_agents: int
+    interviewed_count: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "interview_topic": self.interview_topic,
+            "interview_questions": self.interview_questions,
+            "selected_agents": self.selected_agents,
+            "interviews": [i.to_dict() for i in self.interviews],
+            "selection_reasoning": self.selection_reasoning,
+            "summary": self.summary,
+            "total_agents": self.total_agents,
+            "interviewed_count": self.interviewed_count,
+        }
+
+    def to_text(self) -> str:
+        text = f"Topic: {self.interview_topic}\nSummary: {self.summary}\n"
+        for iv in self.interviews:
+            text += f"\n{iv.agent_name}: {iv.response[:200]}"
+        return text
+
+
+# ============== 抽象接口 ==============
+
+class MemoryProvider(ABC):
+    """
+    MiroFish记忆后端抽象接口
+    所有记忆提供者（Zep、Mem0等）必须实现此接口
+    """
+
+    # --- Graph Building ---
+
+    @abstractmethod
+    def create_graph(self, name: str) -> str:
+        """创建新图谱，返回graph_id"""
+
+    @abstractmethod
+    def set_ontology(self, graph_id: str, ontology: Dict[str, Any]) -> None:
+        """设置实体/关系类型定义"""
+
+    @abstractmethod
+    def add_text_batches(self, graph_id: str, chunks: List[str],
+                         batch_size: int = 3,
+                         progress_callback=None) -> List[str]:
+        """批量添加文本块，返回标识符列表"""
+
+    @abstractmethod
+    def wait_for_processing(self, identifiers: List[str],
+                            progress_callback=None,
+                            timeout: int = 600) -> None:
+        """等待数据处理完成（某些后端可能无需等待）"""
+
+    @abstractmethod
+    def get_graph_data(self, graph_id: str) -> Dict[str, Any]:
+        """获取图谱完整数据: {graph_id, nodes, edges, node_count, edge_count}"""
+
+    @abstractmethod
+    def delete_graph(self, graph_id: str) -> None:
+        """删除图谱及所有数据"""
+
+    # --- Entity Reading ---
+
+    @abstractmethod
+    def filter_defined_entities(self, graph_id: str,
+                                 defined_entity_types: Optional[List[str]] = None,
+                                 enrich_with_edges: bool = True) -> FilteredEntities:
+        """按类型过滤实体"""
+
+    @abstractmethod
+    def get_entity_with_context(self, graph_id: str,
+                                 entity_uuid: str) -> Optional[EntityNode]:
+        """获取实体及其关联的边和节点"""
+
+    @abstractmethod
+    def get_entities_by_type(self, graph_id: str,
+                              entity_type: str) -> List[EntityNode]:
+        """按类型获取实体列表"""
+
+    # --- Memory Updater (Simulation) ---
+
+    @abstractmethod
+    def create_memory_updater(self, simulation_id: str,
+                               graph_id: str) -> None:
+        """为模拟创建并启动记忆更新器"""
+
+    @abstractmethod
+    def stop_memory_updater(self, simulation_id: str) -> None:
+        """停止记忆更新器并flush剩余数据"""
+
+    @abstractmethod
+    def get_memory_updater(self, simulation_id: str):
+        """获取记忆更新器实例"""
+
+    @abstractmethod
+    def stop_all_memory_updaters(self) -> None:
+        """停止所有记忆更新器"""
+
+    # --- Search & Analysis Tools ---
+
+    @abstractmethod
+    def search_graph(self, graph_id: str, query: str,
+                      limit: int = 10) -> SearchResult:
+        """语义搜索图谱"""
+
+    @abstractmethod
+    def insight_forge(self, graph_id: str, query: str,
+                       simulation_requirement: str,
+                       report_context: str = "",
+                       max_sub_queries: int = 5) -> InsightForgeResult:
+        """深度多维搜索"""
+
+    @abstractmethod
+    def panorama_search(self, graph_id: str,
+                         query: str) -> PanoramaResult:
+        """全景搜索"""
+
+    @abstractmethod
+    def quick_search(self, graph_id: str, query: str,
+                      limit: int = 5) -> SearchResult:
+        """快速关键词搜索"""
+
+    @abstractmethod
+    def interview_agents(self, graph_id: str,
+                          interview_topic: str,
+                          interview_questions: List[str],
+                          num_agents: int = 3,
+                          agent_profiles: Optional[Dict] = None,
+                          simulation_id: Optional[str] = None) -> InterviewResult:
+        """访谈模拟Agent。simulation_id用于Zep后端访问模拟运行器。"""
+
+    @abstractmethod
+    def get_graph_statistics(self, graph_id: str) -> Dict[str, Any]:
+        """获取图谱统计信息"""
+
+    @abstractmethod
+    def get_entity_summary(self, graph_id: str,
+                            entity_uuid: str) -> str:
+        """获取实体关系摘要"""
+
+    @abstractmethod
+    def get_all_nodes(self, graph_id: str) -> List[NodeInfo]:
+        """获取所有节点"""
+
+    @abstractmethod
+    def get_all_edges(self, graph_id: str,
+                       include_temporal: bool = True) -> List[EdgeInfo]:
+        """获取所有边"""
+
+    @abstractmethod
+    def get_simulation_context(self, graph_id: str,
+                                simulation_id: str) -> str:
+        """获取模拟上下文信息"""
+
+    # --- Profile Generation ---
+
+    @abstractmethod
+    def search_for_entity_context(self, graph_id: str, query: str,
+                                   limit: int = 30) -> List[Dict[str, Any]]:
+        """搜索实体上下文（用于Profile生成丰富信息）"""

--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -16,11 +16,11 @@ from dataclasses import dataclass, field
 from datetime import datetime
 
 from openai import OpenAI
-from zep_cloud.client import Zep
+from .memory_factory import get_memory_provider
 
 from ..config import Config
 from ..utils.logger import get_logger
-from .zep_entity_reader import EntityNode, ZepEntityReader
+from .memory_provider import EntityNode
 
 logger = get_logger('mirofish.oasis_profile')
 
@@ -197,16 +197,9 @@ class OasisProfileGenerator:
             base_url=self.base_url
         )
         
-        # Zep客户端用于检索丰富上下文
-        self.zep_api_key = zep_api_key or Config.ZEP_API_KEY
-        self.zep_client = None
+        # Memory provider for entity context retrieval
+        self._provider = get_memory_provider()
         self.graph_id = graph_id
-        
-        if self.zep_api_key:
-            try:
-                self.zep_client = Zep(api_key=self.zep_api_key)
-            except Exception as e:
-                logger.warning(f"Zep客户端初始化失败: {e}")
     
     def generate_profile_from_entity(
         self, 
@@ -284,115 +277,45 @@ class OasisProfileGenerator:
     
     def _search_zep_for_entity(self, entity: EntityNode) -> Dict[str, Any]:
         """
-        使用Zep图谱混合搜索功能获取实体相关的丰富信息
-        
-        Zep没有内置混合搜索接口，需要分别搜索edges和nodes然后合并结果。
-        使用并行请求同时搜索，提高效率。
-        
+        使用memory provider搜索实体相关的丰富信息。
+
         Args:
             entity: 实体节点对象
-            
+
         Returns:
             包含facts, node_summaries, context的字典
         """
-        import concurrent.futures
-        
-        if not self.zep_client:
-            return {"facts": [], "node_summaries": [], "context": ""}
-        
         entity_name = entity.name
-        
+
         results = {
             "facts": [],
             "node_summaries": [],
             "context": ""
         }
-        
+
         # 必须有graph_id才能进行搜索
         if not self.graph_id:
-            logger.debug(f"跳过Zep检索：未设置graph_id")
+            logger.debug(f"跳过检索：未设置graph_id")
             return results
-        
+
         comprehensive_query = f"关于{entity_name}的所有信息、活动、事件、关系和背景"
-        
-        def search_edges():
-            """搜索边（事实/关系）- 带重试机制"""
-            max_retries = 3
-            last_exception = None
-            delay = 2.0
-            
-            for attempt in range(max_retries):
-                try:
-                    return self.zep_client.graph.search(
-                        query=comprehensive_query,
-                        graph_id=self.graph_id,
-                        limit=30,
-                        scope="edges",
-                        reranker="rrf"
-                    )
-                except Exception as e:
-                    last_exception = e
-                    if attempt < max_retries - 1:
-                        logger.debug(f"Zep边搜索第 {attempt + 1} 次失败: {str(e)[:80]}, 重试中...")
-                        time.sleep(delay)
-                        delay *= 2
-                    else:
-                        logger.debug(f"Zep边搜索在 {max_retries} 次尝试后仍失败: {e}")
-            return None
-        
-        def search_nodes():
-            """搜索节点（实体摘要）- 带重试机制"""
-            max_retries = 3
-            last_exception = None
-            delay = 2.0
-            
-            for attempt in range(max_retries):
-                try:
-                    return self.zep_client.graph.search(
-                        query=comprehensive_query,
-                        graph_id=self.graph_id,
-                        limit=20,
-                        scope="nodes",
-                        reranker="rrf"
-                    )
-                except Exception as e:
-                    last_exception = e
-                    if attempt < max_retries - 1:
-                        logger.debug(f"Zep节点搜索第 {attempt + 1} 次失败: {str(e)[:80]}, 重试中...")
-                        time.sleep(delay)
-                        delay *= 2
-                    else:
-                        logger.debug(f"Zep节点搜索在 {max_retries} 次尝试后仍失败: {e}")
-            return None
-        
+
         try:
-            # 并行执行edges和nodes搜索
-            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-                edge_future = executor.submit(search_edges)
-                node_future = executor.submit(search_nodes)
-                
-                # 获取结果
-                edge_result = edge_future.result(timeout=30)
-                node_result = node_future.result(timeout=30)
-            
-            # 处理边搜索结果
+            edge_result = self._provider.search_for_entity_context(
+                graph_id=self.graph_id,
+                query=comprehensive_query,
+                limit=30,
+            )
+
+            # 处理边搜索结果 — provider returns a list of dicts with 'fact' key
             all_facts = set()
-            if edge_result and hasattr(edge_result, 'edges') and edge_result.edges:
-                for edge in edge_result.edges:
-                    if hasattr(edge, 'fact') and edge.fact:
-                        all_facts.add(edge.fact)
+            if edge_result:
+                for item in edge_result:
+                    fact = item.get("fact") if isinstance(item, dict) else getattr(item, "fact", None)
+                    if fact:
+                        all_facts.add(fact)
             results["facts"] = list(all_facts)
-            
-            # 处理节点搜索结果
-            all_summaries = set()
-            if node_result and hasattr(node_result, 'nodes') and node_result.nodes:
-                for node in node_result.nodes:
-                    if hasattr(node, 'summary') and node.summary:
-                        all_summaries.add(node.summary)
-                    if hasattr(node, 'name') and node.name and node.name != entity_name:
-                        all_summaries.add(f"相关实体: {node.name}")
-            results["node_summaries"] = list(all_summaries)
-            
+
             # 构建综合上下文
             context_parts = []
             if results["facts"]:
@@ -400,14 +323,12 @@ class OasisProfileGenerator:
             if results["node_summaries"]:
                 context_parts.append("相关实体:\n" + "\n".join(f"- {s}" for s in results["node_summaries"][:10]))
             results["context"] = "\n\n".join(context_parts)
-            
-            logger.info(f"Zep混合检索完成: {entity_name}, 获取 {len(results['facts'])} 条事实, {len(results['node_summaries'])} 个相关节点")
-            
-        except concurrent.futures.TimeoutError:
-            logger.warning(f"Zep检索超时 ({entity_name})")
+
+            logger.info(f"Memory provider检索完成: {entity_name}, 获取 {len(results['facts'])} 条事实")
+
         except Exception as e:
-            logger.warning(f"Zep检索失败 ({entity_name}): {e}")
-        
+            logger.warning(f"Memory provider检索失败 ({entity_name}): {e}")
+
         return results
     
     def _build_entity_context(self, entity: EntityNode) -> str:

--- a/backend/app/services/report_agent.py
+++ b/backend/app/services/report_agent.py
@@ -21,13 +21,13 @@ from enum import Enum
 from ..config import Config
 from ..utils.llm_client import LLMClient
 from ..utils.logger import get_logger
-from .zep_tools import (
-    ZepToolsService, 
-    SearchResult, 
-    InsightForgeResult, 
+from .memory_provider import (
+    SearchResult,
+    InsightForgeResult,
     PanoramaResult,
-    InterviewResult
+    InterviewResult,
 )
+from .memory_factory import get_memory_provider
 
 logger = get_logger('mirofish.report_agent')
 
@@ -886,7 +886,7 @@ class ReportAgent:
         simulation_id: str,
         simulation_requirement: str,
         llm_client: Optional[LLMClient] = None,
-        zep_tools: Optional[ZepToolsService] = None
+        zep_tools: Optional[Any] = None
     ):
         """
         初始化Report Agent
@@ -903,7 +903,7 @@ class ReportAgent:
         self.simulation_requirement = simulation_requirement
         
         self.llm = llm_client or LLMClient()
-        self.zep_tools = zep_tools or ZepToolsService()
+        self.provider = zep_tools or get_memory_provider()
         
         # 工具定义
         self.tools = self._define_tools()
@@ -970,7 +970,7 @@ class ReportAgent:
             if tool_name == "insight_forge":
                 query = parameters.get("query", "")
                 ctx = parameters.get("report_context", "") or report_context
-                result = self.zep_tools.insight_forge(
+                result = self.provider.insight_forge(
                     graph_id=self.graph_id,
                     query=query,
                     simulation_requirement=self.simulation_requirement,
@@ -984,10 +984,9 @@ class ReportAgent:
                 include_expired = parameters.get("include_expired", True)
                 if isinstance(include_expired, str):
                     include_expired = include_expired.lower() in ['true', '1', 'yes']
-                result = self.zep_tools.panorama_search(
+                result = self.provider.panorama_search(
                     graph_id=self.graph_id,
                     query=query,
-                    include_expired=include_expired
                 )
                 return result.to_text()
             
@@ -997,7 +996,7 @@ class ReportAgent:
                 limit = parameters.get("limit", 10)
                 if isinstance(limit, str):
                     limit = int(limit)
-                result = self.zep_tools.quick_search(
+                result = self.provider.quick_search(
                     graph_id=self.graph_id,
                     query=query,
                     limit=limit
@@ -1011,11 +1010,12 @@ class ReportAgent:
                 if isinstance(max_agents, str):
                     max_agents = int(max_agents)
                 max_agents = min(max_agents, 10)
-                result = self.zep_tools.interview_agents(
+                result = self.provider.interview_agents(
+                    graph_id=self.graph_id,
+                    interview_topic=interview_topic,
+                    interview_questions=[interview_topic],
+                    num_agents=max_agents,
                     simulation_id=self.simulation_id,
-                    interview_requirement=interview_topic,
-                    simulation_requirement=self.simulation_requirement,
-                    max_agents=max_agents
                 )
                 return result.to_text()
             
@@ -1027,14 +1027,14 @@ class ReportAgent:
                 return self._execute_tool("quick_search", parameters, report_context)
             
             elif tool_name == "get_graph_statistics":
-                result = self.zep_tools.get_graph_statistics(self.graph_id)
+                result = self.provider.get_graph_statistics(self.graph_id)
                 return json.dumps(result, ensure_ascii=False, indent=2)
             
             elif tool_name == "get_entity_summary":
                 entity_name = parameters.get("entity_name", "")
-                result = self.zep_tools.get_entity_summary(
+                result = self.provider.get_entity_summary(
                     graph_id=self.graph_id,
-                    entity_name=entity_name
+                    entity_uuid=entity_name,
                 )
                 return json.dumps(result, ensure_ascii=False, indent=2)
             
@@ -1046,7 +1046,7 @@ class ReportAgent:
             
             elif tool_name == "get_entities_by_type":
                 entity_type = parameters.get("entity_type", "")
-                nodes = self.zep_tools.get_entities_by_type(
+                nodes = self.provider.get_entities_by_type(
                     graph_id=self.graph_id,
                     entity_type=entity_type
                 )
@@ -1154,7 +1154,7 @@ class ReportAgent:
             progress_callback("planning", 0, "正在分析模拟需求...")
         
         # 首先获取模拟上下文
-        context = self.zep_tools.get_simulation_context(
+        context = self.provider.get_simulation_context(
             graph_id=self.graph_id,
             simulation_requirement=self.simulation_requirement
         )

--- a/backend/app/services/simulation_config_generator.py
+++ b/backend/app/services/simulation_config_generator.py
@@ -20,7 +20,7 @@ from openai import OpenAI
 
 from ..config import Config
 from ..utils.logger import get_logger
-from .zep_entity_reader import EntityNode, ZepEntityReader
+from .memory_provider import EntityNode
 
 logger = get_logger('mirofish.simulation_config')
 

--- a/backend/app/services/simulation_manager.py
+++ b/backend/app/services/simulation_manager.py
@@ -14,7 +14,8 @@ from enum import Enum
 
 from ..config import Config
 from ..utils.logger import get_logger
-from .zep_entity_reader import ZepEntityReader, FilteredEntities
+from .memory_factory import get_memory_provider
+from .memory_provider import FilteredEntities
 from .oasis_profile_generator import OasisProfileGenerator, OasisAgentProfile
 from .simulation_config_generator import SimulationConfigGenerator, SimulationParameters
 
@@ -270,14 +271,14 @@ class SimulationManager:
             
             # ========== 阶段1: 读取并过滤实体 ==========
             if progress_callback:
-                progress_callback("reading", 0, "正在连接Zep图谱...")
+                progress_callback("reading", 0, "正在连接图谱...")
             
-            reader = ZepEntityReader()
-            
+            provider = get_memory_provider()
+
             if progress_callback:
                 progress_callback("reading", 30, "正在读取节点数据...")
-            
-            filtered = reader.filter_defined_entities(
+
+            filtered = provider.filter_defined_entities(
                 graph_id=state.graph_id,
                 defined_entity_types=defined_entity_types,
                 enrich_with_edges=True

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -20,7 +20,7 @@ from queue import Queue
 
 from ..config import Config
 from ..utils.logger import get_logger
-from .zep_graph_memory_updater import ZepGraphMemoryManager
+from .memory_factory import get_memory_provider
 from .simulation_ipc import SimulationIPCClient, CommandType, IPCResponse
 
 logger = get_logger('mirofish.simulation_runner')
@@ -374,7 +374,7 @@ class SimulationRunner:
                 raise ValueError("启用图谱记忆更新时必须提供 graph_id")
             
             try:
-                ZepGraphMemoryManager.create_updater(simulation_id, graph_id)
+                get_memory_provider().create_memory_updater(simulation_id, graph_id)
                 cls._graph_memory_enabled[simulation_id] = True
                 logger.info(f"已启用图谱记忆更新: simulation_id={simulation_id}, graph_id={graph_id}")
             except Exception as e:
@@ -551,7 +551,7 @@ class SimulationRunner:
             # 停止图谱记忆更新器
             if cls._graph_memory_enabled.get(simulation_id, False):
                 try:
-                    ZepGraphMemoryManager.stop_updater(simulation_id)
+                    get_memory_provider().stop_memory_updater(simulation_id)
                     logger.info(f"已停止图谱记忆更新: simulation_id={simulation_id}")
                 except Exception as e:
                     logger.error(f"停止图谱记忆更新器失败: {e}")
@@ -599,7 +599,7 @@ class SimulationRunner:
         graph_memory_enabled = cls._graph_memory_enabled.get(state.simulation_id, False)
         graph_updater = None
         if graph_memory_enabled:
-            graph_updater = ZepGraphMemoryManager.get_updater(state.simulation_id)
+            graph_updater = get_memory_provider().get_memory_updater(state.simulation_id)
         
         try:
             with open(log_path, 'r', encoding='utf-8') as f:
@@ -807,7 +807,7 @@ class SimulationRunner:
         # 停止图谱记忆更新器
         if cls._graph_memory_enabled.get(simulation_id, False):
             try:
-                ZepGraphMemoryManager.stop_updater(simulation_id)
+                get_memory_provider().stop_memory_updater(simulation_id)
                 logger.info(f"已停止图谱记忆更新: simulation_id={simulation_id}")
             except Exception as e:
                 logger.error(f"停止图谱记忆更新器失败: {e}")
@@ -1201,7 +1201,7 @@ class SimulationRunner:
         
         # 首先停止所有图谱记忆更新器（stop_all 内部会打印日志）
         try:
-            ZepGraphMemoryManager.stop_all()
+            get_memory_provider().stop_all_memory_updaters()
         except Exception as e:
             logger.error(f"停止图谱记忆更新器失败: {e}")
         cls._graph_memory_enabled.clear()

--- a/backend/app/services/zep_provider.py
+++ b/backend/app/services/zep_provider.py
@@ -1,0 +1,372 @@
+"""
+ZepProvider - wraps existing Zep services into the MemoryProvider interface.
+Pure delegation: no behavior changes, just type conversion.
+"""
+
+from typing import Dict, Any, List, Optional
+
+from .memory_provider import (
+    MemoryProvider,
+    EntityNode as ProviderEntityNode,
+    FilteredEntities as ProviderFilteredEntities,
+    SearchResult as ProviderSearchResult,
+    NodeInfo as ProviderNodeInfo,
+    EdgeInfo as ProviderEdgeInfo,
+    InsightForgeResult as ProviderInsightForgeResult,
+    PanoramaResult as ProviderPanoramaResult,
+    AgentInterview as ProviderAgentInterview,
+    InterviewResult as ProviderInterviewResult,
+)
+from .graph_builder import GraphBuilderService
+from .zep_entity_reader import (
+    ZepEntityReader,
+    EntityNode as ZepEntityNode,
+    FilteredEntities as ZepFilteredEntities,
+)
+from .zep_tools import (
+    ZepToolsService,
+    SearchResult as ZepSearchResult,
+    NodeInfo as ZepNodeInfo,
+    EdgeInfo as ZepEdgeInfo,
+    InsightForgeResult as ZepInsightForgeResult,
+    PanoramaResult as ZepPanoramaResult,
+    InterviewResult as ZepInterviewResult,
+    AgentInterview as ZepAgentInterview,
+)
+from .zep_graph_memory_updater import ZepGraphMemoryManager
+
+
+# ============== Conversion helpers ==============
+
+def _convert_entity_node(node: ZepEntityNode) -> ProviderEntityNode:
+    """Convert a Zep-internal EntityNode to the provider-agnostic EntityNode."""
+    return ProviderEntityNode(
+        uuid=node.uuid,
+        name=node.name,
+        labels=node.labels,
+        summary=node.summary,
+        attributes=node.attributes,
+        related_edges=node.related_edges,
+        related_nodes=node.related_nodes,
+    )
+
+
+def _convert_filtered_entities(result: ZepFilteredEntities) -> ProviderFilteredEntities:
+    """Convert Zep FilteredEntities to the provider-agnostic FilteredEntities."""
+    return ProviderFilteredEntities(
+        entities=[_convert_entity_node(e) for e in result.entities],
+        entity_types=list(result.entity_types),
+        total_count=result.total_count,
+        filtered_count=result.filtered_count,
+    )
+
+
+def _convert_search_result(result: ZepSearchResult) -> ProviderSearchResult:
+    """Convert a Zep SearchResult to the provider-agnostic SearchResult."""
+    return ProviderSearchResult(
+        facts=result.facts,
+        edges=result.edges,
+        nodes=result.nodes,
+        query=result.query,
+        total_count=result.total_count,
+    )
+
+
+def _convert_node_info(node: ZepNodeInfo) -> ProviderNodeInfo:
+    """Convert a Zep NodeInfo to the provider-agnostic NodeInfo."""
+    return ProviderNodeInfo(
+        uuid=node.uuid,
+        name=node.name,
+        labels=node.labels,
+        summary=node.summary,
+        attributes=node.attributes,
+    )
+
+
+def _convert_edge_info(edge: ZepEdgeInfo) -> ProviderEdgeInfo:
+    """Convert a Zep EdgeInfo to the provider-agnostic EdgeInfo."""
+    return ProviderEdgeInfo(
+        uuid=edge.uuid,
+        name=edge.name,
+        fact=edge.fact,
+        source_node_uuid=edge.source_node_uuid,
+        target_node_uuid=edge.target_node_uuid,
+        source_node_name=edge.source_node_name,
+        target_node_name=edge.target_node_name,
+        created_at=edge.created_at,
+        valid_at=edge.valid_at,
+        invalid_at=edge.invalid_at,
+        expired_at=edge.expired_at,
+    )
+
+
+def _convert_insight_forge_result(result: ZepInsightForgeResult) -> ProviderInsightForgeResult:
+    """Convert a Zep InsightForgeResult to the provider-agnostic InsightForgeResult."""
+    return ProviderInsightForgeResult(
+        query=result.query,
+        simulation_requirement=result.simulation_requirement,
+        sub_queries=result.sub_queries,
+        semantic_facts=result.semantic_facts,
+        entity_insights=result.entity_insights,
+        relationship_chains=result.relationship_chains,
+        total_facts=result.total_facts,
+        total_entities=result.total_entities,
+        total_relationships=result.total_relationships,
+    )
+
+
+def _convert_panorama_result(result: ZepPanoramaResult) -> ProviderPanoramaResult:
+    """Convert a Zep PanoramaResult to the provider-agnostic PanoramaResult."""
+    return ProviderPanoramaResult(
+        query=result.query,
+        all_nodes=[_convert_node_info(n) for n in result.all_nodes],
+        all_edges=[_convert_edge_info(e) for e in result.all_edges],
+        active_facts=result.active_facts,
+        historical_facts=result.historical_facts,
+        total_nodes=result.total_nodes,
+        total_edges=result.total_edges,
+        active_count=result.active_count,
+        historical_count=result.historical_count,
+    )
+
+
+def _convert_agent_interview(interview: ZepAgentInterview) -> ProviderAgentInterview:
+    """Convert a Zep AgentInterview to the provider-agnostic AgentInterview.
+
+    ZepAgentInterview has: agent_name, agent_role, agent_bio, question, response, key_quotes
+    ProviderAgentInterview has: agent_name, agent_id, response, questions
+    """
+    return ProviderAgentInterview(
+        agent_name=interview.agent_name,
+        agent_id=getattr(interview, "agent_id", interview.agent_name),
+        response=interview.response,
+        questions=[interview.question] if hasattr(interview, "question") else [],
+    )
+
+
+def _convert_interview_result(result: ZepInterviewResult) -> ProviderInterviewResult:
+    """Convert a Zep InterviewResult to the provider-agnostic InterviewResult."""
+    return ProviderInterviewResult(
+        interview_topic=result.interview_topic,
+        interview_questions=result.interview_questions,
+        selected_agents=result.selected_agents,
+        interviews=[_convert_agent_interview(i) for i in result.interviews],
+        selection_reasoning=result.selection_reasoning,
+        summary=result.summary,
+        total_agents=result.total_agents,
+        interviewed_count=result.interviewed_count,
+    )
+
+
+# ============== ZepProvider ==============
+
+class ZepProvider(MemoryProvider):
+    """
+    MemoryProvider implementation that delegates to the existing Zep services.
+
+    All service instances are created lazily (on first use) and share the
+    same api_key so callers can pass a per-request key if needed.
+    """
+
+    def __init__(self, api_key: Optional[str] = None):
+        self._api_key = api_key
+        self._graph_builder: Optional[GraphBuilderService] = None
+        self._entity_reader: Optional[ZepEntityReader] = None
+        self._tools: Optional[ZepToolsService] = None
+
+    # --- lazy-init accessors ---
+
+    @property
+    def graph_builder(self) -> GraphBuilderService:
+        if self._graph_builder is None:
+            self._graph_builder = GraphBuilderService(api_key=self._api_key)
+        return self._graph_builder
+
+    @property
+    def entity_reader(self) -> ZepEntityReader:
+        if self._entity_reader is None:
+            self._entity_reader = ZepEntityReader(api_key=self._api_key)
+        return self._entity_reader
+
+    @property
+    def tools(self) -> ZepToolsService:
+        if self._tools is None:
+            self._tools = ZepToolsService(api_key=self._api_key)
+        return self._tools
+
+    # --- Graph Building ---
+
+    def create_graph(self, name: str) -> str:
+        return self.graph_builder.create_graph(name)
+
+    def set_ontology(self, graph_id: str, ontology: Dict[str, Any]) -> None:
+        self.graph_builder.set_ontology(graph_id, ontology)
+
+    def add_text_batches(
+        self,
+        graph_id: str,
+        chunks: List[str],
+        batch_size: int = 3,
+        progress_callback=None,
+    ) -> List[str]:
+        return self.graph_builder.add_text_batches(
+            graph_id, chunks, batch_size, progress_callback
+        )
+
+    def wait_for_processing(
+        self,
+        identifiers: List[str],
+        progress_callback=None,
+        timeout: int = 600,
+    ) -> None:
+        self.graph_builder._wait_for_episodes(
+            identifiers, progress_callback, timeout
+        )
+
+    def get_graph_data(self, graph_id: str) -> Dict[str, Any]:
+        return self.graph_builder.get_graph_data(graph_id)
+
+    def delete_graph(self, graph_id: str) -> None:
+        self.graph_builder.delete_graph(graph_id)
+
+    # --- Entity Reading ---
+
+    def filter_defined_entities(
+        self,
+        graph_id: str,
+        defined_entity_types: Optional[List[str]] = None,
+        enrich_with_edges: bool = True,
+    ) -> ProviderFilteredEntities:
+        result = self.entity_reader.filter_defined_entities(
+            graph_id, defined_entity_types, enrich_with_edges
+        )
+        return _convert_filtered_entities(result)
+
+    def get_entity_with_context(
+        self,
+        graph_id: str,
+        entity_uuid: str,
+    ) -> Optional[ProviderEntityNode]:
+        result = self.entity_reader.get_entity_with_context(graph_id, entity_uuid)
+        if result is None:
+            return None
+        return _convert_entity_node(result)
+
+    def get_entities_by_type(
+        self,
+        graph_id: str,
+        entity_type: str,
+    ) -> List[ProviderEntityNode]:
+        results = self.entity_reader.get_entities_by_type(graph_id, entity_type)
+        return [_convert_entity_node(e) for e in results]
+
+    # --- Memory Updater (Simulation) ---
+
+    def create_memory_updater(self, simulation_id: str, graph_id: str) -> None:
+        ZepGraphMemoryManager.create_updater(simulation_id, graph_id)
+
+    def stop_memory_updater(self, simulation_id: str) -> None:
+        ZepGraphMemoryManager.stop_updater(simulation_id)
+
+    def get_memory_updater(self, simulation_id: str):
+        return ZepGraphMemoryManager.get_updater(simulation_id)
+
+    def stop_all_memory_updaters(self) -> None:
+        ZepGraphMemoryManager.stop_all()
+
+    # --- Search & Analysis Tools ---
+
+    def search_graph(
+        self,
+        graph_id: str,
+        query: str,
+        limit: int = 10,
+    ) -> ProviderSearchResult:
+        result = self.tools.search_graph(graph_id, query, limit)
+        return _convert_search_result(result)
+
+    def insight_forge(
+        self,
+        graph_id: str,
+        query: str,
+        simulation_requirement: str,
+        report_context: str = "",
+        max_sub_queries: int = 5,
+    ) -> ProviderInsightForgeResult:
+        result = self.tools.insight_forge(
+            graph_id, query, simulation_requirement, report_context, max_sub_queries
+        )
+        return _convert_insight_forge_result(result)
+
+    def panorama_search(
+        self,
+        graph_id: str,
+        query: str,
+    ) -> ProviderPanoramaResult:
+        result = self.tools.panorama_search(graph_id, query)
+        return _convert_panorama_result(result)
+
+    def quick_search(
+        self,
+        graph_id: str,
+        query: str,
+        limit: int = 5,
+    ) -> ProviderSearchResult:
+        result = self.tools.quick_search(graph_id, query, limit)
+        return _convert_search_result(result)
+
+    def interview_agents(
+        self,
+        graph_id: str,
+        interview_topic: str,
+        interview_questions: List[str],
+        num_agents: int = 3,
+        agent_profiles: Optional[Dict] = None,
+        simulation_id: Optional[str] = None,
+    ) -> ProviderInterviewResult:
+        # ZepToolsService uses simulation_id to access the simulation runner IPC.
+        sid = simulation_id or graph_id
+        result = self.tools.interview_agents(
+            simulation_id=sid,
+            interview_requirement=interview_topic,
+            max_agents=num_agents,
+            custom_questions=interview_questions if interview_questions else None,
+        )
+        return _convert_interview_result(result)
+
+    def get_graph_statistics(self, graph_id: str) -> Dict[str, Any]:
+        return self.tools.get_graph_statistics(graph_id)
+
+    def get_entity_summary(self, graph_id: str, entity_uuid: str) -> str:
+        result = self.tools.get_entity_summary(graph_id, entity_uuid)
+        # ZepToolsService returns Dict; ABC contract is str
+        if isinstance(result, dict):
+            import json
+            return json.dumps(result, ensure_ascii=False, indent=2)
+        return str(result)
+
+    def get_all_nodes(self, graph_id: str) -> List[ProviderNodeInfo]:
+        results = self.tools.get_all_nodes(graph_id)
+        return [_convert_node_info(n) for n in results]
+
+    def get_all_edges(
+        self,
+        graph_id: str,
+        include_temporal: bool = True,
+    ) -> List[ProviderEdgeInfo]:
+        results = self.tools.get_all_edges(graph_id, include_temporal)
+        return [_convert_edge_info(e) for e in results]
+
+    def get_simulation_context(self, graph_id: str, simulation_id: str) -> str:
+        return self.tools.get_simulation_context(graph_id, simulation_id)
+
+    # --- Profile Generation ---
+
+    def search_for_entity_context(
+        self,
+        graph_id: str,
+        query: str,
+        limit: int = 30,
+    ) -> List[Dict[str, Any]]:
+        result = self.tools.search_graph(graph_id, query, limit)
+        return result.nodes

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+mem0 = [
+    "mem0ai>=1.0.5",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,8 +13,11 @@ flask-cors>=6.0.0
 # OpenAI SDK（统一使用 OpenAI 格式调用 LLM）
 openai>=1.0.0
 
-# ============= Zep Cloud =============
+# ============= 记忆提供者 =============
+# Zep Cloud (默认)
 zep-cloud==3.13.0
+# Mem0 (可选: 仅 MEMORY_PROVIDER=mem0 时需要安装)
+# pip install mem0ai>=1.0.5
 
 # ============= OASIS 社交媒体模拟 =============
 # OASIS 社交模拟框架


### PR DESCRIPTION
Adds Mem0 as an optional memory backend alongside the existing Zep Cloud integration. Users choose via MEMORY_PROVIDER env var (zep default, mem0 optional). Supports both Mem0 Platform (SaaS) and
   Mem0 OSS (self-hosted). Zero breaking changes — all existing Zep behavior is untouched.

  How it works

  MEMORY_PROVIDER=zep (default) → existing Zep services, no change
  MEMORY_PROVIDER=mem0 → Mem0 backend (Platform or OSS)

  A thin MemoryProvider interface sits between API routes and the backend. ZepProvider delegates to existing Zep services (pure delegation, no behavior change). Mem0Provider implements the same
  interface using mem0ai SDK.

  Existing Zep service files (graph_builder.py, zep_entity_reader.py, zep_tools.py, zep_graph_memory_updater.py) are completely untouched.

  Setup for Mem0

  pip install mem0ai  # only needed if using Mem0

  Platform (managed)
  MEMORY_PROVIDER=mem0
  MEM0_API_KEY=your_key

  OR OSS (self-hosted)
  MEMORY_PROVIDER=mem0
  OPENAI_API_KEY=your_key

  Test plan

  - MEMORY_PROVIDER=zep (default) — full pipeline works unchanged
  - MEMORY_PROVIDER=mem0 + MEM0_API_KEY — Platform mode works
  - MEMORY_PROVIDER=mem0 + OPENAI_API_KEY — OSS mode works
  - No mem0ai installed + MEMORY_PROVIDER=zep — works fine (mem0ai is optional)