### PR TITLE
fix: support LLMs without json_object (e.g. Doubao) and fix upload/er…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@
 LLM_API_KEY=your_api_key_here
 LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 LLM_MODEL_NAME=qwen-plus
+# 部分模型（如火山引擎豆包）不支持 response_format.json_object，设为 false 时仅靠提示词要求返回 JSON
+# LLM_JSON_MODE=false
 
 # ===== ZEP记忆图谱配置 =====
 # 每月免费额度即可支撑简单使用：https://app.getzep.com/

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -31,6 +31,8 @@ class Config:
     LLM_API_KEY = os.environ.get('LLM_API_KEY')
     LLM_BASE_URL = os.environ.get('LLM_BASE_URL', 'https://api.openai.com/v1')
     LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'gpt-4o-mini')
+    # 部分模型（如火山引擎豆包）不支持 response_format.json_object，设为 false 时仅靠提示词要求返回 JSON
+    LLM_SUPPORTS_JSON_MODE = os.environ.get('LLM_JSON_MODE', 'true').lower() == 'true'
     
     # Zep配置
     ZEP_API_KEY = os.environ.get('ZEP_API_KEY')

--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -524,20 +524,26 @@ class OasisProfileGenerator:
         max_attempts = 3
         last_error = None
         
+        use_json_mode = getattr(Config, 'LLM_SUPPORTS_JSON_MODE', True)
         for attempt in range(max_attempts):
             try:
