### PR TITLE
feat(llm): add multi-provider LLM support (claude CLI, openai, ollama)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,30 @@
-# LLM API配置（支持 OpenAI SDK 格式的任意 LLM API）
-# 推荐使用阿里百炼平台qwen-plus模型：https://bailian.console.aliyun.com/
-# 注意消耗较大，可先进行小于40轮的模拟尝试
-LLM_API_KEY=your_api_key_here
-LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
-LLM_MODEL_NAME=qwen-plus
+# ===== LLM Provider =====
+# Supported values: claude (default), openai, ollama
+LLM_PROVIDER=claude
 
-# ===== ZEP记忆图谱配置 =====
-# 每月免费额度即可支撑简单使用：https://app.getzep.com/
+# ===== Claude CLI Settings (when LLM_PROVIDER=claude) =====
+# Path to the claude CLI binary (default: "claude", found via PATH)
+# CLAUDE_CLI_PATH=claude
+# Model name for claude CLI (default: sonnet)
+LLM_MODEL_NAME=sonnet
+
+# ===== OpenAI Settings (when LLM_PROVIDER=openai) =====
+# LLM_PROVIDER=openai
+# LLM_API_KEY=your_api_key_here
+# LLM_BASE_URL=https://api.openai.com/v1
+# LLM_MODEL_NAME=gpt-4o-mini
+
+# ===== Ollama Settings (when LLM_PROVIDER=ollama) =====
+# LLM_PROVIDER=ollama
+# LLM_BASE_URL=http://localhost:11434/v1
+# LLM_MODEL_NAME=llama3
+
+# ===== Zep Memory Graph Settings =====
+# Free monthly quota is sufficient for basic usage: https://app.getzep.com/
 ZEP_API_KEY=your_zep_api_key_here
 
-# ===== 加速 LLM 配置（可选）=====
-# 注意如果不使用加速配置，env文件中就不要出现下面的配置项
+# ===== Boost LLM Settings (optional) =====
+# If not using boost config, do not include these variables
 LLM_BOOST_API_KEY=your_api_key_here
 LLM_BOOST_BASE_URL=your_base_url_here
 LLM_BOOST_MODEL_NAME=your_model_name_here

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,54 +1,61 @@
 """
-配置管理
-统一从项目根目录的 .env 文件加载配置
+Configuration management
+Loads configuration from the .env file at the project root
 """
 
 import os
+import shutil
 from dotenv import load_dotenv
 
-# 加载项目根目录的 .env 文件
-# 路径: MiroFish/.env (相对于 backend/app/config.py)
+# Load .env from the project root
+# Path: MiroFish/.env (relative to backend/app/config.py)
 project_root_env = os.path.join(os.path.dirname(__file__), '../../.env')
 
 if os.path.exists(project_root_env):
     load_dotenv(project_root_env, override=True)
 else:
-    # 如果根目录没有 .env，尝试加载环境变量（用于生产环境）
+    # If no .env at root, try loading environment variables (for production)
     load_dotenv(override=True)
 
 
 class Config:
-    """Flask配置类"""
-    
-    # Flask配置
+    """Flask configuration class"""
+
+    # Flask settings
     SECRET_KEY = os.environ.get('SECRET_KEY', 'mirofish-secret-key')
     DEBUG = os.environ.get('FLASK_DEBUG', 'True').lower() == 'true'
-    
-    # JSON配置 - 禁用ASCII转义，让中文直接显示（而不是 \uXXXX 格式）
+
+    # JSON settings - disable ASCII escaping so non-ASCII characters display correctly
     JSON_AS_ASCII = False
-    
-    # LLM配置（统一使用OpenAI格式）
+
+    # LLM provider: "claude" (default), "openai", or "ollama"
+    LLM_PROVIDER = os.environ.get('LLM_PROVIDER', 'claude')
+
+    # LLM settings
     LLM_API_KEY = os.environ.get('LLM_API_KEY')
     LLM_BASE_URL = os.environ.get('LLM_BASE_URL', 'https://api.openai.com/v1')
-    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'gpt-4o-mini')
-    
-    # Zep配置
+    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'sonnet')
+
+    # Claude CLI path (only used when LLM_PROVIDER=claude)
+    CLAUDE_CLI_PATH = os.environ.get('CLAUDE_CLI_PATH', 'claude')
+
+    # Zep settings
     ZEP_API_KEY = os.environ.get('ZEP_API_KEY')
-    
-    # 文件上传配置
+
+    # File upload settings
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50MB
     UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), '../uploads')
     ALLOWED_EXTENSIONS = {'pdf', 'md', 'txt', 'markdown'}
