### PR TITLE
feat: add GitHub Copilot as LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,18 @@ LLM_API_KEY=your_api_key_here
 LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 LLM_MODEL_NAME=qwen-plus
 
+# ===== GitHub Copilot 作为 LLM 后端（可选替代方案）=====
+# 如果你有 GitHub Copilot 订阅，可以直接用它来驱动 MiroFish，无需单独的 LLM API Key
+# 设置方法：
+#   1. 设置 LLM_PROVIDER=github-copilot
+#   2. 设置 GITHUB_TOKEN（或 GH_TOKEN / COPILOT_GITHUB_TOKEN）
+#   3. 无需填写 LLM_API_KEY 和 LLM_BASE_URL（会自动通过 token 交换获取）
+#   4. LLM_MODEL_NAME 可设置为 Copilot 支持的模型（如 gpt-4o, claude-sonnet-4.5 等）
+#
+# LLM_PROVIDER=github-copilot
+# GITHUB_TOKEN=ghp_your_github_token_here
+# LLM_MODEL_NAME=gpt-4o
+
 # ===== ZEP记忆图谱配置 =====
 # 每月免费额度即可支撑简单使用：https://app.getzep.com/
 ZEP_API_KEY=your_zep_api_key_here

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -32,6 +32,10 @@ class Config:
     LLM_BASE_URL = os.environ.get('LLM_BASE_URL', 'https://api.openai.com/v1')
     LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'gpt-4o-mini')
     
+    # LLM Provider 选择（可选：'default' 或 'github-copilot'）
+    # 设置为 'github-copilot' 可直接使用 GitHub Copilot 订阅作为 LLM 后端
+    LLM_PROVIDER = os.environ.get('LLM_PROVIDER', 'default')
+    
     # Zep配置
     ZEP_API_KEY = os.environ.get('ZEP_API_KEY')
     

--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -13,6 +13,7 @@ import random
 import time
 from typing import Dict, Any, List, Optional
 from dataclasses import dataclass, field
+from ..utils.copilot_auth import is_copilot_provider, get_copilot_token_manager, COPILOT_REQUEST_HEADERS
 from datetime import datetime
 
 from openai import OpenAI
@@ -185,17 +186,29 @@ class OasisProfileGenerator:
         zep_api_key: Optional[str] = None,
         graph_id: Optional[str] = None
     ):
-        self.api_key = api_key or Config.LLM_API_KEY
-        self.base_url = base_url or Config.LLM_BASE_URL
+        # 支持 GitHub Copilot 作为 LLM 后端
+        if not api_key and is_copilot_provider():
+            mgr = get_copilot_token_manager()
+            self.api_key = mgr.get_api_key()
+            self.base_url = base_url or mgr.get_base_url()
+            self._copilot_mode = True
+        else:
+            self.api_key = api_key or Config.LLM_API_KEY
+            self.base_url = base_url or Config.LLM_BASE_URL
+            self._copilot_mode = False
         self.model_name = model_name or Config.LLM_MODEL_NAME
         
         if not self.api_key:
             raise ValueError("LLM_API_KEY 未配置")
         
-        self.client = OpenAI(
-            api_key=self.api_key,
-            base_url=self.base_url
-        )
+        client_kwargs = {"api_key": self.api_key, "base_url": self.base_url}
+        if self._copilot_mode:
+            client_kwargs["default_headers"] = {
+                "Editor-Version": COPILOT_REQUEST_HEADERS["Editor-Version"],
+                "User-Agent": COPILOT_REQUEST_HEADERS["User-Agent"],
+                "X-Github-Api-Version": COPILOT_REQUEST_HEADERS["X-Github-Api-Version"],
+            }
+        self.client = OpenAI(**client_kwargs)
         
         # Zep客户端用于检索丰富上下文
         self.zep_api_key = zep_api_key or Config.ZEP_API_KEY

--- a/backend/app/services/simulation_config_generator.py
+++ b/backend/app/services/simulation_config_generator.py
@@ -13,6 +13,7 @@
 import json
 import math
 from typing import Dict, Any, List, Optional, Callable
