### PR TITLE
feat: add SQLite database layer for state persistence

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -39,6 +39,11 @@ def create_app(config_class=Config):
         logger.info("MiroFish Backend 启动中...")
         logger.info("=" * 50)
     
+    # Initialize database
+    from .database import Database
+    db = Database(app.config.get('DB_PATH', Config.DB_PATH))
+    db.init_db()
+
     # 启用CORS
     CORS(app, resources={r"/api/*": {"origins": "*"}})
     

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -39,6 +39,9 @@ class Config:
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50MB
     UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), '../uploads')
     ALLOWED_EXTENSIONS = {'pdf', 'md', 'txt', 'markdown'}
+
+    # Database
+    DB_PATH = os.path.join(UPLOAD_FOLDER, 'mirofish.db')
     
     # 文本处理配置
     DEFAULT_CHUNK_SIZE = 500  # 默认切块大小

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,344 @@
+"""
+Database layer for MiroFish.
+Provides SQLite-backed persistence for tasks, projects, simulations, and reports.
+"""
+
+import os
+import json
+import sqlite3
+import threading
+from typing import Optional, List, Dict, Any
+
+from .config import Config
+from .utils.logger import get_logger
+
+logger = get_logger('mirofish.database')
+
+# Schema version for migrations
+SCHEMA_VERSION = 1
+
+SCHEMA_SQL = """
+-- Tasks (replaces in-memory TaskManager dict)
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id TEXT PRIMARY KEY,
+    task_type TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    progress INTEGER DEFAULT 0,
+    message TEXT DEFAULT '',
+    result TEXT,
+    error TEXT,
+    metadata TEXT,
+    progress_detail TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_tasks_created ON tasks(created_at);
+
+-- Projects (replaces per-project project.json)
+CREATE TABLE IF NOT EXISTS projects (
+    project_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL DEFAULT 'Unnamed Project',
+    status TEXT NOT NULL DEFAULT 'created',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    total_text_length INTEGER DEFAULT 0,
+    ontology TEXT,
+    analysis_summary TEXT,
+    graph_id TEXT,
+    graph_build_task_id TEXT,
+    simulation_requirement TEXT,
+    chunk_size INTEGER DEFAULT 500,
+    chunk_overlap INTEGER DEFAULT 50,
+    error TEXT,
+    files TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);
+CREATE INDEX IF NOT EXISTS idx_projects_created ON projects(created_at);
+
+-- Simulations (replaces per-simulation state.json)
+CREATE TABLE IF NOT EXISTS simulations (
+    simulation_id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    graph_id TEXT NOT NULL,
+    enable_twitter BOOLEAN DEFAULT 1,
+    enable_reddit BOOLEAN DEFAULT 1,
+    status TEXT NOT NULL DEFAULT 'created',
+    entities_count INTEGER DEFAULT 0,
+    profiles_count INTEGER DEFAULT 0,
+    entity_types TEXT,
+    config_generated BOOLEAN DEFAULT 0,
+    config_reasoning TEXT DEFAULT '',
+    current_round INTEGER DEFAULT 0,
+    twitter_status TEXT DEFAULT 'not_started',
+    reddit_status TEXT DEFAULT 'not_started',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    error TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_simulations_project ON simulations(project_id);
+CREATE INDEX IF NOT EXISTS idx_simulations_status ON simulations(status);
+CREATE INDEX IF NOT EXISTS idx_simulations_created ON simulations(created_at);
+
+-- Reports (replaces per-report meta.json)
+CREATE TABLE IF NOT EXISTS reports (
+    report_id TEXT PRIMARY KEY,
+    simulation_id TEXT NOT NULL,
+    graph_id TEXT NOT NULL,
+    simulation_requirement TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    outline TEXT,
+    created_at TEXT NOT NULL,
+    completed_at TEXT DEFAULT '',
+    error TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_reports_simulation ON reports(simulation_id);
+CREATE INDEX IF NOT EXISTS idx_reports_status ON reports(status);
+
+-- Schema version tracking
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+"""
+
+
+class Database:
+    """
+    Thread-safe SQLite database wrapper (singleton).
+    Uses per-thread connections via threading.local().
+    """
+
+    _instance = None
+    _init_lock = threading.Lock()
+
+    def __new__(cls, db_path: Optional[str] = None):
+        if cls._instance is None:
+            with cls._init_lock:
+                if cls._instance is None:
+                    instance = super().__new__(cls)
+                    instance._db_path = db_path or Config.DB_PATH
+                    instance._local = threading.local()
+                    instance._write_lock = threading.Lock()
+                    cls._instance = instance
+        return cls._instance
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """Get or create a per-thread connection."""
+        if not hasattr(self._local, 'conn') or self._local.conn is None:
+            conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA foreign_keys=ON")
+            self._local.conn = conn
+        return self._local.conn
+
+    def init_db(self):
+        """Initialize database schema and run migrations."""
+        os.makedirs(os.path.dirname(self._db_path), exist_ok=True)
+
+        conn = self._get_connection()
+        with self._write_lock:
+            conn.executescript(SCHEMA_SQL)
+
+            # Check and record schema version
+            cursor = conn.execute(
+                "SELECT MAX(version) FROM schema_version"
+            )
+            row = cursor.fetchone()
+            current_version = row[0] if row[0] is not None else 0
+
+            if current_version < SCHEMA_VERSION:
+                from datetime import datetime
+                conn.execute(
+                    "INSERT OR REPLACE INTO schema_version (version, applied_at) VALUES (?, ?)",
+                    (SCHEMA_VERSION, datetime.now().isoformat())
+                )
+                conn.commit()
+
+                # Run one-time migration from files if DB was just created
+                if current_version == 0:
+                    self._migrate_from_files()
+
+        logger.info(f"Database initialized at {self._db_path}")
+
+    def execute(self, sql: str, params: tuple = ()) -> sqlite3.Cursor:
+        """Execute a write query with thread-safe locking."""
+        conn = self._get_connection()
+        with self._write_lock:
+            cursor = conn.execute(sql, params)
+            conn.commit()
+            return cursor
+
+    def executemany(self, sql: str, params_list: List[tuple]) -> sqlite3.Cursor:
+        """Execute many write queries with thread-safe locking."""
+        conn = self._get_connection()
+        with self._write_lock:
+            cursor = conn.executemany(sql, params_list)
+            conn.commit()
+            return cursor
+
+    def fetchone(self, sql: str, params: tuple = ()) -> Optional[sqlite3.Row]:
+        """Execute a read query and return one row."""
+        conn = self._get_connection()
+        cursor = conn.execute(sql, params)
+        return cursor.fetchone()
+
+    def fetchall(self, sql: str, params: tuple = ()) -> List[sqlite3.Row]:
+        """Execute a read query and return all rows."""
+        conn = self._get_connection()
+        cursor = conn.execute(sql, params)
+        return cursor.fetchall()
+
+    def _migrate_from_files(self):
+        """One-time migration: import existing JSON data into SQLite."""
+        logger.info("Running one-time migration from file-based storage...")
+
+        projects_migrated = self._migrate_projects()
+        simulations_migrated = self._migrate_simulations()
+        reports_migrated = self._migrate_reports()
+
+        logger.info(
+            f"Migration complete: {projects_migrated} projects, "
+            f"{simulations_migrated} simulations, {reports_migrated} reports"
+        )
+
+    def _migrate_projects(self) -> int:
+        """Migrate projects from project.json files."""
+        projects_dir = os.path.join(Config.UPLOAD_FOLDER, 'projects')
+        if not os.path.exists(projects_dir):
+            return 0
+
+        count = 0
+        conn = self._get_connection()
+        for project_id in os.listdir(projects_dir):
+            meta_path = os.path.join(projects_dir, project_id, 'project.json')
+            if not os.path.exists(meta_path):
+                continue
+            try:
+                with open(meta_path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                conn.execute(
+                    """INSERT OR IGNORE INTO projects
+                    (project_id, name, status, created_at, updated_at,
+                     total_text_length, ontology, analysis_summary, graph_id,
+                     graph_build_task_id, simulation_requirement, chunk_size,
+                     chunk_overlap, error, files)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        data.get('project_id', project_id),
+                        data.get('name', 'Unnamed Project'),
+                        data.get('status', 'created'),
+                        data.get('created_at', ''),
+                        data.get('updated_at', ''),
+                        data.get('total_text_length', 0),
+                        json.dumps(data.get('ontology')) if data.get('ontology') else None,
+                        data.get('analysis_summary'),
+                        data.get('graph_id'),
+                        data.get('graph_build_task_id'),
+                        data.get('simulation_requirement'),
+                        data.get('chunk_size', 500),
+                        data.get('chunk_overlap', 50),
+                        data.get('error'),
+                        json.dumps(data.get('files', [])),
+                    )
+                )
+                count += 1
+            except Exception as e:
+                logger.warning(f"Failed to migrate project {project_id}: {e}")
+        conn.commit()
+        return count
+
+    def _migrate_simulations(self) -> int:
+        """Migrate simulations from state.json files."""
+        sims_dir = os.path.join(Config.UPLOAD_FOLDER, 'simulations')
+        if not os.path.exists(sims_dir):
+            return 0
+
+        count = 0
+        conn = self._get_connection()
+        for sim_id in os.listdir(sims_dir):
+            state_path = os.path.join(sims_dir, sim_id, 'state.json')
+            if not os.path.exists(state_path):
+                continue
+            try:
+                with open(state_path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                conn.execute(
+                    """INSERT OR IGNORE INTO simulations
+                    (simulation_id, project_id, graph_id, enable_twitter, enable_reddit,
+                     status, entities_count, profiles_count, entity_types,
+                     config_generated, config_reasoning, current_round,
+                     twitter_status, reddit_status, created_at, updated_at, error)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        data.get('simulation_id', sim_id),
+                        data.get('project_id', ''),
+                        data.get('graph_id', ''),
+                        data.get('enable_twitter', True),
+                        data.get('enable_reddit', True),
+                        data.get('status', 'created'),
+                        data.get('entities_count', 0),
+                        data.get('profiles_count', 0),
+                        json.dumps(data.get('entity_types', [])),
+                        data.get('config_generated', False),
+                        data.get('config_reasoning', ''),
+                        data.get('current_round', 0),
+                        data.get('twitter_status', 'not_started'),
+                        data.get('reddit_status', 'not_started'),
+                        data.get('created_at', ''),
+                        data.get('updated_at', ''),
+                        data.get('error'),
+                    )
+                )
+                count += 1
+            except Exception as e:
+                logger.warning(f"Failed to migrate simulation {sim_id}: {e}")
+        conn.commit()
+        return count
+
+    def _migrate_reports(self) -> int:
+        """Migrate reports from meta.json files."""
+        reports_dir = os.path.join(Config.UPLOAD_FOLDER, 'reports')
+        if not os.path.exists(reports_dir):
+            return 0
+
+        count = 0
+        conn = self._get_connection()
+        for report_id in os.listdir(reports_dir):
+            report_path = os.path.join(reports_dir, report_id)
+            if not os.path.isdir(report_path):
+                continue
+            meta_path = os.path.join(report_path, 'meta.json')
+            if not os.path.exists(meta_path):
+                continue
+            try:
+                with open(meta_path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                conn.execute(
+                    """INSERT OR IGNORE INTO reports
+                    (report_id, simulation_id, graph_id, simulation_requirement,
+                     status, outline, created_at, completed_at, error)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        data.get('report_id', report_id),
+                        data.get('simulation_id', ''),
+                        data.get('graph_id', ''),
+                        data.get('simulation_requirement', ''),
+                        data.get('status', 'pending'),
+                        json.dumps(data.get('outline')) if data.get('outline') else None,
+                        data.get('created_at', ''),
+                        data.get('completed_at', ''),
+                        data.get('error'),
+                    )
+                )
+                count += 1
+            except Exception as e:
+                logger.warning(f"Failed to migrate report {report_id}: {e}")
+        conn.commit()
+        return count
+
+
+def get_db() -> Database:
+    """Get the Database singleton instance."""
+    return Database()

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -1,6 +1,6 @@
 """
-项目上下文管理
-用于在服务端持久化项目状态，避免前端在接口间传递大量数据
+Project context management.
+Server-side persistent project state, backed by SQLite + file storage for uploads.
 """
 
 import os
@@ -10,50 +10,42 @@ import shutil
 from datetime import datetime
 from typing import Dict, Any, List, Optional
 from enum import Enum
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from ..config import Config
 
 
 class ProjectStatus(str, Enum):
-    """项目状态"""
-    CREATED = "created"              # 刚创建，文件已上传
-    ONTOLOGY_GENERATED = "ontology_generated"  # 本体已生成
-    GRAPH_BUILDING = "graph_building"    # 图谱构建中
-    GRAPH_COMPLETED = "graph_completed"  # 图谱构建完成
-    FAILED = "failed"                # 失败
+    CREATED = "created"
+    ONTOLOGY_GENERATED = "ontology_generated"
+    GRAPH_BUILDING = "graph_building"
+    GRAPH_COMPLETED = "graph_completed"
+    FAILED = "failed"
 
 
 @dataclass
 class Project:
-    """项目数据模型"""
     project_id: str
     name: str
     status: ProjectStatus
     created_at: str
     updated_at: str
-    
-    # 文件信息
-    files: List[Dict[str, str]] = field(default_factory=list)  # [{filename, path, size}]
+
+    files: List[Dict[str, str]] = field(default_factory=list)
     total_text_length: int = 0
-    
-    # 本体信息（接口1生成后填充）
+
     ontology: Optional[Dict[str, Any]] = None
     analysis_summary: Optional[str] = None
-    
-    # 图谱信息（接口2完成后填充）
+
     graph_id: Optional[str] = None
     graph_build_task_id: Optional[str] = None
-    
-    # 配置
+
     simulation_requirement: Optional[str] = None
     chunk_size: int = 500
     chunk_overlap: int = 50
-    
-    # 错误信息
+
     error: Optional[str] = None
-    
+
     def to_dict(self) -> Dict[str, Any]:
-        """转换为字典"""
         return {
             "project_id": self.project_id,
             "name": self.name,
@@ -71,14 +63,13 @@ class Project:
             "chunk_overlap": self.chunk_overlap,
             "error": self.error
         }
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'Project':
-        """从字典创建"""
         status = data.get('status', 'created')
         if isinstance(status, str):
             status = ProjectStatus(status)
-        
+
         return cls(
             project_id=data['project_id'],
             name=data.get('name', 'Unnamed Project'),
@@ -97,54 +88,79 @@ class Project:
             error=data.get('error')
         )
 
+    @classmethod
+    def from_row(cls, row) -> 'Project':
+        """Create Project from a sqlite3.Row."""
+        ontology = None
+        if row['ontology']:
+            try:
+                ontology = json.loads(row['ontology'])
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        files = []
+        if row['files']:
+            try:
+                files = json.loads(row['files'])
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        return cls(
+            project_id=row['project_id'],
+            name=row['name'],
+            status=ProjectStatus(row['status']),
+            created_at=row['created_at'],
+            updated_at=row['updated_at'],
+            files=files,
+            total_text_length=row['total_text_length'] or 0,
+            ontology=ontology,
+            analysis_summary=row['analysis_summary'],
+            graph_id=row['graph_id'],
+            graph_build_task_id=row['graph_build_task_id'],
+            simulation_requirement=row['simulation_requirement'],
+            chunk_size=row['chunk_size'] or 500,
+            chunk_overlap=row['chunk_overlap'] or 50,
+            error=row['error']
+        )
+
 
 class ProjectManager:
-    """项目管理器 - 负责项目的持久化存储和检索"""
-    
-    # 项目存储根目录
+    """Project manager - SQLite-backed persistence with file storage for uploads."""
+
     PROJECTS_DIR = os.path.join(Config.UPLOAD_FOLDER, 'projects')
-    
+
+    @classmethod
+    def _get_db(cls):
+        from ..database import get_db
+        return get_db()
+
     @classmethod
     def _ensure_projects_dir(cls):
-        """确保项目目录存在"""
         os.makedirs(cls.PROJECTS_DIR, exist_ok=True)
-    
+
     @classmethod
     def _get_project_dir(cls, project_id: str) -> str:
-        """获取项目目录路径"""
         return os.path.join(cls.PROJECTS_DIR, project_id)
-    
+
     @classmethod
     def _get_project_meta_path(cls, project_id: str) -> str:
-        """获取项目元数据文件路径"""
         return os.path.join(cls._get_project_dir(project_id), 'project.json')
-    
+
     @classmethod
     def _get_project_files_dir(cls, project_id: str) -> str:
-        """获取项目文件存储目录"""
         return os.path.join(cls._get_project_dir(project_id), 'files')
-    
+
     @classmethod
     def _get_project_text_path(cls, project_id: str) -> str:
-        """获取项目提取文本存储路径"""
         return os.path.join(cls._get_project_dir(project_id), 'extracted_text.txt')
-    
+
     @classmethod
     def create_project(cls, name: str = "Unnamed Project") -> Project:
-        """
-        创建新项目
-        
-        Args:
-            name: 项目名称
-            
-        Returns:
-            新创建的Project对象
-        """
         cls._ensure_projects_dir()
-        
+
         project_id = f"proj_{uuid.uuid4().hex[:12]}"
         now = datetime.now().isoformat()
-        
+
         project = Project(
             project_id=project_id,
             name=name,
@@ -152,154 +168,143 @@ class ProjectManager:
             created_at=now,
             updated_at=now
         )
-        
-        # 创建项目目录结构
+
+        # Create directory structure for files
         project_dir = cls._get_project_dir(project_id)
         files_dir = cls._get_project_files_dir(project_id)
         os.makedirs(project_dir, exist_ok=True)
         os.makedirs(files_dir, exist_ok=True)
-        
-        # 保存项目元数据
+
+        # Save to database
         cls.save_project(project)
-        
+
         return project
-    
+
     @classmethod
     def save_project(cls, project: Project) -> None:
-        """保存项目元数据"""
+        """Save project metadata to SQLite (and project.json for backwards compat)."""
         project.updated_at = datetime.now().isoformat()
+
+        db = cls._get_db()
+        db.execute(
+            """INSERT OR REPLACE INTO projects
+            (project_id, name, status, created_at, updated_at,
+             total_text_length, ontology, analysis_summary, graph_id,
+             graph_build_task_id, simulation_requirement, chunk_size,
+             chunk_overlap, error, files)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                project.project_id,
+                project.name,
+                project.status.value if isinstance(project.status, ProjectStatus) else project.status,
+                project.created_at,
+                project.updated_at,
+                project.total_text_length,
+                json.dumps(project.ontology, ensure_ascii=False) if project.ontology else None,
+                project.analysis_summary,
+                project.graph_id,
+                project.graph_build_task_id,
+                project.simulation_requirement,
+                project.chunk_size,
+                project.chunk_overlap,
+                project.error,
+                json.dumps(project.files, ensure_ascii=False),
+            )
+        )
+
+        # Also write project.json for backwards compatibility
         meta_path = cls._get_project_meta_path(project.project_id)
