### PR TITLE
fix: add max_items limit to fetch_all_edges to prevent unbounded memory growth

### DIFF
--- a/backend/app/utils/zep_paging.py
+++ b/backend/app/utils/zep_paging.py
@@ -19,6 +19,7 @@ logger = get_logger('mirofish.zep_paging')
 
 _DEFAULT_PAGE_SIZE = 100
 _MAX_NODES = 2000
+_MAX_EDGES = 5000
 _DEFAULT_MAX_RETRIES = 3
 _DEFAULT_RETRY_DELAY = 2.0  # seconds, doubles each retry
 
@@ -106,10 +107,11 @@ def fetch_all_edges(
     client: Zep,
     graph_id: str,
     page_size: int = _DEFAULT_PAGE_SIZE,
+    max_items: int = _MAX_EDGES,
     max_retries: int = _DEFAULT_MAX_RETRIES,
     retry_delay: float = _DEFAULT_RETRY_DELAY,
 ) -> list[Any]:
-    """分页获取图谱所有边，返回完整列表。每页请求自带重试。"""
+    """分页获取图谱所有边，最多返回 max_items 条（默认 5000）。每页请求自带重试。"""
     all_edges: list[Any] = []
     cursor: str | None = None
     page_num = 0
@@ -132,6 +134,10 @@ def fetch_all_edges(
             break
 
         all_edges.extend(batch)
+        if len(all_edges) >= max_items:
+            all_edges = all_edges[:max_items]
+            logger.warning(f"Edge count reached limit ({max_items}), stopping pagination for graph {graph_id}")
+            break
         if len(batch) < page_size:
             break
 


### PR DESCRIPTION
## What

`fetch_all_nodes` has a `max_items` guard (default 2000) to cap memory usage during pagination, but `fetch_all_edges` had no equivalent safeguard — allowing unbounded memory growth on graphs with large numbers of edges.

## How

- Added `_MAX_EDGES = 5000` constant alongside the existing `_MAX_NODES = 2000`
- Added `max_items: int = _MAX_EDGES` parameter to `fetch_all_edges` signature
- Added the same loop-guard pattern used in `fetch_all_nodes`: cap the list, emit a `logger.warning`, and break pagination once the limit is reached
- Updated the docstring to document the new default cap

The change is a direct mirror of the existing `fetch_all_nodes` implementation — no new patterns introduced.

## Testing

- [x] Diff verified against `fetch_all_nodes` pattern — identical guard logic
- [x] No existing tests broken (no test suite for this module currently)
- [x] Backwards compatible — `max_items` is an optional parameter with a sensible default

## Related

Closes #513