-                response = self.client.chat.completions.create(
-                    model=self.model_name,
-                    messages=[
+                kwargs = {
+                    "model": self.model_name,
+                    "messages": [
                         {"role": "system", "content": self._get_system_prompt(is_individual)},
                         {"role": "user", "content": prompt}
                     ],
-                    response_format={"type": "json_object"},
-                    temperature=0.7 - (attempt * 0.1)  # 每次重试降低温度
-                    # 不设置max_tokens，让LLM自由发挥
-                )
+                    "temperature": 0.7 - (attempt * 0.1)
+                }
+                if use_json_mode:
+                    kwargs["response_format"] = {"type": "json_object"}
+                response = self.client.chat.completions.create(**kwargs)
                 
                 content = response.choices[0].message.content
+                if not use_json_mode:
+                    import re
+                    content = re.sub(r'^```(?:json)?\s*\n?', '', content.strip(), flags=re.IGNORECASE)
+                    content = re.sub(r'\n?```\s*$', '', content).strip()
                 
                 # 检查是否被截断（finish_reason不是'stop'）
                 finish_reason = response.choices[0].finish_reason

--- a/backend/app/services/simulation_config_generator.py
+++ b/backend/app/services/simulation_config_generator.py
@@ -437,20 +437,25 @@ class SimulationConfigGenerator:
         max_attempts = 3
         last_error = None
         
+        use_json_mode = getattr(Config, 'LLM_SUPPORTS_JSON_MODE', True)
         for attempt in range(max_attempts):
             try:
-                response = self.client.chat.completions.create(
-                    model=self.model_name,
-                    messages=[
+                kwargs = {
+                    "model": self.model_name,
+                    "messages": [
                         {"role": "system", "content": system_prompt},
                         {"role": "user", "content": prompt}
                     ],
-                    response_format={"type": "json_object"},
-                    temperature=0.7 - (attempt * 0.1)  # 每次重试降低温度
-                    # 不设置max_tokens，让LLM自由发挥
-                )
+                    "temperature": 0.7 - (attempt * 0.1)
+                }
+                if use_json_mode:
+                    kwargs["response_format"] = {"type": "json_object"}
+                response = self.client.chat.completions.create(**kwargs)
                 
                 content = response.choices[0].message.content
+                if not use_json_mode:
+                    content = re.sub(r'^```(?:json)?\s*\n?', '', content.strip(), flags=re.IGNORECASE)
+                    content = re.sub(r'\n?```\s*$', '', content).strip()
                 finish_reason = response.choices[0].finish_reason
                 
                 # 检查是否被截断

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -4,8 +4,9 @@ LLM客户端封装
 """
 
 import json
+import os
 import re
-from typing import Optional, Dict, Any, List
+from typing import Dict, Any, List, Optional
 from openai import OpenAI
 
 from ..config import Config
@@ -71,7 +72,8 @@ class LLMClient:
         self,
         messages: List[Dict[str, str]],
         temperature: float = 0.3,
-        max_tokens: int = 4096
+        max_tokens: int = 4096,
+        use_json_mode: Optional[bool] = None
     ) -> Dict[str, Any]:
         """
         发送聊天请求并返回JSON
@@ -80,15 +82,20 @@ class LLMClient:
             messages: 消息列表
             temperature: 温度参数
             max_tokens: 最大token数
+            use_json_mode: 是否使用 response_format.json_object；None 时从 Config.LLM_SUPPORTS_JSON_MODE 读取
             
         Returns:
             解析后的JSON对象
         """
+        if use_json_mode is None:
+            # 每次调用时读取，避免进程启动时 .env 未加载导致豆包等模型仍传 json_object
+            use_json_mode = os.environ.get('LLM_JSON_MODE', 'true').strip().lower() == 'true'
+        response_format = {"type": "json_object"} if use_json_mode else None
         response = self.chat(
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
-            response_format={"type": "json_object"}
+            response_format=response_format
         )
         # 清理markdown代码块标记
         cleaned_response = response.strip()

--- a/frontend/src/api/graph.js
+++ b/frontend/src/api/graph.js
@@ -6,14 +6,11 @@ import service, { requestWithRetry } from './index'
  * @returns {Promise}
  */
 export function generateOntology(formData) {
-  return requestWithRetry(() => 
+  return requestWithRetry(() =>
     service({
       url: '/api/graph/ontology/generate',
       method: 'post',
-      data: formData,
-      headers: {
-        'Content-Type': 'multipart/form-data'
-      }
+      data: formData
     })
   )
 }

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -12,6 +12,10 @@ const service = axios.create({
 // 请求拦截器
 service.interceptors.request.use(
   config => {
+    // 发送 FormData 时不带 Content-Type，让浏览器自动添加 multipart/form-data 和 boundary
+    if (config.data && typeof FormData !== 'undefined' && config.data instanceof FormData) {
+      delete config.headers['Content-Type']
+    }
     return config
   },
   error => {

--- a/frontend/src/views/MainView.vue
+++ b/frontend/src/views/MainView.vue
@@ -48,9 +48,29 @@
 
       <!-- Right Panel: Step Components -->
       <div class="panel-wrapper right" :style="rightPanelStyle">
+        <!-- 无待上传时：/process/new 直接显示本地上传表单 -->
+        <div v-if="showInlineUpload" class="inline-upload-card">
+          <h3 class="inline-upload-title">本地生成</h3>
+          <p class="inline-upload-desc">请上传种子文档并填写模拟需求，或 <a href="/">返回首页</a> 操作。</p>
+          <form @submit.prevent="submitInlineUpload" class="inline-upload-form">
+            <div class="form-group">
+              <label>种子文档（PDF / MD / TXT）</label>
+              <input type="file" ref="inlineFileInput" accept=".pdf,.md,.txt" multiple @change="onInlineFilesChange" class="file-input" />
+              <span v-if="inlineFiles.length" class="file-hint">{{ inlineFiles.length }} 个文件已选</span>
+            </div>
+            <div class="form-group">
+              <label>模拟需求描述</label>
+              <textarea v-model="inlineRequirement" placeholder="例：基于该事件模拟各方在社交媒体上的发声与互动，预测舆论走向。" rows="4" class="textarea-input"></textarea>
+            </div>
+            <p v-if="error" class="inline-error">{{ error }}</p>
+            <button type="submit" class="submit-btn" :disabled="!canSubmitInline || loading">
+              {{ loading ? '生成中...' : '开始生成' }}
+            </button>
+          </form>
+        </div>
         <!-- Step 1: 图谱构建 -->
         <Step1GraphBuild 
-          v-if="currentStep === 1"
+          v-else-if="currentStep === 1"
           :currentPhase="currentPhase"
           :projectData="projectData"
           :ontologyProgress="ontologyProgress"
@@ -81,7 +101,7 @@ import GraphPanel from '../components/GraphPanel.vue'
 import Step1GraphBuild from '../components/Step1GraphBuild.vue'
 import Step2EnvSetup from '../components/Step2EnvSetup.vue'
 import { generateOntology, getProject, buildGraph, getTaskStatus, getGraphData } from '../api/graph'
-import { getPendingUpload, clearPendingUpload } from '../store/pendingUpload'
+import { getPendingUpload, setPendingUpload, clearPendingUpload } from '../store/pendingUpload'
 
 const route = useRoute()
 const router = useRouter()
@@ -104,6 +124,13 @@ const currentPhase = ref(-1) // -1: Upload, 0: Ontology, 1: Build, 2: Complete
 const ontologyProgress = ref(null)
 const buildProgress = ref(null)
 const systemLogs = ref([])
+
+// 直接访问 /process/new 时的本地上传表单
+const showInlineUpload = ref(false)
+const inlineFiles = ref([])
+const inlineRequirement = ref('')
+const inlineFileInput = ref(null)
+const canSubmitInline = computed(() => inlineFiles.value.length > 0 && (inlineRequirement.value || '').trim().length > 0)
 
 // Polling timers
 let pollTimer = null
@@ -180,17 +207,36 @@ const handleGoBack = () => {
 const initProject = async () => {
   addLog('Project view initialized.')
   if (currentProjectId.value === 'new') {
-    await handleNewProject()
+    const pending = getPendingUpload()
+    if (pending.isPending && pending.files.length > 0) {
+      await handleNewProject()
+    } else {
+      showInlineUpload.value = true
+      addLog('No pending upload. Show inline upload form.')
+    }
   } else {
     await loadProject()
   }
 }
 
+const onInlineFilesChange = (e) => {
+  const list = e.target.files ? Array.from(e.target.files) : []
+  inlineFiles.value = list.filter(f => /\.(pdf|md|txt)$/i.test(f.name))
+}
+
+const submitInlineUpload = async () => {
+  if (!canSubmitInline.value || loading.value) return
+  setPendingUpload(inlineFiles.value, inlineRequirement.value.trim())
+  showInlineUpload.value = false
+  await handleNewProject()
+}
+
 const handleNewProject = async () => {
   const pending = getPendingUpload()
   if (!pending.isPending || pending.files.length === 0) {
-    error.value = 'No pending files found.'
-    addLog('Error: No pending files found for new project.')
+    showInlineUpload.value = true
+    error.value = ''
+    addLog('No pending files. Show inline upload form.')
     return
   }
   
@@ -209,18 +255,23 @@ const handleNewProject = async () => {
       clearPendingUpload()
       currentProjectId.value = res.data.project_id
       projectData.value = res.data
-      
+
       router.replace({ name: 'Process', params: { projectId: res.data.project_id } })
       ontologyProgress.value = null
       addLog(`Ontology generated successfully for project ${res.data.project_id}`)
       await startBuildGraph()
     } else {
-      error.value = res.error || 'Ontology generation failed'
+      error.value = res.error || '本体生成失败，请检查后端与 LLM 配置'
       addLog(`Error generating ontology: ${error.value}`)
+      showInlineUpload.value = true
     }
   } catch (err) {
-    error.value = err.message
-    addLog(`Exception in handleNewProject: ${err.message}`)
+    const backendError = err.response?.data?.error
+    const msg = backendError || err.message || '请求失败，请确认后端已启动（端口 5001）'
+    error.value = msg
+    addLog(`Exception in handleNewProject: ${msg}`)
+    if (err.response?.data?.traceback) addLog(err.response.data.traceback)
+    showInlineUpload.value = true
   } finally {
     loading.value = false
   }
@@ -536,5 +587,85 @@ onUnmounted(() => {
 
 .panel-wrapper.left {
   border-right: 1px solid #EAEAEA;
+}
+
+/* 本地上传表单（/process/new 无待上传时） */
+.inline-upload-card {
+  padding: 24px;
+  max-width: 520px;
+  margin: 0 auto;
+}
+.inline-upload-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0 0 8px 0;
+  color: #000;
+}
+.inline-upload-desc {
+  font-size: 13px;
+  color: #666;
+  margin: 0 0 20px 0;
+}
+.inline-upload-desc a {
+  color: #FF5722;
+  text-decoration: none;
+}
+.inline-upload-desc a:hover {
+  text-decoration: underline;
+}
+.inline-upload-form .form-group {
+  margin-bottom: 16px;
+}
+.inline-upload-form label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 6px;
+}
+.inline-upload-form .file-input {
+  display: block;
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 13px;
+}
+.inline-upload-form .file-hint {
+  font-size: 12px;
+  color: #666;
+  margin-top: 4px;
+  display: block;
+}
+.inline-upload-form .textarea-input {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 13px;
+  resize: vertical;
+  font-family: inherit;
+}
+.inline-upload-form .inline-error {
+  color: #c62828;
+  font-size: 13px;
+  margin: 0 0 12px 0;
+}
+.inline-upload-form .submit-btn {
+  padding: 10px 24px;
+  background: #000;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.inline-upload-form .submit-btn:hover:not(:disabled) {
+  background: #333;
+}
+.inline-upload-form .submit-btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
 }
 </style>


### PR DESCRIPTION
…ror UX

- Add LLM_JSON_MODE env (default true): when false, do not send response_format.json_object
- LLMClient.chat_json, SimulationConfigGenerator, OasisProfileGenerator respect LLM_JSON_MODE
- Strip markdown code fences from LLM response when parsing JSON without json_object
- Fix FormData upload: do not set Content-Type so browser sets multipart boundary (fixes 500)
- On 500, show backend error and traceback in frontend instead of generic message
- /process/new: when no pending upload, show inline upload form for local use

Made-with: Cursor