-        
-        with open(meta_path, 'w', encoding='utf-8') as f:
-            json.dump(project.to_dict(), f, ensure_ascii=False, indent=2)
-    
+        project_dir = os.path.dirname(meta_path)
+        if os.path.exists(project_dir):
+            try:
+                with open(meta_path, 'w', encoding='utf-8') as f:
+                    json.dump(project.to_dict(), f, ensure_ascii=False, indent=2)
+            except OSError:
+                pass
+
     @classmethod
     def get_project(cls, project_id: str) -> Optional[Project]:
-        """
-        获取项目
-        
-        Args:
-            project_id: 项目ID
-            
-        Returns:
-            Project对象，如果不存在返回None
-        """
+        """Get project from DB, with fallback to file."""
+        db = cls._get_db()
+        row = db.fetchone("SELECT * FROM projects WHERE project_id = ?", (project_id,))
+        if row:
+            return Project.from_row(row)
+
+        # Fallback: try loading from project.json
         meta_path = cls._get_project_meta_path(project_id)
-        
         if not os.path.exists(meta_path):
             return None
-        
+
         with open(meta_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
-        
-        return Project.from_dict(data)
-    
+
+        project = Project.from_dict(data)
+        # Migrate to DB for next time
+        cls.save_project(project)
+        return project
+
     @classmethod
     def list_projects(cls, limit: int = 50) -> List[Project]:
-        """
-        列出所有项目
-        
-        Args:
-            limit: 返回数量限制
-            
-        Returns:
-            项目列表，按创建时间倒序
-        """
-        cls._ensure_projects_dir()
-        
-        projects = []
-        for project_id in os.listdir(cls.PROJECTS_DIR):
-            project = cls.get_project(project_id)
-            if project:
-                projects.append(project)
-        
-        # 按创建时间倒序排序
-        projects.sort(key=lambda p: p.created_at, reverse=True)
-        
-        return projects[:limit]
-    
+        db = cls._get_db()
+        rows = db.fetchall(
+            "SELECT * FROM projects ORDER BY created_at DESC LIMIT ?",
+            (limit,)
+        )
+        return [Project.from_row(row) for row in rows]
+
     @classmethod
     def delete_project(cls, project_id: str) -> bool:
-        """
-        删除项目及其所有文件
-        
-        Args:
-            project_id: 项目ID
-            
-        Returns:
-            是否删除成功
-        """
+        # Delete from DB
+        db = cls._get_db()
+        db.execute("DELETE FROM projects WHERE project_id = ?", (project_id,))
+
+        # Delete files
         project_dir = cls._get_project_dir(project_id)
-        
-        if not os.path.exists(project_dir):
-            return False
-        
-        shutil.rmtree(project_dir)
+        if os.path.exists(project_dir):
+            shutil.rmtree(project_dir)
+            return True
         return True
-    
+
     @classmethod
     def save_file_to_project(cls, project_id: str, file_storage, original_filename: str) -> Dict[str, str]:
-        """
-        保存上传的文件到项目目录
-        
-        Args:
-            project_id: 项目ID
-            file_storage: Flask的FileStorage对象
-            original_filename: 原始文件名
-            
-        Returns:
-            文件信息字典 {filename, path, size}
-        """
         files_dir = cls._get_project_files_dir(project_id)
         os.makedirs(files_dir, exist_ok=True)
-        
-        # 生成安全的文件名
+
         ext = os.path.splitext(original_filename)[1].lower()
         safe_filename = f"{uuid.uuid4().hex[:8]}{ext}"
         file_path = os.path.join(files_dir, safe_filename)
-        
-        # 保存文件
+
         file_storage.save(file_path)
-        
-        # 获取文件大小
         file_size = os.path.getsize(file_path)
-        
+
         return {
             "original_filename": original_filename,
             "saved_filename": safe_filename,
             "path": file_path,
             "size": file_size
         }
-    
+
     @classmethod
     def save_extracted_text(cls, project_id: str, text: str) -> None:
-        """保存提取的文本"""
         text_path = cls._get_project_text_path(project_id)
         with open(text_path, 'w', encoding='utf-8') as f:
             f.write(text)
-    
+
     @classmethod
     def get_extracted_text(cls, project_id: str) -> Optional[str]:
-        """获取提取的文本"""
         text_path = cls._get_project_text_path(project_id)
-        
         if not os.path.exists(text_path):
             return None
-        
         with open(text_path, 'r', encoding='utf-8') as f:
             return f.read()
-    
+
     @classmethod
     def get_project_files(cls, project_id: str) -> List[str]:
-        """获取项目的所有文件路径"""
         files_dir = cls._get_project_files_dir(project_id)
-        
         if not os.path.exists(files_dir):
             return []
-        
         return [
-            os.path.join(files_dir, f) 
-            for f in os.listdir(files_dir) 
+            os.path.join(files_dir, f)
+            for f in os.listdir(files_dir)
             if os.path.isfile(os.path.join(files_dir, f))
         ]
-

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -1,41 +1,40 @@
 """
-任务状态管理
-用于跟踪长时间运行的任务（如图谱构建）
+Task status management.
+Tracks long-running tasks (graph building, report generation, etc.)
+Persisted to SQLite for crash resilience.
 """
 
+import json
 import uuid
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Dict, Any, Optional
 from dataclasses import dataclass, field
 
 
 class TaskStatus(str, Enum):
-    """任务状态枚举"""
-    PENDING = "pending"          # 等待中
-    PROCESSING = "processing"    # 处理中
-    COMPLETED = "completed"      # 已完成
-    FAILED = "failed"            # 失败
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
 
 
 @dataclass
 class Task:
-    """任务数据类"""
     task_id: str
     task_type: str
     status: TaskStatus
     created_at: datetime
     updated_at: datetime
-    progress: int = 0              # 总进度百分比 0-100
-    message: str = ""              # 状态消息
-    result: Optional[Dict] = None  # 任务结果
-    error: Optional[str] = None    # 错误信息
-    metadata: Dict = field(default_factory=dict)  # 额外元数据
-    progress_detail: Dict = field(default_factory=dict)  # 详细进度信息
-    
+    progress: int = 0
+    message: str = ""
+    result: Optional[Dict] = None
+    error: Optional[str] = None
+    metadata: Dict = field(default_factory=dict)
+    progress_detail: Dict = field(default_factory=dict)
+
     def to_dict(self) -> Dict[str, Any]:
-        """转换为字典"""
         return {
             "task_id": self.task_id,
             "task_type": self.task_type,
@@ -51,58 +50,88 @@ class Task:
         }
 
 
+def _json_dumps(obj) -> Optional[str]:
+    """Serialize dict/list to JSON string, or None."""
+    if obj is None:
+        return None
+    return json.dumps(obj, ensure_ascii=False)
+
+
+def _json_loads(s) -> Optional[Dict]:
+    """Deserialize JSON string to dict/list, or None."""
+    if s is None:
+        return None
+    try:
+        return json.loads(s)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _row_to_task(row) -> Task:
+    """Convert a sqlite3.Row to a Task dataclass."""
+    return Task(
+        task_id=row['task_id'],
+        task_type=row['task_type'],
+        status=TaskStatus(row['status']),
+        created_at=datetime.fromisoformat(row['created_at']),
+        updated_at=datetime.fromisoformat(row['updated_at']),
+        progress=row['progress'] or 0,
+        message=row['message'] or '',
+        result=_json_loads(row['result']),
+        error=row['error'],
+        metadata=_json_loads(row['metadata']) or {},
+        progress_detail=_json_loads(row['progress_detail']) or {},
+    )
+
+
 class TaskManager:
     """
-    任务管理器
-    线程安全的任务状态管理
+    Task manager backed by SQLite.
+    Thread-safe singleton.
     """
-    
+
     _instance = None
     _lock = threading.Lock()
-    
+
     def __new__(cls):
-        """单例模式"""
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
                     cls._instance = super().__new__(cls)
-                    cls._instance._tasks: Dict[str, Task] = {}
-                    cls._instance._task_lock = threading.Lock()
+                    cls._instance._write_lock = threading.Lock()
         return cls._instance
-    
+
+    def _get_db(self):
+        from ..database import get_db
+        return get_db()
+
     def create_task(self, task_type: str, metadata: Optional[Dict] = None) -> str:
-        """
-        创建新任务
-        
-        Args:
-            task_type: 任务类型
-            metadata: 额外元数据
-            
-        Returns:
-            任务ID
-        """
         task_id = str(uuid.uuid4())
         now = datetime.now()
-        
-        task = Task(
-            task_id=task_id,
-            task_type=task_type,
-            status=TaskStatus.PENDING,
-            created_at=now,
-            updated_at=now,
-            metadata=metadata or {}
+
+        db = self._get_db()
+        db.execute(
+            """INSERT INTO tasks
+            (task_id, task_type, status, created_at, updated_at,
+             progress, message, result, error, metadata, progress_detail)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                task_id, task_type, TaskStatus.PENDING.value,
+                now.isoformat(), now.isoformat(),
+                0, '', None, None,
+                _json_dumps(metadata or {}),
+                _json_dumps({}),
+            )
         )
-        
-        with self._task_lock:
-            self._tasks[task_id] = task
-        
         return task_id
-    
+
     def get_task(self, task_id: str) -> Optional[Task]:
-        """获取任务"""
-        with self._task_lock:
-            return self._tasks.get(task_id)
-    
+        db = self._get_db()
+        row = db.fetchone("SELECT * FROM tasks WHERE task_id = ?", (task_id,))
+        if row is None:
+            return None
+        return _row_to_task(row)
+
     def update_task(
         self,
         task_id: str,
@@ -113,72 +142,68 @@ class TaskManager:
         error: Optional[str] = None,
         progress_detail: Optional[Dict] = None
     ):
-        """
-        更新任务状态
-        
-        Args:
-            task_id: 任务ID
-            status: 新状态
-            progress: 进度
-            message: 消息
-            result: 结果
-            error: 错误信息
-            progress_detail: 详细进度信息
-        """
-        with self._task_lock:
-            task = self._tasks.get(task_id)
-            if task:
-                task.updated_at = datetime.now()
-                if status is not None:
-                    task.status = status
-                if progress is not None:
-                    task.progress = progress
-                if message is not None:
-                    task.message = message
-                if result is not None:
-                    task.result = result
-                if error is not None:
-                    task.error = error
-                if progress_detail is not None:
-                    task.progress_detail = progress_detail
-    
+        sets = ["updated_at = ?"]
+        params = [datetime.now().isoformat()]
+
+        if status is not None:
+            sets.append("status = ?")
+            params.append(status.value)
+        if progress is not None:
+            sets.append("progress = ?")
+            params.append(progress)
+        if message is not None:
+            sets.append("message = ?")
+            params.append(message)
+        if result is not None:
+            sets.append("result = ?")
+            params.append(_json_dumps(result))
+        if error is not None:
+            sets.append("error = ?")
+            params.append(error)
+        if progress_detail is not None:
+            sets.append("progress_detail = ?")
+            params.append(_json_dumps(progress_detail))
+
+        params.append(task_id)
+
+        db = self._get_db()
+        db.execute(
+            f"UPDATE tasks SET {', '.join(sets)} WHERE task_id = ?",
+            tuple(params)
+        )
+
     def complete_task(self, task_id: str, result: Dict):
-        """标记任务完成"""
         self.update_task(
             task_id,
             status=TaskStatus.COMPLETED,
             progress=100,
-            message="任务完成",
+            message="Task completed",
             result=result
         )
-    
+
     def fail_task(self, task_id: str, error: str):
-        """标记任务失败"""
         self.update_task(
             task_id,
             status=TaskStatus.FAILED,
-            message="任务失败",
+            message="Task failed",
             error=error
         )
-    
-    def list_tasks(self, task_type: Optional[str] = None) -> list:
-        """列出任务"""
-        with self._task_lock:
-            tasks = list(self._tasks.values())
-            if task_type:
-                tasks = [t for t in tasks if t.task_type == task_type]
-            return [t.to_dict() for t in sorted(tasks, key=lambda x: x.created_at, reverse=True)]
-    
-    def cleanup_old_tasks(self, max_age_hours: int = 24):
-        """清理旧任务"""
-        from datetime import timedelta
-        cutoff = datetime.now() - timedelta(hours=max_age_hours)
-        
-        with self._task_lock:
-            old_ids = [
-                tid for tid, task in self._tasks.items()
-                if task.created_at < cutoff and task.status in [TaskStatus.COMPLETED, TaskStatus.FAILED]
-            ]
-            for tid in old_ids:
-                del self._tasks[tid]
 
+    def list_tasks(self, task_type: Optional[str] = None) -> list:
+        db = self._get_db()
+        if task_type:
+            rows = db.fetchall(
+                "SELECT * FROM tasks WHERE task_type = ? ORDER BY created_at DESC",
+                (task_type,)
+            )
+        else:
+            rows = db.fetchall("SELECT * FROM tasks ORDER BY created_at DESC")
+        return [_row_to_task(row).to_dict() for row in rows]
+
+    def cleanup_old_tasks(self, max_age_hours: int = 24):
+        cutoff = (datetime.now() - timedelta(hours=max_age_hours)).isoformat()
+        db = self._get_db()
+        db.execute(
+            "DELETE FROM tasks WHERE created_at < ? AND status IN (?, ?)",
+            (cutoff, TaskStatus.COMPLETED.value, TaskStatus.FAILED.value)
+        )

--- a/backend/app/services/report_agent.py
+++ b/backend/app/services/report_agent.py
@@ -2423,149 +2423,187 @@ class ReportManager:
         return '\n'.join(result_lines)
     
     @classmethod
+    def _get_db(cls):
+        from ..database import get_db
+        return get_db()
+
+    @classmethod
     def save_report(cls, report: Report) -> None:
-        """保存报告元信息和完整报告"""
+        """Save report metadata to SQLite and content files to disk."""
         cls._ensure_report_folder(report.report_id)
-        
-        # 保存元信息JSON
+
+        # Save to SQLite
+        db = cls._get_db()
+        db.execute(
+            """INSERT OR REPLACE INTO reports
+            (report_id, simulation_id, graph_id, simulation_requirement,
+             status, outline, created_at, completed_at, error)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                report.report_id,
+                report.simulation_id,
+                report.graph_id,
+                report.simulation_requirement,
+                report.status.value,
+                json.dumps(report.outline.to_dict(), ensure_ascii=False) if report.outline else None,
+                report.created_at,
+                report.completed_at,
+                report.error,
+            )
+        )
+
+        # Save meta.json for backwards compatibility
         with open(cls._get_report_path(report.report_id), 'w', encoding='utf-8') as f:
             json.dump(report.to_dict(), f, ensure_ascii=False, indent=2)
-        
-        # 保存大纲
+
+        # Save outline
         if report.outline:
             cls.save_outline(report.report_id, report.outline)
-        
-        # 保存完整Markdown报告
+
+        # Save full Markdown report
         if report.markdown_content:
             with open(cls._get_report_markdown_path(report.report_id), 'w', encoding='utf-8') as f:
                 f.write(report.markdown_content)
-        
-        logger.info(f"报告已保存: {report.report_id}")
+
+        logger.info(f"Report saved: {report.report_id}")
     
     @classmethod
-    def get_report(cls, report_id: str) -> Optional[Report]:
-        """获取报告"""
-        path = cls._get_report_path(report_id)
-        
-        if not os.path.exists(path):
-            # 兼容旧格式：检查直接存储在reports目录下的文件
-            old_path = os.path.join(cls.REPORTS_DIR, f"{report_id}.json")
-            if os.path.exists(old_path):
-                path = old_path
-            else:
-                return None
-        
-        with open(path, 'r', encoding='utf-8') as f:
-            data = json.load(f)
-        
-        # 重建Report对象
+    def _build_report_from_data(cls, data: Dict[str, Any], report_id: str) -> Report:
+        """Build a Report object from a dict (shared by DB and file loading)."""
         outline = None
         if data.get('outline'):
             outline_data = data['outline']
-            sections = []
-            for s in outline_data.get('sections', []):
-                sections.append(ReportSection(
-                    title=s['title'],
-                    content=s.get('content', '')
-                ))
-            outline = ReportOutline(
-                title=outline_data['title'],
-                summary=outline_data['summary'],
-                sections=sections
-            )
-        
-        # 如果markdown_content为空，尝试从full_report.md读取
+            if isinstance(outline_data, str):
+                try:
+                    outline_data = json.loads(outline_data)
+                except (json.JSONDecodeError, TypeError):
+                    outline_data = None
+            if outline_data:
+                sections = []
+                for s in outline_data.get('sections', []):
+                    sections.append(ReportSection(
+                        title=s['title'],
+                        content=s.get('content', '')
+                    ))
+                outline = ReportOutline(
+                    title=outline_data['title'],
+                    summary=outline_data['summary'],
+                    sections=sections
+                )
+
+        # Load markdown content from file
         markdown_content = data.get('markdown_content', '')
         if not markdown_content:
             full_report_path = cls._get_report_markdown_path(report_id)
             if os.path.exists(full_report_path):
                 with open(full_report_path, 'r', encoding='utf-8') as f:
                     markdown_content = f.read()
-        
+
         return Report(
-            report_id=data['report_id'],
-            simulation_id=data['simulation_id'],
-            graph_id=data['graph_id'],
-            simulation_requirement=data['simulation_requirement'],
-            status=ReportStatus(data['status']),
+            report_id=data.get('report_id', report_id),
+            simulation_id=data.get('simulation_id', ''),
+            graph_id=data.get('graph_id', ''),
+            simulation_requirement=data.get('simulation_requirement', ''),
+            status=ReportStatus(data.get('status', 'pending')),
             outline=outline,
             markdown_content=markdown_content,
             created_at=data.get('created_at', ''),
             completed_at=data.get('completed_at', ''),
             error=data.get('error')
         )
+
+    @classmethod
+    def get_report(cls, report_id: str) -> Optional[Report]:
+        """Get report from DB with fallback to file."""
+        # Try SQLite first
+        db = cls._get_db()
+        row = db.fetchone("SELECT * FROM reports WHERE report_id = ?", (report_id,))
+        if row:
+            return cls._build_report_from_data(dict(row), report_id)
+
+        # Fallback to file
+        path = cls._get_report_path(report_id)
+        if not os.path.exists(path):
+            old_path = os.path.join(cls.REPORTS_DIR, f"{report_id}.json")
+            if os.path.exists(old_path):
+                path = old_path
+            else:
+                return None
+
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        report = cls._build_report_from_data(data, report_id)
+        # Migrate to DB
+        cls.save_report(report)
+        return report
     
     @classmethod
     def get_report_by_simulation(cls, simulation_id: str) -> Optional[Report]:
-        """根据模拟ID获取报告"""
+        """Get report by simulation ID."""
+        db = cls._get_db()
+        row = db.fetchone(
+            "SELECT * FROM reports WHERE simulation_id = ? ORDER BY created_at DESC LIMIT 1",
+            (simulation_id,)
+        )
+        if row:
+            return cls._build_report_from_data(dict(row), row['report_id'])
+
+        # Fallback to directory scan
         cls._ensure_reports_dir()
-        
         for item in os.listdir(cls.REPORTS_DIR):
             item_path = os.path.join(cls.REPORTS_DIR, item)
-            # 新格式：文件夹
             if os.path.isdir(item_path):
                 report = cls.get_report(item)
                 if report and report.simulation_id == simulation_id:
                     return report
-            # 兼容旧格式：JSON文件
             elif item.endswith('.json'):
                 report_id = item[:-5]
                 report = cls.get_report(report_id)
                 if report and report.simulation_id == simulation_id:
                     return report
-        
         return None
-    
+
     @classmethod
     def list_reports(cls, simulation_id: Optional[str] = None, limit: int = 50) -> List[Report]:
-        """列出报告"""
-        cls._ensure_reports_dir()
-        
-        reports = []
-        for item in os.listdir(cls.REPORTS_DIR):
-            item_path = os.path.join(cls.REPORTS_DIR, item)
-            # 新格式：文件夹
-            if os.path.isdir(item_path):
-                report = cls.get_report(item)
-                if report:
-                    if simulation_id is None or report.simulation_id == simulation_id:
-                        reports.append(report)
-            # 兼容旧格式：JSON文件
-            elif item.endswith('.json'):
-                report_id = item[:-5]
-                report = cls.get_report(report_id)
-                if report:
-                    if simulation_id is None or report.simulation_id == simulation_id:
-                        reports.append(report)
-        
-        # 按创建时间倒序
-        reports.sort(key=lambda r: r.created_at, reverse=True)
-        
-        return reports[:limit]
-    
+        """List reports from SQLite."""
+        db = cls._get_db()
+        if simulation_id:
+            rows = db.fetchall(
+                "SELECT * FROM reports WHERE simulation_id = ? ORDER BY created_at DESC LIMIT ?",
+                (simulation_id, limit)
+            )
+        else:
+            rows = db.fetchall(
+                "SELECT * FROM reports ORDER BY created_at DESC LIMIT ?",
+                (limit,)
+            )
+
+        return [cls._build_report_from_data(dict(row), row['report_id']) for row in rows]
+
     @classmethod
     def delete_report(cls, report_id: str) -> bool:
-        """删除报告（整个文件夹）"""
+        """Delete report from DB and filesystem."""
         import shutil
-        
+
+        # Delete from DB
+        db = cls._get_db()
+        db.execute("DELETE FROM reports WHERE report_id = ?", (report_id,))
+
         folder_path = cls._get_report_folder(report_id)
-        
-        # 新格式：删除整个文件夹
         if os.path.exists(folder_path) and os.path.isdir(folder_path):
             shutil.rmtree(folder_path)
-            logger.info(f"报告文件夹已删除: {report_id}")
+            logger.info(f"Report deleted: {report_id}")
             return True
-        
-        # 兼容旧格式：删除单独的文件
+
+        # Legacy format
         deleted = False
         old_json_path = os.path.join(cls.REPORTS_DIR, f"{report_id}.json")
         old_md_path = os.path.join(cls.REPORTS_DIR, f"{report_id}.md")
-        
         if os.path.exists(old_json_path):
             os.remove(old_json_path)
             deleted = True
         if os.path.exists(old_md_path):
             os.remove(old_md_path)
             deleted = True
-        
         return deleted

--- a/backend/app/services/simulation_manager.py
+++ b/backend/app/services/simulation_manager.py
@@ -113,60 +113,118 @@ class SimulationState:
 
 class SimulationManager:
     """
-    模拟管理器
-    
-    核心功能：
-    1. 从Zep图谱读取实体并过滤
-    2. 生成OASIS Agent Profile
-    3. 使用LLM智能生成模拟配置参数
-    4. 准备预设脚本所需的所有文件
+    Simulation manager.
+    SQLite-backed persistence with file storage for large blobs (profiles, configs).
     """
-    
+
     # 模拟数据存储目录
     SIMULATION_DATA_DIR = os.path.join(
-        os.path.dirname(__file__), 
+        os.path.dirname(__file__),
         '../../uploads/simulations'
     )
-    
+
     def __init__(self):
         # 确保目录存在
         os.makedirs(self.SIMULATION_DATA_DIR, exist_ok=True)
-        
-        # 内存中的模拟状态缓存
-        self._simulations: Dict[str, SimulationState] = {}
-    
+
+    @staticmethod
+    def _get_db():
+        from ..database import get_db
+        return get_db()
+
     def _get_simulation_dir(self, simulation_id: str) -> str:
         """获取模拟数据目录"""
         sim_dir = os.path.join(self.SIMULATION_DATA_DIR, simulation_id)
         os.makedirs(sim_dir, exist_ok=True)
         return sim_dir
-    
+
     def _save_simulation_state(self, state: SimulationState):
-        """保存模拟状态到文件"""
+        """Save simulation state to SQLite and state.json."""
+        state.updated_at = datetime.now().isoformat()
+
+        db = self._get_db()
+        db.execute(
+            """INSERT OR REPLACE INTO simulations
+            (simulation_id, project_id, graph_id, enable_twitter, enable_reddit,
+             status, entities_count, profiles_count, entity_types,
+             config_generated, config_reasoning, current_round,
+             twitter_status, reddit_status, created_at, updated_at, error)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                state.simulation_id,
+                state.project_id,
+                state.graph_id,
+                state.enable_twitter,
+                state.enable_reddit,
+                state.status.value,
+                state.entities_count,
+                state.profiles_count,
+                json.dumps(state.entity_types),
+                state.config_generated,
+                state.config_reasoning,
+                state.current_round,
+                state.twitter_status,
+                state.reddit_status,
+                state.created_at,
+                state.updated_at,
+                state.error,
+            )
+        )
+
+        # Also write state.json for backwards compatibility
         sim_dir = self._get_simulation_dir(state.simulation_id)
         state_file = os.path.join(sim_dir, "state.json")
-        
-        state.updated_at = datetime.now().isoformat()
-        
-        with open(state_file, 'w', encoding='utf-8') as f:
-            json.dump(state.to_dict(), f, ensure_ascii=False, indent=2)
-        
-        self._simulations[state.simulation_id] = state
-    
+        try:
+            with open(state_file, 'w', encoding='utf-8') as f:
+                json.dump(state.to_dict(), f, ensure_ascii=False, indent=2)
+        except OSError:
+            pass
+
     def _load_simulation_state(self, simulation_id: str) -> Optional[SimulationState]:
-        """从文件加载模拟状态"""
-        if simulation_id in self._simulations:
-            return self._simulations[simulation_id]
-        
+        """Load simulation state from SQLite, with fallback to file."""
+        db = self._get_db()
+        row = db.fetchone(
+            "SELECT * FROM simulations WHERE simulation_id = ?",
+            (simulation_id,)
+        )
+        if row:
+            entity_types = []
+            if row['entity_types']:
+                try:
+                    entity_types = json.loads(row['entity_types'])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+            return SimulationState(
+                simulation_id=row['simulation_id'],
+                project_id=row['project_id'],
+                graph_id=row['graph_id'],
+                enable_twitter=bool(row['enable_twitter']),
+                enable_reddit=bool(row['enable_reddit']),
+                status=SimulationStatus(row['status']),
+                entities_count=row['entities_count'] or 0,
+                profiles_count=row['profiles_count'] or 0,
+                entity_types=entity_types,
+                config_generated=bool(row['config_generated']),
+                config_reasoning=row['config_reasoning'] or '',
+                current_round=row['current_round'] or 0,
+                twitter_status=row['twitter_status'] or 'not_started',
+                reddit_status=row['reddit_status'] or 'not_started',
+                created_at=row['created_at'],
+                updated_at=row['updated_at'],
+                error=row['error'],
+            )
+
+        # Fallback: try loading from state.json
         sim_dir = self._get_simulation_dir(simulation_id)
         state_file = os.path.join(sim_dir, "state.json")
-        
+
         if not os.path.exists(state_file):
             return None
-        
+
         with open(state_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
-        
+
         state = SimulationState(
             simulation_id=simulation_id,
             project_id=data.get("project_id", ""),
@@ -186,8 +244,9 @@ class SimulationManager:
             updated_at=data.get("updated_at", datetime.now().isoformat()),
             error=data.get("error"),
         )
-        
-        self._simulations[simulation_id] = state
+
+        # Migrate to DB for next time
+        self._save_simulation_state(state)
         return state
     
     def create_simulation(
@@ -456,25 +515,49 @@ class SimulationManager:
             raise
     
     def get_simulation(self, simulation_id: str) -> Optional[SimulationState]:
-        """获取模拟状态"""
+        """Get simulation state."""
         return self._load_simulation_state(simulation_id)
-    
+
     def list_simulations(self, project_id: Optional[str] = None) -> List[SimulationState]:
-        """列出所有模拟"""
+        """List all simulations, optionally filtered by project_id."""
+        db = self._get_db()
+        if project_id:
+            rows = db.fetchall(
+                "SELECT * FROM simulations WHERE project_id = ? ORDER BY created_at DESC",
+                (project_id,)
+            )
+        else:
+            rows = db.fetchall("SELECT * FROM simulations ORDER BY created_at DESC")
+
         simulations = []
-        
-        if os.path.exists(self.SIMULATION_DATA_DIR):
-            for sim_id in os.listdir(self.SIMULATION_DATA_DIR):
-                # 跳过隐藏文件（如 .DS_Store）和非目录文件
-                sim_path = os.path.join(self.SIMULATION_DATA_DIR, sim_id)
-                if sim_id.startswith('.') or not os.path.isdir(sim_path):
-                    continue
-                
-                state = self._load_simulation_state(sim_id)
-                if state:
-                    if project_id is None or state.project_id == project_id:
-                        simulations.append(state)
-        
+        for row in rows:
+            entity_types = []
+            if row['entity_types']:
+                try:
+                    entity_types = json.loads(row['entity_types'])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+            simulations.append(SimulationState(
+                simulation_id=row['simulation_id'],
+                project_id=row['project_id'],
+                graph_id=row['graph_id'],
+                enable_twitter=bool(row['enable_twitter']),
+                enable_reddit=bool(row['enable_reddit']),
+                status=SimulationStatus(row['status']),
+                entities_count=row['entities_count'] or 0,
+                profiles_count=row['profiles_count'] or 0,
+                entity_types=entity_types,
+                config_generated=bool(row['config_generated']),
+                config_reasoning=row['config_reasoning'] or '',
+                current_round=row['current_round'] or 0,
+                twitter_status=row['twitter_status'] or 'not_started',
+                reddit_status=row['reddit_status'] or 'not_started',
+                created_at=row['created_at'],
+                updated_at=row['updated_at'],
+                error=row['error'],
+            ))
+
         return simulations
     
     def get_profiles(self, simulation_id: str, platform: str = "reddit") -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Add SQLite database layer (`database.py`) with thread-safe wrapper, WAL mode, and automatic migration from existing JSON files
- Migrate `TaskManager` from in-memory dict to SQLite — tasks now survive server restarts
- Migrate `ProjectManager`, `SimulationManager`, `ReportManager` to SQLite-backed with file fallback
- Large blobs (uploads, profiles, action logs, reports) remain on disk
- Backwards compatible: existing file-based data is auto-migrated on first startup

## Test plan
- [ ] Start backend, create a project, restart backend, verify project persists via `GET /api/graph/project/list`
- [ ] Start a graph build task, restart backend, verify task status still queryable
- [ ] Verify existing projects/simulations/reports are auto-migrated from JSON files to SQLite
- [ ] Verify `mirofish.db` is created in `backend/uploads/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)