### PR TITLE
feat(graph): Add world base enrich workflow

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -529,6 +529,190 @@ def build_graph():
         }), 500
 
 
+@graph_bp.route('/enrich', methods=['POST'])
+def enrich_graph():
+    """
+    将新的 overlay 文本注入到已有 graph 中，并为后续 simulation prepare
+    创建一个复用 graph_id 的派生项目。
+
+    请求（JSON）：
+        {
+            "project_id": "proj_base_xxxx",          // 必填，world base 对应项目
+            "graph_id": "mirofish_xxxx",             // 可选，不传则使用项目已有 graph_id
+            "project_name": "Overlay Project Name",  // 可选，派生项目名称
+            "overlay_text": "# Event Overlay ...",   // 必填，新的上下文种子
+            "simulation_requirement": "...",         // 可选，覆盖派生项目的模拟要求
+            "chunk_size": 500,                       // 可选
+            "chunk_overlap": 50,                     // 可选
+            "batch_size": 3                          // 可选
+        }
+    """
+    try:
+        logger.info("=== 开始 enrich graph ===")
+
+        if not Config.ZEP_API_KEY:
+            return jsonify({
+                "success": False,
+                "error": t('api.zepApiKeyMissing')
+            }), 500
+
+        data = request.get_json() or {}
+        base_project_id = data.get('project_id')
+        overlay_text = (data.get('overlay_text') or data.get('text') or '').strip()
+
+        if not base_project_id:
+            return jsonify({
+                "success": False,
+                "error": t('api.requireProjectId')
+            }), 400
+
+        if not overlay_text:
+            return jsonify({
+                "success": False,
+                "error": "overlay_text is required"
+            }), 400
+
+        base_project = ProjectManager.get_project(base_project_id)
+        if not base_project:
+            return jsonify({
+                "success": False,
+                "error": t('api.projectNotFound', id=base_project_id)
+            }), 404
+
+        graph_id = data.get('graph_id') or base_project.graph_id
+        if not graph_id:
+            return jsonify({
+                "success": False,
+                "error": t('api.graphNotBuilt')
+            }), 400
+
+        overlay_project = ProjectManager.create_derived_project(
+            base_project_id=base_project.project_id,
+            name=data.get('project_name') or f"{base_project.name} Overlay",
+            extracted_text=overlay_text,
+            simulation_requirement=data.get('simulation_requirement'),
+            seed_filename="overlay_seed.md"
+        )
+        overlay_project.graph_id = graph_id
+        ProjectManager.save_project(overlay_project)
+
+        chunk_size = data.get('chunk_size', base_project.chunk_size or Config.DEFAULT_CHUNK_SIZE)
+        chunk_overlap = data.get('chunk_overlap', base_project.chunk_overlap or Config.DEFAULT_CHUNK_OVERLAP)
+        batch_size = data.get('batch_size', 3)
+
+        task_manager = TaskManager()
+        task_id = task_manager.create_task(
+            task_type="graph_enrich",
+            metadata={
+                "project_id": overlay_project.project_id,
+                "base_project_id": base_project.project_id,
+                "graph_id": graph_id,
+                "text_length": len(overlay_text)
+            }
+        )
+        current_locale = get_locale()
+
+        def enrich_task():
+            set_locale(current_locale)
+            enrich_logger = get_logger('mirofish.enrich')
+            try:
+                task_manager.update_task(
+                    task_id,
+                    status=TaskStatus.PROCESSING,
+                    progress=5,
+                    message="Initializing graph enrichment"
+                )
+
+                builder = GraphBuilderService(api_key=Config.ZEP_API_KEY)
+                chunks = TextProcessor.split_text(
+                    overlay_text,
+                    chunk_size=chunk_size,
+                    overlap=chunk_overlap
+                )
+
+                task_manager.update_task(
+                    task_id,
+                    progress=15,
+                    message=f"Prepared {len(chunks)} overlay chunks"
+                )
+
+                def add_progress_callback(msg, progress_ratio):
+                    task_manager.update_task(
+                        task_id,
+                        progress=15 + int(progress_ratio * 50),
+                        message=msg
+                    )
+
+                episode_uuids = builder.add_text_batches(
+                    graph_id,
+                    chunks,
+                    batch_size=batch_size,
+                    progress_callback=add_progress_callback
+                )
+
+                task_manager.update_task(
+                    task_id,
+                    progress=70,
+                    message="Waiting for graph enrichment processing"
+                )
+
+                def wait_progress_callback(msg, progress_ratio):
+                    task_manager.update_task(
+                        task_id,
+                        progress=70 + int(progress_ratio * 25),
+                        message=msg
+                    )
+
+                builder._wait_for_episodes(episode_uuids, wait_progress_callback)
+
+                overlay_project.status = ProjectStatus.GRAPH_COMPLETED
+                overlay_project.graph_id = graph_id
+                ProjectManager.save_project(overlay_project)
+
+                enrich_logger.info(
+                    f"[{task_id}] Graph enrich completed: graph_id={graph_id}, project_id={overlay_project.project_id}"
+                )
+                task_manager.complete_task(task_id, {
+                    "project_id": overlay_project.project_id,
+                    "base_project_id": base_project.project_id,
+                    "graph_id": graph_id,
+                    "chunks_processed": len(chunks)
+                })
+            except Exception as e:
+                enrich_logger.error(f"[{task_id}] Graph enrich failed: {str(e)}")
+                enrich_logger.debug(traceback.format_exc())
+                overlay_project.status = ProjectStatus.FAILED
+                overlay_project.error = str(e)
+                ProjectManager.save_project(overlay_project)
+                task_manager.update_task(
+                    task_id,
+                    status=TaskStatus.FAILED,
+                    message=f"Graph enrich failed: {str(e)}",
+                    error=traceback.format_exc()
+                )
+
+        thread = threading.Thread(target=enrich_task, daemon=True)
+        thread.start()
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "project_id": overlay_project.project_id,
+                "base_project_id": base_project.project_id,
+                "graph_id": graph_id,
+                "task_id": task_id,
+                "message": "Graph enrichment task started"
+            }
+        })
+
+    except Exception as e:
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
+
+
 # ============== 任务查询接口 ==============
 
 @graph_bp.route('/task/<task_id>', methods=['GET'])

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -356,6 +356,52 @@ def _check_simulation_prepared(simulation_id: str) -> tuple:
         return False, {"reason": f"读取状态文件失败: {str(e)}"}
 
 
