### PR TITLE
docs: add GitHub-native citation support

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use MiroFish in academic work, please cite the repository and, when relevant, the specific release you used."
+title: "MiroFish"
+type: software
+authors:
+  - family-names: "BaiFu"
+abstract: "A simple and universal swarm intelligence engine for simulation, prediction, and multi-agent interaction."
+repository-code: "https://github.com/666ghj/MiroFish"
+url: "https://github.com/666ghj/MiroFish"
+license: "AGPL-3.0-only"
+version: "v0.1.2"
+date-released: "2026-03-07"
+keywords:
+  - MiroFish
+  - swarm intelligence
+  - multi-agent systems
+  - simulation
+  - prediction
+  - LLM

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -186,6 +186,17 @@ docker compose up -d
 
 MiroFish团队长期招募全职/实习，如果你对多Agent应用感兴趣，欢迎投递简历至：**mirofish@shanda.com**
 
+## 📚 如何引用
+
+如果你在学术研究、学位论文或软件报告中使用了 MiroFish，建议通过 GitHub 的 **Cite this repository** 功能引用本仓库。
+
+建议保留以下引用信息：
+- 项目名称：**MiroFish**
+- 仓库地址：`https://github.com/666ghj/MiroFish`
+- 版本：`v0.1.2`
+
+如果你的工作依赖某个具体 release，建议在引用中明确写出对应版本号。
+
 ## 📄 致谢
 
 **MiroFish 得到了盛大集团的战略支持和孵化！**

--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ Reads `.env` from root directory by default, maps ports `3000 (frontend) / 5001 
 
 The MiroFish team is recruiting full-time/internship positions. If you're interested in multi-agent simulation and LLM applications, feel free to send your resume to: **mirofish@shanda.com**
 
+## 📚 How to Cite
+
+If you use MiroFish in academic research, theses, or software reports, please cite the repository using GitHub's **Cite this repository** feature.
+
+Suggested citation metadata:
+- Project: **MiroFish**
+- Repository: `https://github.com/666ghj/MiroFish`
+- Version: `v0.1.2`
+
+If your work depends on a specific release, please cite that release version explicitly.
+
 ## 📄 Acknowledgments
 
 **MiroFish has received strategic support and incubation from Shanda Group!**


### PR DESCRIPTION
This PR follows up on #323 and adds a small, documentation-only citation layer for MiroFish.

Changes:
- adds `CITATION.cff`
- adds a short "How to Cite / 如何引用" section to `README.md` and `README-ZH.md`

Why:
- improves software citation support for papers, theses, and technical reports
- enables GitHub's native repository citation UI
- keeps the change small and maintainable

Notes:
- documentation only
- no code changes
- no authorship changes
- no Zenodo dependency
- if a newer release exists before merge, the version/date in `CITATION.cff` can be updated accordingly
