### PR TITLE
fix: restrict Python version to <3.13 to avoid tiktoken build failure

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mirofish-backend"
 version = "0.1.0"
 description = "MiroFish - 简洁通用的群体智能引擎，预测万物"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 license = { text = "AGPL-3.0" }
 authors = [
     { name = "MiroFish Team" }


### PR DESCRIPTION
Fixes #311

## Problem
`pyproject.toml` declares `requires-python = ">=3.11"` without an upper bound, implying Python 3.13 is supported. However, the `camel-ai==0.2.78` dependency pins `tiktoken==0.7.0`, which has no pre-built wheels for Python 3.13 and requires a Rust compiler to build from source. This results in a confusing build error with no clear explanation of the root cause.

## Solution
Add an explicit upper bound `<3.13` to the `requires-python` constraint in `backend/pyproject.toml`. This causes package managers (uv, pip) to immediately report a clear incompatibility error when Python 3.13 is used, instead of failing deep inside a Rust compilation step.

## Testing
- Verified the constraint change is accurate: `camel-ai==0.2.78` → `tiktoken==0.7.0` has no Python 3.13 wheels
- The fix matches the behavior described by the bot in #311 (Python ≤3.12 required)