### PR TITLE
fix(api): remove duplicate to_dict() in /api/graph/tasks — crashes every request

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -554,7 +554,7 @@ def list_tasks():
     
     return jsonify({
         "success": True,
-        "data": [t.to_dict() for t in tasks],
+        "data": tasks,
         "count": len(tasks)
     })
 


### PR DESCRIPTION
## Summary

Fixes #304

`TaskManager.list_tasks()` already returns dicts. The endpoint called `.to_dict()` again on plain dicts → `AttributeError` on every request.

## Fix

```diff
- "data": [t.to_dict() for t in tasks],
+ "data": tasks,
```

One line, one file.