+def _recover_prepare_status_from_state(simulation_id: str) -> dict | None:
+    """
+    当 task_id 因服务重启丢失时，尝试从持久化 state.json 恢复 prepare 状态。
+    """
+    manager = SimulationManager()
+    state = manager.get_simulation(simulation_id)
+    if not state:
+        return None
+
+    status_value = state.status.value if hasattr(state.status, 'value') else str(state.status)
+    already_prepared = bool(
+        state.config_generated or status_value in {"ready", "running", "completed", "stopped", "failed"}
+    )
+    progress_by_status = {
+        "created": 0,
+        "preparing": 50,
+        "ready": 100,
+        "running": 100,
+        "completed": 100,
+        "stopped": 100,
+        "failed": 100
+    }
+
+    return {
+        "simulation_id": simulation_id,
+        "status": "ready" if already_prepared else status_value,
+        "progress": progress_by_status.get(status_value, 0),
+        "message": (
+            t('api.taskCompletedPrepared')
+            if already_prepared
+            else "Prepare task metadata was lost after restart; returning persisted simulation state."
+        ),
+        "already_prepared": already_prepared,
+        "prepare_info": {
+            "status": status_value,
+            "entities_count": state.entities_count,
+            "profiles_count": state.profiles_count,
+            "entity_types": state.entity_types,
+            "config_generated": state.config_generated,
+            "created_at": state.created_at,
+            "updated_at": state.updated_at,
+            "error": state.error
+        }
+    }
+
+
 @simulation_bp.route('/prepare', methods=['POST'])
 def prepare_simulation():
     """
@@ -729,6 +775,13 @@ def get_prepare_status():
                             "already_prepared": True,
                             "prepare_info": prepare_info
                         }
+                    })
+
+                recovered = _recover_prepare_status_from_state(simulation_id)
+                if recovered:
+                    return jsonify({
+                        "success": True,
+                        "data": recovered
                     })
             
             return jsonify({

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -277,6 +277,32 @@ class ProjectManager:
         text_path = cls._get_project_text_path(project_id)
         with open(text_path, 'w', encoding='utf-8') as f:
             f.write(text)
+
+    @classmethod
+    def save_text_file_to_project(
+        cls,
+        project_id: str,
+        filename: str,
+        text: str
+    ) -> Dict[str, str]:
+        """保存文本内容到项目文件目录"""
+        files_dir = cls._get_project_files_dir(project_id)
+        os.makedirs(files_dir, exist_ok=True)
+
+        safe_filename = filename or f"{uuid.uuid4().hex[:8]}.md"
+        file_path = os.path.join(files_dir, safe_filename)
+
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(text)
+
+        file_size = os.path.getsize(file_path)
+
+        return {
+            "original_filename": safe_filename,
+            "saved_filename": safe_filename,
+            "path": file_path,
+            "size": file_size
+        }
     
     @classmethod
     def get_extracted_text(cls, project_id: str) -> Optional[str]:
@@ -303,3 +329,55 @@ class ProjectManager:
             if os.path.isfile(os.path.join(files_dir, f))
         ]
 
+    @classmethod
+    def create_derived_project(
+        cls,
+        base_project_id: str,
+        name: str,
+        extracted_text: str,
+        simulation_requirement: Optional[str] = None,
+        seed_filename: str = "overlay_seed.md"
+    ) -> Project:
+        """
+        从已有项目派生一个轻量项目，复用同一个 graph_id 和 ontology。
+
+        该项目用于 event overlay / fast scenario 场景：
+        - 不重新生成 ontology
+        - 不重新构建 graph
+        - 保留独立的 extracted_text 和 simulation_requirement，供 prepare 阶段使用
+        """
+        base_project = cls.get_project(base_project_id)
+        if not base_project:
+            raise ValueError(f"Base project not found: {base_project_id}")
+
+        derived = cls.create_project(name=name or f"{base_project.name} Overlay")
+        derived.ontology = base_project.ontology
+        derived.analysis_summary = base_project.analysis_summary
+        derived.graph_id = base_project.graph_id
+        derived.chunk_size = base_project.chunk_size
+        derived.chunk_overlap = base_project.chunk_overlap
+        derived.simulation_requirement = (
+            simulation_requirement
+            if simulation_requirement is not None
+            else base_project.simulation_requirement
+        )
+        derived.status = (
+            ProjectStatus.GRAPH_COMPLETED
+            if base_project.graph_id
+            else ProjectStatus.ONTOLOGY_GENERATED
+        )
+
+        cls.save_extracted_text(derived.project_id, extracted_text)
+        file_info = cls.save_text_file_to_project(
+            derived.project_id,
+            filename=seed_filename,
+            text=extracted_text
+        )
+        derived.files.append({
+            "filename": file_info["original_filename"],
+            "size": file_info["size"]
+        })
+        derived.total_text_length = len(extracted_text)
+        cls.save_project(derived)
+
+        return derived


### PR DESCRIPTION
Add graph enrichment support for overlay-based scenarios so derived projects can reuse an existing graph instead of rebuilding from scratch.

Persist enough project state to recover prepare status after restarts, which keeps simulation orchestration traceable even when task IDs are lost.