### PR TITLE
fix: stop polling when simulation fails

### DIFF
--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -513,6 +513,7 @@ const fetchRunStatus = async () => {
       
       // 检测模拟是否已完成（通过 runner_status 或平台完成状态判断）
       const isCompleted = data.runner_status === 'completed' || data.runner_status === 'stopped'
+      const isFailed = data.runner_status === 'failed'
       
       // 额外检查：如果后端还没来得及更新 runner_status，但平台已经报告完成
       // 通过检测 twitter_completed 和 reddit_completed 状态判断
@@ -526,6 +527,11 @@ const fetchRunStatus = async () => {
         phase.value = 2
         stopPolling()
         emit('update-status', 'completed')
+      } else if (isFailed) {
+        addLog(t('log.simFailed') + (data.error ? `: ${data.error}` : ''))
+        phase.value = 2
+        stopPolling()
+        emit('update-status', 'error')
       }
     }
   } catch (err) {

--- a/locales/en.json
+++ b/locales/en.json
@@ -537,6 +537,7 @@
     "stopException": "Stop error: {error}",
     "allPlatformsCompleted": "✓ All platform simulations have ended",
     "simCompleted": "✓ Simulation completed",
+    "simFailed": "✗ Simulation failed",
     "reportRequestSent": "Report generation request sent, please wait...",
     "startingReportGen": "Starting report generation...",
     "reportGenTaskStarted": "✓ Report generation task started: {reportId}",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -537,6 +537,7 @@
     "stopException": "停止异常: {error}",
     "allPlatformsCompleted": "✓ 检测到所有平台模拟已结束",
     "simCompleted": "✓ 模拟已完成",
+    "simFailed": "✗ 模拟失败",
     "reportRequestSent": "报告生成请求已发送，请稍候...",
     "startingReportGen": "正在启动报告生成...",
     "reportGenTaskStarted": "✓ 报告生成任务已启动: {reportId}",


### PR DESCRIPTION
Previously, the frontend only checked for 'completed' and 'stopped' status to stop polling. When the simulation process exited with an error (runner_status === 'failed'), polling continued indefinitely.

This commit adds handling for the 'failed' status:
- Stop polling when runner_status is 'failed'
- Display error message in the log
- Update UI status to 'error'
- Add i18n translations for simFailed key