-    
-    # 文本处理配置
-    DEFAULT_CHUNK_SIZE = 500  # 默认切块大小
-    DEFAULT_CHUNK_OVERLAP = 50  # 默认重叠大小
-    
-    # OASIS模拟配置
+
+    # Text processing settings
+    DEFAULT_CHUNK_SIZE = 500
+    DEFAULT_CHUNK_OVERLAP = 50
+
+    # OASIS simulation settings
     OASIS_DEFAULT_MAX_ROUNDS = int(os.environ.get('OASIS_DEFAULT_MAX_ROUNDS', '10'))
     OASIS_SIMULATION_DATA_DIR = os.path.join(os.path.dirname(__file__), '../uploads/simulations')
-    
-    # OASIS平台可用动作配置
+
+    # OASIS platform available actions
     OASIS_TWITTER_ACTIONS = [
         'CREATE_POST', 'LIKE_POST', 'REPOST', 'FOLLOW', 'DO_NOTHING', 'QUOTE_POST'
     ]
@@ -57,19 +64,41 @@ class Config:
         'LIKE_COMMENT', 'DISLIKE_COMMENT', 'SEARCH_POSTS', 'SEARCH_USER',
         'TREND', 'REFRESH', 'DO_NOTHING', 'FOLLOW', 'MUTE'
     ]
-    
-    # Report Agent配置
+
+    # Report Agent settings
     REPORT_AGENT_MAX_TOOL_CALLS = int(os.environ.get('REPORT_AGENT_MAX_TOOL_CALLS', '5'))
     REPORT_AGENT_MAX_REFLECTION_ROUNDS = int(os.environ.get('REPORT_AGENT_MAX_REFLECTION_ROUNDS', '2'))
     REPORT_AGENT_TEMPERATURE = float(os.environ.get('REPORT_AGENT_TEMPERATURE', '0.5'))
-    
+
     @classmethod
     def validate(cls):
-        """验证必要配置"""
+        """Validate required configuration."""
+        import logging
+        log = logging.getLogger('mirofish.config')
         errors = []
-        if not cls.LLM_API_KEY:
-            errors.append("LLM_API_KEY 未配置")
-        if not cls.ZEP_API_KEY:
-            errors.append("ZEP_API_KEY 未配置")
-        return errors
 
+        provider = cls.LLM_PROVIDER
+
+        if provider == "claude":
+            if shutil.which(cls.CLAUDE_CLI_PATH) is None:
+                errors.append(
+                    f"Claude CLI not found at '{cls.CLAUDE_CLI_PATH}'. "
+                    "Install it or set CLAUDE_CLI_PATH."
+                )
+        elif provider == "openai":
+            if not cls.LLM_API_KEY:
+                errors.append("LLM_API_KEY is not configured (required for openai provider)")
+        elif provider == "ollama":
+            if cls.LLM_BASE_URL and "11434" not in cls.LLM_BASE_URL:
+                log.warning(
+                    "LLM_BASE_URL (%s) does not contain port 11434; "
+                    "make sure Ollama is reachable.",
+                    cls.LLM_BASE_URL,
+                )
+        else:
+            errors.append(f"Unknown LLM_PROVIDER: '{provider}' (expected claude, openai, or ollama)")
+
+        if not cls.ZEP_API_KEY:
+            errors.append("ZEP_API_KEY is not configured")
+
+        return errors

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1,9 +1,9 @@
 """
-工具模块
+Utility modules
 """
 
 from .file_parser import FileParser
-from .llm_client import LLMClient
+from .llm_client import LLMClient, LLMError
 
-__all__ = ['FileParser', 'LLMClient']
+__all__ = ['FileParser', 'LLMClient', 'LLMError']
 

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -1,37 +1,209 @@
 """
-LLM客户端封装
-统一使用OpenAI格式调用
+LLM client wrapper
+Supports claude CLI, OpenAI SDK, and Ollama HTTP providers
 """
 
 import json
 import re
+import subprocess
 from typing import Optional, Dict, Any, List
-from openai import OpenAI
 
 from ..config import Config
+from ..utils.logger import get_logger
+
+logger = get_logger('mirofish.llm_client')
+
+
+class LLMError(ValueError):
+    """Exception raised for LLM-related errors.
+
+    Extends ValueError for backward compatibility with existing callers
+    that catch ValueError from the old LLMClient API.
+    """
+    pass
 
 
 class LLMClient:
-    """LLM客户端"""
-    
+    """Unified LLM client supporting multiple providers."""
+
     def __init__(
         self,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
-        model: Optional[str] = None
+        model: Optional[str] = None,
+        provider: Optional[str] = None
     ):
+        self.provider = provider or Config.LLM_PROVIDER
+        self.model = model or Config.LLM_MODEL_NAME
         self.api_key = api_key or Config.LLM_API_KEY
         self.base_url = base_url or Config.LLM_BASE_URL
