### PR TITLE
feat(pipeline): add provision-and-start endpoint

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -4,6 +4,9 @@
 """
 
 import os
+import json
+import time
+import uuid
 import traceback
 import threading
 from flask import request, jsonify
@@ -12,6 +15,8 @@ from . import graph_bp
 from ..config import Config
 from ..services.ontology_generator import OntologyGenerator
 from ..services.graph_builder import GraphBuilderService
+from ..services.simulation_manager import SimulationManager, SimulationStatus
+from ..services.simulation_runner import SimulationRunner
 from ..services.text_processor import TextProcessor
 from ..utils.file_parser import FileParser
 from ..utils.logger import get_logger
@@ -28,6 +33,145 @@ def allowed_file(filename: str) -> bool:
         return False
     ext = os.path.splitext(filename)[1].lower().lstrip('.')
     return ext in Config.ALLOWED_EXTENSIONS
+
+
+def _build_pipeline_project_name(seed_data: dict, config: dict) -> str:
+    """构建管道项目名称"""
+    raw_name = (
+        ((seed_data or {}).get('marketContext') or {}).get('query')
+        or config.get('scenario_description')
+        or config.get('time_horizon')
+        or 'Oracle scenario'
+    )
+    normalized = str(raw_name).replace('\n', ' ').strip()
+    suffix = normalized[:64] or 'Oracle scenario'
+    return f"DreamWard Oracle - {suffix}"
+
+
+def _build_pipeline_simulation_requirement(seed_data: dict, config: dict) -> str:
+    """构建模拟需求描述"""
+    scenario_query = (
+        config.get('scenario_description')
+        or ((seed_data or {}).get('marketContext') or {}).get('query')
+        or 'Oraklet-simulering'
+    )
+    horizon = config.get('time_horizon') or 'ukjent horisont'
+    rounds = config.get('rounds') or '未知'
+    return (
+        f"{scenario_query}. "
+        f"Kjør simuleringen over {horizon} med {rounds} runder "
+        f"basert på den opplastede DreamWard-porteføljedokumentasjonen."
+    )
+
+
+def _build_pipeline_document(seed_data: dict, config: dict) -> str:
+    """将 DreamWard seed_data 转换为 MiroFish 可处理的 Markdown 文档"""
+    properties = seed_data.get('properties') or []
+    market_context = seed_data.get('marketContext') or {}
+    regulatory_context = seed_data.get('regulatoryContext') or {}
+    demographic_data = seed_data.get('demographicData') or {}
+    agent_profiles = seed_data.get('agentProfiles') or []
+
+    payload = {
+        "scenario": {
+            "query": market_context.get('query') or config.get('scenario_description'),
+            "time_horizon": config.get('time_horizon'),
+            "rounds": config.get('rounds'),
+            "entity_types": config.get('entity_types') or [],
+            "agents": config.get('agents'),
+        },
+        "properties": properties,
+        "market_context": market_context,
+        "regulatory_context": regulatory_context,
+        "demographic_data": demographic_data,
+        "agent_profiles": agent_profiles,
+        "metadata": seed_data.get('metadata') or {},
+    }
+
+    property_lines = []
+    for index, prop in enumerate(properties, start=1):
+        parts = [
+            prop.get('address'),
+            prop.get('city'),
+            prop.get('propertyType'),
+            f"leie {prop.get('monthlyRentNok')} NOK/mnd" if prop.get('monthlyRentNok') else None,
+            f"verdi {prop.get('currentValueNok')} NOK" if prop.get('currentValueNok') else None,
+            f"{prop.get('sizeSqm')} kvm" if prop.get('sizeSqm') else None,
+        ]
+        property_lines.append(f"{index}. {' • '.join([str(p) for p in parts if p])}")
+
+    return "\n".join([
+        '# DreamWard Oracle provisioning dossier',
+        '',
+        'Denne filen er generert av DreamWard for å opprette et MiroFish-prosjekt, generere ontologi og bygge en graph-backed simulering.',
+        '',
+        '## Scenario',
+        f"- Query: {market_context.get('query') or config.get('scenario_description') or 'Ukjent'}",
+        f"- Tidshorisont: {config.get('time_horizon') or 'Ukjent'}",
+        f"- Runder: {config.get('rounds') or 'Ukjent'}",
+        f"- Ønskede entitetstyper: {', '.join(config.get('entity_types') or []) or 'Ikke spesifisert'}",
+        '',
+        '## Eiendommer',
+        *(property_lines if property_lines else ['- Ingen eiendommer i seed_data.']),
+        '',
+        '## Full strukturert kontekst (JSON)',
+        '```json',
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        '```',
+        '',
+    ])
+
+
+def _resolve_parallel_profile_count(agents_config) -> int:
+    """根据配置推导 prepare 阶段的并行 profile 生成数"""
+    if isinstance(agents_config, int):
+        raw_count = agents_config
+    elif isinstance(agents_config, list):
+        raw_count = len(agents_config)
+    else:
+        raw_count = 1
+    return max(1, min(5, raw_count or 1))
+
+
+def _update_pipeline_task(
+    task_manager: TaskManager,
+    task_id: str,
+    phase: str,
+    status: TaskStatus = None,
+    progress: int = None,
+    message: str = None,
+    result: dict = None,
+    error: str = None,
+    project_id: str = None,
+    graph_task_id: str = None,
+    job_id: str = None,
+):
+    """更新 pipeline 任务状态并附带阶段详情"""
+    progress_detail = {
+        "phase": phase,
+        "project_id": project_id,
+        "graph_task_id": graph_task_id,
+        "job_id": job_id,
+    }
+    task_manager.update_task(
+        task_id,
+        status=status,
+        progress=progress,
+        message=message,
+        result=result,
+        error=error,
+        progress_detail=progress_detail,
+    )
+
+
+def _find_pipeline_task_by_pipeline_id(pipeline_id: str):
+    """根据 pipeline_id 查找任务"""
+    task_manager = TaskManager()
+    for task in task_manager.list_tasks(task_type="graph_pipeline"):
+        metadata = (task or {}).get('metadata') or {}
+        if metadata.get('pipeline_id') == pipeline_id:
+            return task
+    return None
 
 
 # ============== 项目管理接口 ==============
@@ -522,6 +666,369 @@ def build_graph():
             "error": str(e),
             "traceback": traceback.format_exc()
         }), 500
+
+
+@graph_bp.route('/pipeline/provision-and-start', methods=['POST'])
+def provision_and_start():
+    """
+    Full pipeline: ontology → graph build → simulation create → prepare → start.
+    Runs in background thread, returns immediately with task tracking.
+    """
+    try:
+        logger.info("=== 开始启动全流程 pipeline ===")
+
+        if not Config.ZEP_API_KEY:
+            return jsonify({
+                "success": False,
+                "error": "配置错误: ZEP_API_KEY未配置"
+            }), 500
+
+        data = request.get_json() or {}
+        seed_data = data.get('seed_data')
+        config = data.get('config') or {}
+
+        if not isinstance(seed_data, dict):
+            return jsonify({
+                "success": False,
+                "error": "请提供 seed_data 对象"
+            }), 400
+
+        if not isinstance(config, dict):
+            return jsonify({
+                "success": False,
+                "error": "请提供 config 对象"
+            }), 400
+
+        rounds = config.get('rounds')
+        if rounds is not None:
+            try:
+                rounds = int(rounds)
+                if rounds <= 0:
+                    raise ValueError()
+            except (TypeError, ValueError):
+                return jsonify({
+                    "success": False,
+                    "error": "config.rounds 必须是正整数"
+                }), 400
+            config['rounds'] = rounds
+
+        agents_config = config.get('agents')
+        if isinstance(agents_config, int) and agents_config <= 0:
+            return jsonify({
+                "success": False,
+                "error": "config.agents 必须是正整数"
+            }), 400
+
+        entity_types = config.get('entity_types')
+        if entity_types is not None:
+            if not isinstance(entity_types, list):
+                return jsonify({
+                    "success": False,
+                    "error": "config.entity_types 必须是字符串数组"
+                }), 400
+            config['entity_types'] = [str(entity_type).strip() for entity_type in entity_types if str(entity_type).strip()]
+
+        pipeline_id = str(uuid.uuid4())
+        project_name = _build_pipeline_project_name(seed_data, config)
+        task_manager = TaskManager()
+        task_id = task_manager.create_task(
+            task_type="graph_pipeline",
+            metadata={
+                "pipeline_id": pipeline_id,
+                "project_name": project_name,
+            }
+        )
+
+        def pipeline_task():
+            pipeline_logger = get_logger('mirofish.pipeline')
+            project = None
+            project_id = None
+            graph_task_id = None
+            graph_id = None
+            simulation_id = None
+            simulation_manager = SimulationManager()
+
+            try:
+                pipeline_logger.info(f"[{pipeline_id}] Pipeline started")
+                _update_pipeline_task(
+                    task_manager,
+                    task_id,
+                    phase="ontology_generation",
+                    status=TaskStatus.PROCESSING,
+                    progress=10,
+                    message="Generating ontology..."
+                )
+
+                project = ProjectManager.create_project(name=project_name)
+                project_id = project.project_id
+                project.simulation_requirement = _build_pipeline_simulation_requirement(seed_data, config)
+
+                provisioning_document = _build_pipeline_document(seed_data, config)
+                processed_text = TextProcessor.preprocess_text(provisioning_document)
+
+                project.total_text_length = len(processed_text)
+                project.files = [{
+                    "filename": "dreamward-oracle-brief.md",
+                    "size": len(provisioning_document.encode('utf-8'))
+                }]
+                ProjectManager.save_extracted_text(project_id, processed_text)
+
+                files_dir = ProjectManager._get_project_files_dir(project_id)
+                os.makedirs(files_dir, exist_ok=True)
+                brief_path = os.path.join(files_dir, 'dreamward-oracle-brief.md')
+                with open(brief_path, 'w', encoding='utf-8') as f:
+                    f.write(provisioning_document)
+
+                ProjectManager.save_project(project)
+                pipeline_logger.info(f"[{pipeline_id}] Phase 1/4 ontology generation: project_id={project_id}")
+
+                ontology = OntologyGenerator().generate(
+                    document_texts=[processed_text],
+                    simulation_requirement=project.simulation_requirement,
+                    additional_context=(
+                        "DreamWard Oracle generated this dossier from structured property, tenant, market, "
+                        "and scenario data. Use it as the authoritative source when deriving the ontology "
+                        "and building the graph."
+                    )
+                )
+
+                project.ontology = {
+                    "entity_types": ontology.get("entity_types", []),
+                    "edge_types": ontology.get("edge_types", [])
+                }
+                project.analysis_summary = ontology.get("analysis_summary", "")
+                project.status = ProjectStatus.ONTOLOGY_GENERATED
+                ProjectManager.save_project(project)
+
+                pipeline_logger.info(f"[{pipeline_id}] Phase 2/4 graph building")
+                _update_pipeline_task(
+                    task_manager,
+                    task_id,
+                    phase="graph_building",
+                    progress=30,
+                    message="Building knowledge graph...",
+                    project_id=project_id
+                )
+
+                builder = GraphBuilderService(api_key=Config.ZEP_API_KEY)
+                graph_task_id = builder.build_graph_async(
+                    text=processed_text,
+                    ontology=project.ontology,
+                    graph_name=project.name or 'MiroFish Graph',
+                    chunk_size=project.chunk_size or Config.DEFAULT_CHUNK_SIZE,
+                    chunk_overlap=project.chunk_overlap or Config.DEFAULT_CHUNK_OVERLAP,
+                    batch_size=3
+                )
+
+                project.status = ProjectStatus.GRAPH_BUILDING
+                project.graph_build_task_id = graph_task_id
+                ProjectManager.save_project(project)
+
+                while True:
+                    graph_task = task_manager.get_task(graph_task_id)
+                    if not graph_task:
+                        raise RuntimeError(f"图谱构建任务不存在: {graph_task_id}")
+
+                    graph_progress = max(0, min(graph_task.progress or 0, 100))
+                    pipeline_progress = 30 + int(graph_progress * 0.4)
+                    _update_pipeline_task(
+                        task_manager,
+                        task_id,
+                        phase="graph_building",
+                        progress=pipeline_progress,
+                        message=graph_task.message or "Building knowledge graph...",
+                        project_id=project_id,
+                        graph_task_id=graph_task_id
+                    )
+
+                    if graph_task.status == TaskStatus.COMPLETED:
+                        graph_result = graph_task.result or {}
+                        graph_id = graph_result.get('graph_id')
+                        if not graph_id:
+                            raise RuntimeError("图谱构建完成但未返回 graph_id")
+                        project.graph_id = graph_id
+                        project.status = ProjectStatus.GRAPH_COMPLETED
+                        ProjectManager.save_project(project)
+                        break
+
+                    if graph_task.status == TaskStatus.FAILED:
+                        raise RuntimeError(graph_task.message or graph_task.error or "图谱构建失败")
+
+                    time.sleep(2)
+
+                pipeline_logger.info(f"[{pipeline_id}] Phase 3/4 simulation setup: graph_id={graph_id}")
+                _update_pipeline_task(
+                    task_manager,
+                    task_id,
+                    phase="simulation_setup",
+                    progress=70,
+                    message="Preparing simulation agents...",
+                    project_id=project_id,
+                    graph_task_id=graph_task_id
+                )
+
+                simulation_state = simulation_manager.create_simulation(
+                    project_id=project_id,
+                    graph_id=graph_id,
+                    enable_twitter=True,
+                    enable_reddit=True,
+                )
+                simulation_id = simulation_state.simulation_id
+
+                def prepare_progress_callback(stage, progress, message, **kwargs):
+                    pipeline_progress = 70 + min(9, int(max(0, min(progress, 100)) / 10))
+                    _update_pipeline_task(
+                        task_manager,
+                        task_id,
+                        phase="simulation_setup",
+                        progress=pipeline_progress,
+                        message=message or "Preparing simulation agents...",
+                        project_id=project_id,
+                        graph_task_id=graph_task_id,
+                        job_id=simulation_id
+                    )
+
+                prepared_state = simulation_manager.prepare_simulation(
+                    simulation_id=simulation_id,
+                    simulation_requirement=project.simulation_requirement or "",
+                    document_text=processed_text,
+                    defined_entity_types=config.get('entity_types'),
+                    use_llm_for_profiles=True,
+                    progress_callback=prepare_progress_callback,
+                    parallel_profile_count=_resolve_parallel_profile_count(agents_config)
+                )
+
+                if prepared_state.status != SimulationStatus.READY:
+                    raise RuntimeError(prepared_state.error or f"模拟准备未完成: {prepared_state.status.value}")
+
+                pipeline_logger.info(f"[{pipeline_id}] Phase 4/4 simulation start: simulation_id={simulation_id}")
+                _update_pipeline_task(
+                    task_manager,
+                    task_id,
+                    phase="simulation_running",
+                    progress=80,
+                    message="Simulation running...",
+                    project_id=project_id,
+                    graph_task_id=graph_task_id,
+                    job_id=simulation_id
+                )
+
+                SimulationRunner.start_simulation(
+                    simulation_id=simulation_id,
+                    platform='parallel',
+                    max_rounds=config.get('rounds'),
+                    enable_graph_memory_update=False,
+                    graph_id=None
+                )
+
+                latest_state = simulation_manager.get_simulation(simulation_id)
+                if latest_state:
+                    latest_state.status = SimulationStatus.RUNNING
+                    simulation_manager._save_simulation_state(latest_state)
+
+                _update_pipeline_task(
+                    task_manager,
+                    task_id,
+                    phase="completed",
+                    status=TaskStatus.COMPLETED,
+                    progress=100,
+                    message="Pipeline completed",
+                    result={
+                        "job_id": simulation_id,
+                        "project_id": project_id,
+                        "graph_id": graph_id,
+                    },
+                    project_id=project_id,
+                    graph_task_id=graph_task_id,
+                    job_id=simulation_id
+                )
+                pipeline_logger.info(f"[{pipeline_id}] Pipeline completed: job_id={simulation_id}")
+
+            except Exception as e:
+                pipeline_logger.error(f"[{pipeline_id}] Pipeline failed: {str(e)}")
+                pipeline_logger.debug(traceback.format_exc())
+
+                if project:
+                    project.status = ProjectStatus.FAILED
+                    project.error = str(e)
+                    ProjectManager.save_project(project)
+
+                if simulation_id:
+                    latest_state = simulation_manager.get_simulation(simulation_id)
+                    if latest_state:
+                        latest_state.status = SimulationStatus.FAILED
+                        latest_state.error = str(e)
+                        simulation_manager._save_simulation_state(latest_state)
+
+                _update_pipeline_task(
+                    task_manager,
+                    task_id,
+                    phase="failed",
+                    status=TaskStatus.FAILED,
+                    message=f"Pipeline failed: {str(e)}",
+                    error=traceback.format_exc(),
+                    project_id=project_id,
+                    graph_task_id=graph_task_id,
+                    job_id=simulation_id
+                )
+
+        thread = threading.Thread(target=pipeline_task, daemon=True)
+        thread.start()
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "pipeline_id": pipeline_id,
+                "task_id": task_id,
+                "message": "Pipeline started"
+            }
+        })
+
+    except Exception as e:
+        logger.error(f"启动 pipeline 失败: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
+
+
+@graph_bp.route('/pipeline/status/<pipeline_id>', methods=['GET'])
+def get_pipeline_status(pipeline_id: str):
+    """查询 pipeline 状态"""
+    task = _find_pipeline_task_by_pipeline_id(pipeline_id)
+
+    if not task:
+        return jsonify({
+            "success": False,
+            "error": f"Pipeline 不存在: {pipeline_id}"
+        }), 404
+
+    progress_detail = task.get('progress_detail') or {}
+    result = task.get('result')
+    job_id = None
+    if isinstance(result, dict):
+        job_id = result.get('job_id')
+    if not job_id:
+        job_id = progress_detail.get('job_id')
+
+    status = task.get('status')
+    if status == TaskStatus.PROCESSING.value:
+        status = 'running'
+
+    return jsonify({
+        "success": True,
+        "data": {
+            "pipeline_id": pipeline_id,
+            "task_id": task.get('task_id'),
+            "status": status,
+            "phase": progress_detail.get('phase', 'pending'),
+            "progress": task.get('progress', 0),
+            "message": task.get('message', ''),
+            "job_id": job_id,
+            "result": result,
+        }
+    })
 
 
 # ============== 任务查询接口 ==============

--- a/backend/tests/test_graph_pipeline.py
+++ b/backend/tests/test_graph_pipeline.py
@@ -1,0 +1,260 @@
+import tempfile
+import threading
+import time as pytime
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from flask import Flask
+
+from app.api import graph as graph_api
+from app.models.project import ProjectManager
+from app.models.task import TaskManager, TaskStatus
+
+
+class DummyOntologyGenerator:
+    def generate(self, document_texts, simulation_requirement, additional_context=None):
+        pytime.sleep(0.03)
+        return {
+            "entity_types": [{"name": "Investor", "attributes": []}],
+            "edge_types": [{"name": "OWNS", "attributes": []}],
+            "analysis_summary": "ok",
+        }
+
+
+class DummyGraphBuilderService:
+    def __init__(self, api_key=None):
+        self.api_key = api_key
+
+    def build_graph_async(
+        self,
+        text,
+        ontology,
+        graph_name="MiroFish Graph",
+        chunk_size=500,
+        chunk_overlap=50,
+        batch_size=3,
+    ):
+        task_manager = TaskManager()
+        task_id = task_manager.create_task("graph_build")
+        task_manager.update_task(
+            task_id,
+            status=TaskStatus.PROCESSING,
+            progress=5,
+            message="starting graph build",
+        )
+
+        def worker():
+            pytime.sleep(0.04)
+            task_manager.update_task(
+                task_id,
+                status=TaskStatus.PROCESSING,
+                progress=50,
+                message="halfway through graph build",
+            )
+            pytime.sleep(0.04)
+            task_manager.update_task(
+                task_id,
+                status=TaskStatus.COMPLETED,
+                progress=100,
+                message="graph complete",
+                result={"graph_id": "graph_test_123"},
+            )
+
+        threading.Thread(target=worker, daemon=True).start()
+        return task_id
+
+
+class DummySimulationManager:
+    _states = {}
+
+    def create_simulation(
+        self,
+        project_id,
+        graph_id,
+        enable_twitter=True,
+        enable_reddit=True,
+    ):
+        state = SimpleNamespace(
+            simulation_id="sim_test_123",
+            project_id=project_id,
+            graph_id=graph_id,
+            status=graph_api.SimulationStatus.CREATED,
+            error=None,
+        )
+        self._states[state.simulation_id] = state
+        return state
+
+    def prepare_simulation(
+        self,
+        simulation_id,
+        simulation_requirement,
+        document_text,
+        defined_entity_types=None,
+        use_llm_for_profiles=True,
+        progress_callback=None,
+        parallel_profile_count=3,
+    ):
+        if progress_callback:
+            progress_callback("reading", 20, "Reading entities...")
+        pytime.sleep(0.03)
+        if progress_callback:
+            progress_callback("generating_profiles", 60, "Generating profiles...")
+        pytime.sleep(0.03)
+        if progress_callback:
+            progress_callback("generating_config", 100, "Preparation done")
+
+        state = self._states[simulation_id]
+        state.status = graph_api.SimulationStatus.READY
+        return state
+
+    def get_simulation(self, simulation_id):
+        return self._states.get(simulation_id)
+
+    def _save_simulation_state(self, state):
+        self._states[state.simulation_id] = state
+
+
+class DummySimulationRunner:
+    @classmethod
+    def start_simulation(
+        cls,
+        simulation_id,
+        platform="parallel",
+        max_rounds=None,
+        enable_graph_memory_update=False,
+        graph_id=None,
+    ):
+        return SimpleNamespace(simulation_id=simulation_id, runner_status="running")
+
+
+class GraphPipelineEndpointTest(unittest.TestCase):
+    def setUp(self):
+        TaskManager()._tasks.clear()
+        DummySimulationManager._states = {}
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+        self.patches = [
+            patch.object(ProjectManager, "PROJECTS_DIR", str(Path(self.temp_dir.name) / "projects")),
+            patch.object(graph_api.Config, "ZEP_API_KEY", "test-key"),
+            patch.object(graph_api, "OntologyGenerator", DummyOntologyGenerator),
+            patch.object(graph_api, "GraphBuilderService", DummyGraphBuilderService),
+            patch.object(graph_api, "SimulationManager", DummySimulationManager),
+            patch.object(graph_api, "SimulationRunner", DummySimulationRunner),
+            patch.object(graph_api.time, "sleep", lambda seconds: pytime.sleep(0.01)),
+        ]
+
+        for active_patch in self.patches:
+            active_patch.start()
+            self.addCleanup(active_patch.stop)
+
+        app = Flask(__name__)
+        app.testing = True
+        app.register_blueprint(graph_api.graph_bp, url_prefix="/api/graph")
+        self.client = app.test_client()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def payload(self):
+        return {
+            "seed_data": {
+                "properties": [
+                    {
+                        "address": "Karl Johans gate 1",
+                        "city": "Oslo",
+                        "propertyType": "Apartment",
+                        "monthlyRentNok": 18000,
+                        "currentValueNok": 5200000,
+                        "sizeSqm": 68,
+                    }
+                ],
+                "marketContext": {
+                    "query": "Hva skjer med boligmarkedet i Oslo?",
+                    "generatedAt": "2026-03-20T15:00:00Z",
+                    "currency": "NOK",
+                },
+                "regulatoryContext": {"relevantSignals": []},
+                "demographicData": {},
+                "agentProfiles": [{"type": "Investor", "name": "Owner"}],
+                "metadata": {"locale": "nb-NO"},
+            },
+            "config": {
+                "agents": 4,
+                "rounds": 6,
+                "time_horizon": "10y",
+                "scenario_description": "Test pipeline scenario",
+                "entity_types": ["Investor", "Banker"],
+            },
+        }
+
+    def test_provision_and_start_returns_immediately_and_completes(self):
+        started_at = pytime.perf_counter()
+        response = self.client.post("/api/graph/pipeline/provision-and-start", json=self.payload())
+        elapsed = pytime.perf_counter() - started_at
+
+        self.assertEqual(response.status_code, 200)
+        self.assertLess(elapsed, 1.0)
+
+        body = response.get_json()
+        data = body["data"]
+        self.assertEqual(data["message"], "Pipeline started")
+        self.assertTrue(data["pipeline_id"])
+        self.assertTrue(data["task_id"])
+
+        pytime.sleep(0.05)
+        in_flight = self.client.get(f"/api/graph/pipeline/status/{data['pipeline_id']}")
+        self.assertEqual(in_flight.status_code, 200)
+        in_flight_data = in_flight.get_json()["data"]
+        self.assertIn(in_flight_data["status"], {"running", "completed"})
+        self.assertGreaterEqual(in_flight_data["progress"], 10)
+
+        deadline = pytime.time() + 2
+        final_data = None
+        while pytime.time() < deadline:
+            status_response = self.client.get(f"/api/graph/pipeline/status/{data['pipeline_id']}")
+            self.assertEqual(status_response.status_code, 200)
+            final_data = status_response.get_json()["data"]
+            if final_data["status"] == "completed":
+                break
+            pytime.sleep(0.02)
+
+        self.assertIsNotNone(final_data)
+        self.assertEqual(final_data["status"], "completed")
+        self.assertEqual(final_data["phase"], "completed")
+        self.assertEqual(final_data["progress"], 100)
+        self.assertEqual(final_data["job_id"], "sim_test_123")
+        self.assertEqual(final_data["result"]["job_id"], "sim_test_123")
+        self.assertEqual(final_data["result"]["graph_id"], "graph_test_123")
+        self.assertTrue(final_data["result"]["project_id"].startswith("proj_"))
+
+    def test_pipeline_status_returns_404_for_unknown_pipeline(self):
+        response = self.client.get("/api/graph/pipeline/status/does-not-exist")
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(response.get_json()["success"])
+
+    def test_provision_and_start_requires_seed_data(self):
+        response = self.client.post("/api/graph/pipeline/provision-and-start", json={"config": {}})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "请提供 seed_data 对象")
+
+    def test_provision_and_start_validates_rounds(self):
+        response = self.client.post(
+            "/api/graph/pipeline/provision-and-start",
+            json={"seed_data": {}, "config": {"rounds": 0}},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "config.rounds 必须是正整数")
+
+    def test_provision_and_start_validates_entity_types(self):
+        response = self.client.post(
+            "/api/graph/pipeline/provision-and-start",
+            json={"seed_data": {}, "config": {"entity_types": "Investor"}},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "config.entity_types 必须是字符串数组")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add POST /api/graph/pipeline/provision-and-start to run ontology -> graph build -> simulation prepare -> simulation start in a background daemon thread
- add GET /api/graph/pipeline/status/<pipeline_id> to expose pipeline phase/progress/job_id via TaskManager metadata
- add a focused backend test file covering immediate response, status tracking, and request validation with stubbed services

## Validation
- python -m py_compile backend/app/api/graph.py backend/tests/test_graph_pipeline.py
- python -m unittest tests.test_graph_pipeline -q *(blocked in this environment: backend Python dependencies like lask are not installed)*
