### PR TITLE
fix: read VITE_API_BASE_URL from .env for Vite dev proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,9 @@ ZEP_API_KEY=your_zep_api_key_here
 LLM_BOOST_API_KEY=your_api_key_here
 LLM_BOOST_BASE_URL=your_base_url_here
 LLM_BOOST_MODEL_NAME=your_model_name_here
+
+# ===== 前端 / 部署配置（可选）=====
+# 后端 API 地址（axios 客户端 + Vite 开发代理均读取此变量）
+# 默认值：http://localhost:5001
+# 若后端运行在其他主机或端口，请取消注释并修改为对应地址
+# VITE_API_BASE_URL=http://localhost:5001

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,24 +1,29 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [vue()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, 'src'),
-      '@locales': path.resolve(__dirname, '../locales')
-    }
-  },
-  server: {
-    port: 3000,
-    open: true,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:5001',
-        changeOrigin: true,
-        secure: false
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, path.resolve(__dirname, '..'), '')
+  const backendUrl = env.VITE_API_BASE_URL || 'http://localhost:5001'
+
+  return {
+    plugins: [vue()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, 'src'),
+        '@locales': path.resolve(__dirname, '../locales')
+      }
+    },
+    server: {
+      port: 3000,
+      open: true,
+      proxy: {
+        '/api': {
+          target: backendUrl,
+          changeOrigin: true,
+          secure: false
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #480

## Problem

The Vite development proxy target in `frontend/vite.config.js` was hardcoded to `http://localhost:5001`. Even when users set `VITE_API_BASE_URL` in their `.env` file to point to a custom backend host or port, the dev proxy continued routing to `localhost:5001` — making the variable half-effective during development. Additionally, `VITE_API_BASE_URL` was absent from `.env.example`, so users had no way to discover that the variable existed.

## Solution

- **`frontend/vite.config.js`**: Switched from `defineConfig({})` to the function form `defineConfig(({ mode }) => { ... })` and used Vite's `loadEnv()` to read `VITE_API_BASE_URL` from the project root `.env` file. The proxy target now falls back to `http://localhost:5001` when the variable is unset, preserving existing default behaviour.
- **`.env.example`**: Added a commented-out `VITE_API_BASE_URL` entry with a short explanation, so users deploying on non-default hosts can discover and enable it without digging through source code.

## Testing

- Default behaviour (no `VITE_API_BASE_URL` set): proxy still targets `http://localhost:5001` — no regression.
- Custom host (e.g. `VITE_API_BASE_URL=http://192.168.1.100:5001` in `.env`): `npm run dev` now proxies API requests to the configured host, matching what the axios client already does at runtime.