-        self.model = model or Config.LLM_MODEL_NAME
-        
-        if not self.api_key:
-            raise ValueError("LLM_API_KEY 未配置")
-        
-        self.client = OpenAI(
-            api_key=self.api_key,
+        self._openai_client = None
+
+        if self.provider == "openai":
+            if not self.api_key:
+                raise LLMError("LLM_API_KEY is not configured (required for openai provider)")
+            self._init_openai_client()
+        elif self.provider == "ollama":
+            self._init_openai_client()
+
+    def _init_openai_client(self):
+        """Initialize the OpenAI SDK client (used by openai and ollama providers)."""
+        from openai import OpenAI
+        self._openai_client = OpenAI(
+            api_key=self.api_key or "ollama",
             base_url=self.base_url
         )
-    
+
+    def _flatten_messages(self, messages: List[Dict[str, str]]) -> tuple[str, str]:
+        """
+        Convert multi-turn messages into a single system prompt and user prompt.
+
+        Extracts system messages as the system prompt.
+        Remaining messages are formatted as:
+            [User]
+            content
+
+            [Assistant]
+            content
+
+        Returns:
+            Tuple of (system_prompt, user_prompt)
+        """
+        system_parts = []
+        conversation_parts = []
+
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            if role == "system":
+                system_parts.append(content)
+            elif role == "assistant":
+                conversation_parts.append(f"[Assistant]\n{content}")
+            else:
+                conversation_parts.append(f"[User]\n{content}")
+
+        system_prompt = "\n\n".join(system_parts)
+        user_prompt = "\n\n".join(conversation_parts)
+        return system_prompt, user_prompt
+
+    @staticmethod
+    def _clean_response(content: str) -> str:
+        """Remove <think> tags and strip the response."""
+        content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
+        return content
+
+    @staticmethod
+    def _clean_json_response(content: str) -> str:
+        """Remove markdown code fences from JSON responses."""
+        cleaned = content.strip()
+        cleaned = re.sub(r'^```(?:json)?\s*\n?', '', cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r'\n?```\s*$', '', cleaned)
+        return cleaned.strip()
+
+    # ── Claude CLI provider ──────────────────────────────────────────
+
+    def _claude_chat(
+        self,
+        messages: List[Dict[str, str]],
+        max_tokens: int = 4096,
+        **kwargs
+    ) -> str:
+        """Send a chat request via the claude CLI."""
+        system_prompt, user_prompt = self._flatten_messages(messages)
+
+        cmd = [
+            Config.CLAUDE_CLI_PATH,
+            "-p",
+            "--bare",
+            "--output-format", "json",
+        ]
+
+        if system_prompt:
+            cmd.extend(["--system-prompt", system_prompt])
+
+        if self.model:
+            cmd.extend(["--model", self.model])
+
+        logger.debug("Claude CLI command: %s", " ".join(cmd))
+
+        try:
+            result = subprocess.run(
+                cmd,
+                input=user_prompt,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        except subprocess.TimeoutExpired:
+            raise LLMError("Claude CLI timed out after 300 seconds")
+        except FileNotFoundError:
+            raise LLMError(
+                f"Claude CLI not found at '{Config.CLAUDE_CLI_PATH}'. "
+                "Install it or set CLAUDE_CLI_PATH."
+            )
+
+        if result.returncode != 0:
+            stderr = result.stderr.strip() if result.stderr else "(no stderr)"
+            raise LLMError(f"Claude CLI returned exit code {result.returncode}: {stderr}")
+
+        stdout = result.stdout.strip()
+        if not stdout:
+            raise LLMError("Claude CLI returned empty output")
+
+        # Parse JSON envelope
+        try:
+            envelope = json.loads(stdout)
+        except json.JSONDecodeError:
+            # If not valid JSON, treat raw stdout as the response text
+            logger.warning("Claude CLI output is not JSON, using raw text")
+            return self._clean_response(stdout)
+
+        if isinstance(envelope, dict):
+            if envelope.get("is_error"):
+                raise LLMError(f"Claude CLI error: {envelope.get('result', 'unknown error')}")
+            text = envelope.get("result", stdout)
+        else:
+            text = stdout
+
+        return self._clean_response(str(text))
+
+    # ── OpenAI SDK provider ──────────────────────────────────────────
+
+    def _openai_chat(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+        response_format: Optional[Dict] = None
+    ) -> str:
+        """Send a chat request via the OpenAI SDK."""
+        kwargs = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        if response_format:
+            kwargs["response_format"] = response_format
+
+        response = self._openai_client.chat.completions.create(**kwargs)
+        content = response.choices[0].message.content
+        return self._clean_response(content)
+
+    # ── Ollama provider (uses OpenAI-compatible endpoint) ────────────
+
+    def _ollama_chat(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+        response_format: Optional[Dict] = None
+    ) -> str:
+        """Send a chat request to Ollama via the OpenAI-compatible API."""
+        return self._openai_chat(messages, temperature, max_tokens, response_format)
+
+    # ── Public API ───────────────────────────────────────────────────
+
     def chat(
         self,
         messages: List[Dict[str, str]],
@@ -40,33 +212,24 @@ class LLMClient:
         response_format: Optional[Dict] = None
     ) -> str:
         """
-        发送聊天请求
-        
+        Send a chat request.
+
         Args:
-            messages: 消息列表
-            temperature: 温度参数
-            max_tokens: 最大token数
-            response_format: 响应格式（如JSON模式）
-            
+            messages: List of message dicts with 'role' and 'content'.
+            temperature: Temperature parameter (ignored for claude provider).
+            max_tokens: Maximum tokens for the response.
+            response_format: Response format hint (e.g. {"type": "json_object"}).
+
         Returns:
-            模型响应文本
+            Model response text.
         """
-        kwargs = {
-            "model": self.model,
-            "messages": messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-        }
-        
-        if response_format:
-            kwargs["response_format"] = response_format
-        
-        response = self.client.chat.completions.create(**kwargs)
-        content = response.choices[0].message.content
-        # 部分模型（如MiniMax M2.5）会在content中包含<think>思考内容，需要移除
-        content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
-        return content
-    
+        if self.provider == "claude":
+            return self._claude_chat(messages, max_tokens=max_tokens)
+        elif self.provider == "ollama":
+            return self._ollama_chat(messages, temperature, max_tokens, response_format)
+        else:
+            return self._openai_chat(messages, temperature, max_tokens, response_format)
+
     def chat_json(
         self,
         messages: List[Dict[str, str]],
@@ -74,30 +237,36 @@ class LLMClient:
         max_tokens: int = 4096
     ) -> Dict[str, Any]:
         """
-        发送聊天请求并返回JSON
-        
+        Send a chat request and return parsed JSON.
+
         Args:
-            messages: 消息列表
-            temperature: 温度参数
-            max_tokens: 最大token数
-            
+            messages: List of message dicts with 'role' and 'content'.
+            temperature: Temperature parameter (ignored for claude provider).
+            max_tokens: Maximum tokens for the response.
+
         Returns:
-            解析后的JSON对象
+            Parsed JSON object.
         """
-        response = self.chat(
-            messages=messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            response_format={"type": "json_object"}
-        )
-        # 清理markdown代码块标记
-        cleaned_response = response.strip()
-        cleaned_response = re.sub(r'^```(?:json)?\s*\n?', '', cleaned_response, flags=re.IGNORECASE)
-        cleaned_response = re.sub(r'\n?```\s*$', '', cleaned_response)
-        cleaned_response = cleaned_response.strip()
+        if self.provider == "claude":
+            # For claude, append JSON instruction to the last user message
+            messages = [m.copy() for m in messages]
+            for i in range(len(messages) - 1, -1, -1):
+                if messages[i].get("role") != "system":
+                    messages[i]["content"] += (
+                        "\n\nRespond with valid JSON only, no markdown code fences."
+                    )
+                    break
+            response = self._claude_chat(messages, max_tokens=max_tokens)
+        else:
+            response = self.chat(
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                response_format={"type": "json_object"}
+            )
 
+        cleaned = self._clean_json_response(response)
         try:
-            return json.loads(cleaned_response)
+            return json.loads(cleaned)
         except json.JSONDecodeError:
-            raise ValueError(f"LLM返回的JSON格式无效: {cleaned_response}")
-
+            raise LLMError(f"Invalid JSON returned by LLM: {cleaned[:500]}")


### PR DESCRIPTION
## Summary
- Rewrite `LLMClient` to support three providers via `LLM_PROVIDER` config: `claude` (default, uses CLI subprocess), `openai` (existing SDK path), and `ollama` (OpenAI-compatible HTTP)
- Add `LLMError` exception class (extends `ValueError` for backward compatibility), `_flatten_messages()` helper, and provider-aware dispatch in `chat()`/`chat_json()`
- Update `Config` with `LLM_PROVIDER`, `CLAUDE_CLI_PATH`, and provider-specific validation in `validate()`
- Translate all Chinese comments, docstrings, and error messages to English across `llm_client.py`, `config.py`, `.env.example`, and `utils/__init__.py`

## Test plan
- [x] `from app.utils.llm_client import LLMClient` imports successfully
- [x] `py_compile` passes for both `llm_client.py` and `config.py`
- [x] No Chinese characters remaining in modified files
- [x] `LLMError` is a subclass of `ValueError` (backward compat verified)
- [x] `_flatten_messages()` correctly separates system/user/assistant messages
- [x] `_clean_response()` removes `<think>` tags
- [x] `_clean_json_response()` removes markdown code fences

🤖 Generated with [Claude Code](https://claude.com/claude-code)