### PR TITLE
Docs: Cross-platform backend dev launcher with automatic command fallback

### DIFF
--- a/scripts/dev-backend.js
+++ b/scripts/dev-backend.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform backend dev launcher.
+ * Tries launch commands in order: uv, python3, python, py
+ * so Windows users without uv can still run `npm run dev`.
+ */
+
+const { spawn } = require('child_process');
+const path = require('path');
+
+const backend_script = path.join(__dirname, '..', 'backend', 'run.py');
+
+const candidates = [
+    ['uv', ['run', 'python', backend_script]],
+    ['python3', [backend_script]],
+    ['python', [backend_script]],
+    ['py', [backend_script]],
+];
+
+function try_next(index) {
+    if (index >= candidates.length) {
+        console.error('No suitable Python interpreter found. Install uv, python3, python, or py.');
+        process.exit(1);
+    }
+
+    const [cmd, args] = candidates[index];
+    console.log(`Trying: ${cmd} ${args.join(' ')}`);
+
+    const child = spawn(cmd, args, {
+        stdio: 'inherit',
+        shell: process.platform === 'win32',
+    });
+
+    child.on('error', () => {
+        try_next(index + 1);
+    });
+
+    child.on('exit', (code) => {
+        if (code !== 0) {
+            process.exit(code);
+        }
+    });
+}
+
+try_next(0);


### PR DESCRIPTION
## Description

Add a small Node script that starts `backend/run.py` in a robust cross-platform way. It should detect and try backend launch commands in order, so Windows users can still use one command (`npm run dev`) even if `uv` is not installed but `python`/`py` is available.

## Changes

- `scripts/dev-backend.js` (new)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `high`


Closes #313