### PR TITLE
Add allowedHosts to Vite server configuration

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
   server: {
     port: 3000,
     open: true,
+    allowedHosts: ['mirofish-cpj2-production-1046.up.railway.app'],
     proxy: {
       '/api': {
         target: 'http://localhost:5001',


### PR DESCRIPTION
Title: "Fix Vite allowedHosts for production domain"
Description: "Adds the Railway production domain to the list of allowed hosts"

标题：“修复 Vite 在生产域名中的 allowedHosts 设置”
描述：“将 Railway 的生产域名添加到允许的主机列表中”