+from ..utils.copilot_auth import is_copilot_provider, get_copilot_token_manager, COPILOT_REQUEST_HEADERS
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
 
@@ -227,17 +228,29 @@ class SimulationConfigGenerator:
         base_url: Optional[str] = None,
         model_name: Optional[str] = None
     ):
-        self.api_key = api_key or Config.LLM_API_KEY
-        self.base_url = base_url or Config.LLM_BASE_URL
+        # 支持 GitHub Copilot 作为 LLM 后端
+        if not api_key and is_copilot_provider():
+            mgr = get_copilot_token_manager()
+            self.api_key = mgr.get_api_key()
+            self.base_url = base_url or mgr.get_base_url()
+            self._copilot_mode = True
+        else:
+            self.api_key = api_key or Config.LLM_API_KEY
+            self.base_url = base_url or Config.LLM_BASE_URL
+            self._copilot_mode = False
         self.model_name = model_name or Config.LLM_MODEL_NAME
         
         if not self.api_key:
             raise ValueError("LLM_API_KEY 未配置")
         
-        self.client = OpenAI(
-            api_key=self.api_key,
-            base_url=self.base_url
-        )
+        client_kwargs = {"api_key": self.api_key, "base_url": self.base_url}
+        if self._copilot_mode:
+            client_kwargs["default_headers"] = {
+                "Editor-Version": COPILOT_REQUEST_HEADERS["Editor-Version"],
+                "User-Agent": COPILOT_REQUEST_HEADERS["User-Agent"],
+                "X-Github-Api-Version": COPILOT_REQUEST_HEADERS["X-Github-Api-Version"],
+            }
+        self.client = OpenAI(**client_kwargs)
     
     def generate_config(
         self,

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -4,6 +4,7 @@
 
 from .file_parser import FileParser
 from .llm_client import LLMClient
+from .copilot_auth import is_copilot_provider, CopilotTokenManager
 
-__all__ = ['FileParser', 'LLMClient']
+__all__ = ['FileParser', 'LLMClient', 'is_copilot_provider', 'CopilotTokenManager']
 

--- a/backend/app/utils/copilot_auth.py
+++ b/backend/app/utils/copilot_auth.py
@@ -1,0 +1,304 @@
+"""
+GitHub Copilot Token Exchange
+Exchanges a GitHub token for a short-lived Copilot API token,
+enabling use of GitHub Copilot subscription as an LLM provider.
+
+Auth flow (mirrors OpenClaw's github-copilot extension):
+  1. Take a GitHub token (PAT, GH_TOKEN, GITHUB_TOKEN, etc.)
+  2. POST to api.github.com/copilot_internal/v2/token → short-lived Copilot token + proxy-ep
+  3. Derive the OpenAI-compatible base URL from proxy-ep
+  4. Cache token locally, auto-refresh when expired
+"""
+
+import os
+import json
+import re
+import time
+import threading
+from typing import Optional, Dict, Any
+
+from .logger import get_logger
+
+logger = get_logger('mirofish.copilot_auth')
+
+# GitHub Copilot internal token exchange endpoint
+COPILOT_TOKEN_URL = "https://api.github.com/copilot_internal/v2/token"
+
+# Default base URL when proxy-ep cannot be derived
+DEFAULT_COPILOT_API_BASE_URL = "https://api.individual.githubcopilot.com"
+
+# Safety margin: refresh token 5 minutes before expiry
+TOKEN_REFRESH_MARGIN_SECONDS = 5 * 60
+
+# Headers to mimic a Copilot client (required by the API)
+COPILOT_REQUEST_HEADERS = {
+    "Accept": "application/json",
+    "Editor-Version": "vscode/1.96.2",
+    "User-Agent": "GitHubCopilotChat/0.26.7",
+    "X-Github-Api-Version": "2025-04-01",
+}
+
+
+class CopilotTokenManager:
+    """
+    Manages GitHub Copilot API token lifecycle:
+    - Exchange GitHub token for Copilot API token
+    - Cache token in memory and optionally on disk
+    - Auto-refresh before expiry
+    - Thread-safe access
+
+    Usage:
+        manager = CopilotTokenManager(github_token="ghp_xxx")
+        api_key = manager.get_api_key()
+        base_url = manager.get_base_url()
+    """
+
+    def __init__(
+        self,
+        github_token: str,
+        cache_dir: Optional[str] = None,
+    ):
+        self._github_token = github_token
+        self._lock = threading.Lock()
+
+        # In-memory cache
+        self._cached_token: Optional[str] = None
+        self._cached_base_url: str = DEFAULT_COPILOT_API_BASE_URL
+        self._expires_at: float = 0  # epoch seconds
+
+        # Disk cache path
+        if cache_dir:
+            os.makedirs(cache_dir, exist_ok=True)
+            self._cache_path = os.path.join(cache_dir, "copilot-token.json")
+        else:
+            self._cache_path = None
+
+        # Try loading from disk cache on init
+        self._load_disk_cache()
+
+    def get_api_key(self) -> str:
+        """
+        Get a valid Copilot API token. Refreshes automatically if expired.
+        Thread-safe.
+        """
+        with self._lock:
+            if self._is_token_valid():
+                return self._cached_token
+        # Release lock during network call, then re-acquire to store
+        return self._refresh_token()
+
+    def get_base_url(self) -> str:
+        """
+        Get the Copilot API base URL (derived from the token's proxy-ep).
+        Ensures a valid token exists first.
+        """
+        # Ensure we have a valid token (which sets base_url)
+        self.get_api_key()
+        with self._lock:
+            return self._cached_base_url
+
+    def _is_token_valid(self) -> bool:
+        """Check if cached token is still usable (with safety margin)."""
+        if not self._cached_token:
+            return False
+        return time.time() < (self._expires_at - TOKEN_REFRESH_MARGIN_SECONDS)
+
+    def _refresh_token(self) -> str:
+        """Exchange GitHub token for a fresh Copilot API token."""
+        import urllib.request
+        import urllib.error
+
+        logger.info("Exchanging GitHub token for Copilot API token...")
+
+        headers = {
+            **COPILOT_REQUEST_HEADERS,
+            "Authorization": f"Bearer {self._github_token}",
+        }
+
+        req = urllib.request.Request(
+            COPILOT_TOKEN_URL,
+            method="GET",
+            headers=headers,
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace") if e.fp else ""
+            logger.error(
+                "Copilot token exchange failed: HTTP %d — %s", e.code, body
+            )
+            raise RuntimeError(
+                f"GitHub Copilot token exchange failed (HTTP {e.code}). "
+                "Ensure your GitHub token is valid and you have an active Copilot subscription."
+            ) from e
+        except Exception as e:
+            logger.error("Copilot token exchange error: %s", e)
+            raise RuntimeError(
+                f"GitHub Copilot token exchange failed: {e}"
+            ) from e
+
+        token = data.get("token", "")
+        expires_at_unix = data.get("expires_at", 0)
+
+        if not token:
+            raise RuntimeError(
+                "Copilot token exchange returned empty token. "
+                "Check your GitHub Copilot subscription status."
+            )
+
+        # expires_at from the API is in seconds since epoch
+        if isinstance(expires_at_unix, (int, float)):
+            expires_at = float(expires_at_unix)
+        else:
+            # Fallback: assume 30 minutes from now
+            expires_at = time.time() + 1800
+
+        base_url = self._derive_base_url_from_token(token)
+
+        with self._lock:
+            self._cached_token = token
+            self._expires_at = expires_at
+            self._cached_base_url = base_url
+
+        # Persist to disk
+        self._save_disk_cache(token, expires_at)
+
+        logger.info(
+            "Copilot token acquired (expires in %d min), base_url=%s",
+            int((expires_at - time.time()) / 60),
+            base_url,
+        )
+
+        return token
+
+    @staticmethod
+    def _derive_base_url_from_token(token: str) -> str:
+        """
+        Derive the OpenAI-compatible API base URL from the Copilot token.
+
+        The token contains semicolon-delimited key=value pairs.
+        The proxy-ep field indicates which proxy endpoint to use.
+        Convert proxy.* → api.* (matching OpenClaw's behavior).
+        """
+        match = re.search(r"(?:^|;)\s*proxy-ep=([^;\s]+)", token, re.IGNORECASE)
+        if not match:
+            return DEFAULT_COPILOT_API_BASE_URL
+
+        proxy_ep = match.group(1).strip()
+        if not proxy_ep:
+            return DEFAULT_COPILOT_API_BASE_URL
+
+        # Strip protocol, replace proxy. prefix with api.
+        host = re.sub(r"^https?://", "", proxy_ep)
+        host = re.sub(r"^proxy\.", "api.", host, flags=re.IGNORECASE)
+
+        if not host:
+            return DEFAULT_COPILOT_API_BASE_URL
+
+        return f"https://{host}"
+
+    def _load_disk_cache(self):
+        """Load cached token from disk if available and valid."""
+        if not self._cache_path or not os.path.exists(self._cache_path):
+            return
+        try:
+            with open(self._cache_path, "r") as f:
+                data = json.load(f)
+            token = data.get("token", "")
+            expires_at = data.get("expires_at", 0)
+            if token and time.time() < (expires_at - TOKEN_REFRESH_MARGIN_SECONDS):
+                self._cached_token = token
+                self._expires_at = expires_at
+                self._cached_base_url = self._derive_base_url_from_token(token)
+                logger.debug("Loaded Copilot token from disk cache")
+        except Exception as e:
+            logger.debug("Could not load Copilot token cache: %s", e)
+
+    def _save_disk_cache(self, token: str, expires_at: float):
+        """Persist token to disk for cross-process reuse."""
+        if not self._cache_path:
+            return
+        try:
+            data = {
+                "token": token,
+                "expires_at": expires_at,
+                "updated_at": time.time(),
+            }
+            with open(self._cache_path, "w") as f:
+                json.dump(data, f)
+            logger.debug("Saved Copilot token to disk cache")
+        except Exception as e:
+            logger.debug("Could not save Copilot token cache: %s", e)
+
+
+def resolve_github_token() -> Optional[str]:
+    """
+    Resolve a GitHub token from environment variables.
+    Checks (in priority order): COPILOT_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN.
+    Returns None if no token is found.
+    """
+    for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        token = os.environ.get(var, "").strip()
+        if token:
+            logger.debug("Resolved GitHub token from %s", var)
+            return token
+    return None
+
+
+def is_copilot_provider() -> bool:
+    """
+    Check if the user has configured GitHub Copilot as their LLM provider.
+    Returns True if LLM_PROVIDER is set to 'github-copilot' or
+    if a GitHub token is available and no LLM_API_KEY is set.
+    """
+    provider = os.environ.get("LLM_PROVIDER", "").strip().lower()
+    if provider == "github-copilot":
+        return True
+
+    # Auto-detect: if no LLM_API_KEY but a GitHub token exists
+    llm_key = os.environ.get("LLM_API_KEY", "").strip()
+    if not llm_key and resolve_github_token():
+        return True
+
+    return False
+
+
+# Module-level singleton (lazy-initialized)
+_token_manager: Optional[CopilotTokenManager] = None
+_manager_lock = threading.Lock()
+
+
+def get_copilot_token_manager() -> CopilotTokenManager:
+    """
+    Get or create the singleton CopilotTokenManager.
+    Thread-safe lazy initialization.
+    """
+    global _token_manager
+    if _token_manager is not None:
+        return _token_manager
+
+    with _manager_lock:
+        if _token_manager is not None:
+            return _token_manager
+
+        github_token = resolve_github_token()
+        if not github_token:
+            raise RuntimeError(
+                "GitHub Copilot provider is enabled but no GitHub token found. "
+                "Set COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN in your .env file."
+            )
+
+        # Cache directory inside the backend data directory
+        cache_dir = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "uploads",
+            ".copilot-cache",
+        )
+
+        _token_manager = CopilotTokenManager(
+            github_token=github_token,
+            cache_dir=cache_dir,
+        )
+        return _token_manager

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -1,6 +1,7 @@
 """
 LLM客户端封装
 统一使用OpenAI格式调用
+支持 GitHub Copilot 作为 LLM 后端（自动token交换）
 """
 
 import json
@@ -9,10 +10,13 @@ from typing import Optional, Dict, Any, List
 from openai import OpenAI
 
 from ..config import Config
+from .copilot_auth import is_copilot_provider, get_copilot_token_manager
 
 
 class LLMClient:
-    """LLM客户端"""
+    """LLM客户端（支持标准 OpenAI API 和 GitHub Copilot）"""
+    
+    _copilot_mode: bool = False
     
     def __init__(
         self,
@@ -20,12 +24,24 @@ class LLMClient:
         base_url: Optional[str] = None,
         model: Optional[str] = None
     ):
-        self.api_key = api_key or Config.LLM_API_KEY
-        self.base_url = base_url or Config.LLM_BASE_URL
-        self.model = model or Config.LLM_MODEL_NAME
+        # 检测是否使用 GitHub Copilot 作为 LLM 后端
+        if not api_key and is_copilot_provider():
+            self._copilot_mode = True
+            mgr = get_copilot_token_manager()
+            self.api_key = mgr.get_api_key()
+            self.base_url = base_url or mgr.get_base_url()
+            self.model = model or Config.LLM_MODEL_NAME
+        else:
+            self._copilot_mode = False
+            self.api_key = api_key or Config.LLM_API_KEY
+            self.base_url = base_url or Config.LLM_BASE_URL
+            self.model = model or Config.LLM_MODEL_NAME
         
         if not self.api_key:
-            raise ValueError("LLM_API_KEY 未配置")
+            raise ValueError(
+                "LLM_API_KEY 未配置。请设置 LLM_API_KEY，"
+                "或设置 LLM_PROVIDER=github-copilot 并配置 GITHUB_TOKEN 以使用 Copilot。"
+            )
         
         self.client = OpenAI(
             api_key=self.api_key,
@@ -51,6 +67,10 @@ class LLMClient:
         Returns:
             模型响应文本
         """
+        # 如果使用 Copilot，自动刷新可能过期的 token
+        if self._copilot_mode:
+            self._refresh_copilot_client()
+        
         kwargs = {
             "model": self.model,
             "messages": messages,
@@ -66,6 +86,18 @@ class LLMClient:
         # 部分模型（如MiniMax M2.5）会在content中包含<think>思考内容，需要移除
         content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
         return content
+    
+    def _refresh_copilot_client(self):
+        """刷新 Copilot token（如果已过期），并重建 OpenAI 客户端"""
+        mgr = get_copilot_token_manager()
+        new_key = mgr.get_api_key()
+        if new_key != self.api_key:
+            self.api_key = new_key
+            self.base_url = mgr.get_base_url()
+            self.client = OpenAI(
+                api_key=self.api_key,
+                base_url=self.base_url
+            )
     
     def chat_json(
         self,

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -10,7 +10,7 @@ from typing import Optional, Dict, Any, List
 from openai import OpenAI
 
 from ..config import Config
-from .copilot_auth import is_copilot_provider, get_copilot_token_manager
+from .copilot_auth import is_copilot_provider, get_copilot_token_manager, COPILOT_REQUEST_HEADERS
 
 
 class LLMClient:
@@ -43,10 +43,21 @@ class LLMClient:
                 "或设置 LLM_PROVIDER=github-copilot 并配置 GITHUB_TOKEN 以使用 Copilot。"
             )
         
-        self.client = OpenAI(
-            api_key=self.api_key,
-            base_url=self.base_url
-        )
+        self.client = self._create_openai_client()
+    
+    def _create_openai_client(self) -> OpenAI:
+        """创建 OpenAI 客户端（Copilot 模式下附加必需的请求头）"""
+        kwargs = {
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+        }
+        if self._copilot_mode:
+            kwargs["default_headers"] = {
+                "Editor-Version": COPILOT_REQUEST_HEADERS["Editor-Version"],
+                "User-Agent": COPILOT_REQUEST_HEADERS["User-Agent"],
+                "X-Github-Api-Version": COPILOT_REQUEST_HEADERS["X-Github-Api-Version"],
+            }
+        return OpenAI(**kwargs)
     
     def chat(
         self,
@@ -94,10 +105,7 @@ class LLMClient:
         if new_key != self.api_key:
             self.api_key = new_key
             self.base_url = mgr.get_base_url()
-            self.client = OpenAI(
-                api_key=self.api_key,
-                base_url=self.base_url
-            )
+            self.client = self._create_openai_client()
     
     def chat_json(
         self,

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -1023,8 +1023,29 @@ def create_model(config: Dict[str, Any], use_boost: bool = False):
     if llm_api_key:
         os.environ["OPENAI_API_KEY"] = llm_api_key
     
+    # 支持 GitHub Copilot 作为 LLM 后端
     if not os.environ.get("OPENAI_API_KEY"):
-        raise ValueError("缺少 API Key 配置，请在项目根目录 .env 文件中设置 LLM_API_KEY")
+        try:
+            from app.utils.copilot_auth import is_copilot_provider, get_copilot_token_manager
+            if is_copilot_provider():
+                from app.utils.copilot_auth import COPILOT_REQUEST_HEADERS
+                mgr = get_copilot_token_manager()
+                os.environ["OPENAI_API_KEY"] = mgr.get_api_key()
+                llm_base_url = mgr.get_base_url()
+                # camel-ai 使用 openai SDK，需要设置必需的 Copilot 请求头
+                import openai
+                openai.default_headers = {
+                    "Editor-Version": COPILOT_REQUEST_HEADERS["Editor-Version"],
+                    "User-Agent": COPILOT_REQUEST_HEADERS["User-Agent"],
+                    "X-Github-Api-Version": COPILOT_REQUEST_HEADERS["X-Github-Api-Version"],
+                }
+                config_label = "[Copilot LLM]"
+                print(f"  → 使用 GitHub Copilot 作为 LLM 后端")
+        except Exception as e:
+            print(f"  Copilot 初始化失败: {e}")
+    
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise ValueError("缺少 API Key 配置，请在项目根目录 .env 文件中设置 LLM_API_KEY 或 LLM_PROVIDER=github-copilot")
     
     if llm_base_url:
         os.environ["OPENAI_API_BASE_URL"] = llm_base_url

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -453,8 +453,27 @@ class RedditSimulationRunner:
         if llm_api_key:
             os.environ["OPENAI_API_KEY"] = llm_api_key
         
+        # 支持 GitHub Copilot 作为 LLM 后端
         if not os.environ.get("OPENAI_API_KEY"):
-            raise ValueError("缺少 API Key 配置，请在项目根目录 .env 文件中设置 LLM_API_KEY")
+            try:
+                from app.utils.copilot_auth import is_copilot_provider, get_copilot_token_manager
+                if is_copilot_provider():
+                    from app.utils.copilot_auth import COPILOT_REQUEST_HEADERS
+                    mgr = get_copilot_token_manager()
+                    os.environ["OPENAI_API_KEY"] = mgr.get_api_key()
+                    llm_base_url = mgr.get_base_url()
+                    import openai
+                    openai.default_headers = {
+                        "Editor-Version": COPILOT_REQUEST_HEADERS["Editor-Version"],
+                        "User-Agent": COPILOT_REQUEST_HEADERS["User-Agent"],
+                        "X-Github-Api-Version": COPILOT_REQUEST_HEADERS["X-Github-Api-Version"],
+                    }
+                    print(f"  → 使用 GitHub Copilot 作为 LLM 后端")
+            except Exception as e:
+                print(f"  Copilot 初始化失败: {e}")
+        
+        if not os.environ.get("OPENAI_API_KEY"):
+            raise ValueError("缺少 API Key 配置，请在项目根目录 .env 文件中设置 LLM_API_KEY 或 LLM_PROVIDER=github-copilot")
         
         if llm_base_url:
             os.environ["OPENAI_API_BASE_URL"] = llm_base_url

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -446,8 +446,27 @@ class TwitterSimulationRunner:
         if llm_api_key:
             os.environ["OPENAI_API_KEY"] = llm_api_key
         
+        # 支持 GitHub Copilot 作为 LLM 后端
         if not os.environ.get("OPENAI_API_KEY"):
-            raise ValueError("缺少 API Key 配置，请在项目根目录 .env 文件中设置 LLM_API_KEY")
+            try:
+                from app.utils.copilot_auth import is_copilot_provider, get_copilot_token_manager
+                if is_copilot_provider():
+                    from app.utils.copilot_auth import COPILOT_REQUEST_HEADERS
+                    mgr = get_copilot_token_manager()
+                    os.environ["OPENAI_API_KEY"] = mgr.get_api_key()
+                    llm_base_url = mgr.get_base_url()
+                    import openai
+                    openai.default_headers = {
+                        "Editor-Version": COPILOT_REQUEST_HEADERS["Editor-Version"],
+                        "User-Agent": COPILOT_REQUEST_HEADERS["User-Agent"],
+                        "X-Github-Api-Version": COPILOT_REQUEST_HEADERS["X-Github-Api-Version"],
+                    }
+                    print(f"  → 使用 GitHub Copilot 作为 LLM 后端")
+            except Exception as e:
+                print(f"  Copilot 初始化失败: {e}")
+        
+        if not os.environ.get("OPENAI_API_KEY"):
+            raise ValueError("缺少 API Key 配置，请在项目根目录 .env 文件中设置 LLM_API_KEY 或 LLM_PROVIDER=github-copilot")
         
         if llm_base_url:
             os.environ["OPENAI_API_BASE_URL"] = llm_base_url


### PR DESCRIPTION
## Summary

Enable using a **GitHub Copilot subscription** to power MiroFish's LLM calls — no separate API key needed.

## Motivation

Many developers already have a GitHub Copilot subscription. This PR lets them use that same subscription to run MiroFish simulations, removing the need to set up and pay for a separate LLM API provider.

This uses the same token exchange mechanism as [OpenClaw](https://github.com/openclaw/openclaw)'s built-in `github-copilot` provider.

## How it works

1. Exchanges a GitHub token for a short-lived Copilot API token via `api.github.com/copilot_internal/v2/token`
2. Derives the OpenAI-compatible base URL from the token's `proxy-ep` field
3. Caches tokens in memory + on disk, auto-refreshes before expiry
4. Thread-safe for concurrent simulation agent calls
5. **Zero changes needed** for existing users — only activates when `LLM_PROVIDER=github-copilot` is set (or when no `LLM_API_KEY` exists but a GitHub token is detected)

## Configuration

```env
LLM_PROVIDER=github-copilot
GITHUB_TOKEN=ghp_xxx
LLM_MODEL_NAME=gpt-4o
```

Also supports `GH_TOKEN` and `COPILOT_GITHUB_TOKEN` env vars (priority: `COPILOT_GITHUB_TOKEN` > `GH_TOKEN` > `GITHUB_TOKEN`).

## Files changed

| File | Change |
|------|--------|
| `backend/app/utils/copilot_auth.py` | **NEW** — Token exchange, caching, auto-refresh |
| `backend/app/utils/llm_client.py` | Copilot auto-detection + token refresh before each call |
| `backend/app/config.py` | Added `LLM_PROVIDER` config key |
| `backend/app/utils/__init__.py` | Export new module |
| `.env.example` | Copilot setup instructions |

## Notes

- Uses only stdlib `urllib` for the token exchange (no new dependencies)
- Copilot models available depend on the user's plan (Free/Pro/Business/Enterprise)
- Rate limits are lower than dedicated LLM APIs — users should start with small simulations (<40 rounds)
- The `copilot_internal` API is undocumented but stable (used by VS Code Copilot + OpenClaw)