### PR TITLE
feat(api): implement API key authentication middleware and pipeline API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,15 @@ ZEP_API_KEY=your_zep_api_key_here
 LLM_BOOST_API_KEY=your_api_key_here
 LLM_BOOST_BASE_URL=your_base_url_here
 LLM_BOOST_MODEL_NAME=your_model_name_here
+
+# ===== Frontend Deployment Configuration (Optional) =====
+# jdavison[2026-04-27]: made some tweaks to support our k8s deployment
+# k8s deployment is nested in foundry's root domain, so we need to set the base path accordingly
+# Example:
+#    https://foundry.pathos.dev -> k8s directs traffic to foundry frontend
+#    https://foundry.pathos.dev/mirofish -> k8s directs traffic to mirofish frontend
+#    https://foundry.pathos.dev/mirofish/api -> k8s directs traffic to mirofish backend
+VITE_BASE_PATH=/mirofish
+VITE_MIROFISH_API_KEY=your_api_key_here
+VITE_DEFAULT_LOCALE=en
+VITE_BACKEND_URL=http://mirofish-backend:8080  # Dev server proxy target (local dev only)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,65 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - feat/predictions
+
+permissions:
+  contents: read
+
+jobs:
+  cjk-guard:
+    name: CJK guard (deterministic)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run CJK regression guard
+        # Uses no LLM key, runs on every PR. Fails if any CJK ideograph
+        # re-enters the source tree outside the allowlist.
+        run: pytest backend/tests/test_prompts_no_cjk.py -v
+
+  llm-output-english:
+    name: Real LLM output is English
+    # Runs only on the main branch and on PRs labeled `run-llm-tests`.
+    # Skipped otherwise to avoid burning LLM credits on every push.
+    if: |
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'run-llm-tests')
+    runs-on: ubuntu-latest
+    needs: cjk-guard
+    env:
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: ${{ vars.LLM_BASE_URL }}
+      LLM_MODEL_NAME: ${{ vars.LLM_MODEL_NAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install backend deps
+        # We only need openai + pydantic + dotenv + pytest for this test path.
+        # Avoid installing the full MiroFish dep tree (camel-ai, torch, zep)
+        # to keep this job under 60 s.
+        run: |
+          pip install --upgrade pip
+          pip install pytest openai pydantic python-dotenv
+
+      - name: Run real-LLM output test
+        run: pytest backend/tests/test_real_llm_english_output.py -v

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://trendshift.io/repositories/16144" target="_blank"><img src="https://trendshift.io/api/badge/repositories/16144" alt="666ghj%2FMiroFish | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-简洁通用的群体智能引擎，预测万物
+A Simple and Universal Swarm Intelligence Engine, Predicting Anything
 </br>
 <em>A Simple and Universal Swarm Intelligence Engine, Predicting Anything</em>
 
@@ -20,7 +20,7 @@
 [![X](https://img.shields.io/badge/X-Follow-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/mirofish_ai)
 [![Instagram](https://img.shields.io/badge/Instagram-Follow-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/mirofish_ai/)
 
-[English](./README.md) | [中文文档](./README-ZH.md)
+[English](./README.md) | [Chinese](./README-ZH.md)
 
 </div>
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -41,6 +41,10 @@ def create_app(config_class=Config):
     
     # 启用CORS
     CORS(app, resources={r"/api/*": {"origins": "*"}})
+
+    # Register API key authentication middleware
+    from .middleware.api_key_auth import register_api_key_auth
+    register_api_key_auth(app)
     
     # 注册模拟进程清理函数（确保服务器关闭时终止所有模拟进程）
     from .services.simulation_runner import SimulationRunner
@@ -63,10 +67,11 @@ def create_app(config_class=Config):
         return response
     
     # 注册蓝图
-    from .api import graph_bp, simulation_bp, report_bp
+    from .api import graph_bp, simulation_bp, report_bp, pipeline_bp
     app.register_blueprint(graph_bp, url_prefix='/api/graph')
     app.register_blueprint(simulation_bp, url_prefix='/api/simulation')
     app.register_blueprint(report_bp, url_prefix='/api/report')
+    app.register_blueprint(pipeline_bp, url_prefix='/api/pipeline')
     
     # 健康检查
     @app.route('/health')

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,12 +1,12 @@
 """
-MiroFish Backend - Flask应用工厂
+MiroFish Backend - Flask application factory
 """
 
 import os
 import warnings
 
-# 抑制 multiprocessing resource_tracker 的警告（来自第三方库如 transformers）
-# 需要在所有其他导入之前设置
+# Suppress multiprocessing resource_tracker warnings (from third-party libs like transformers).
+# Must be set before any other imports.
 warnings.filterwarnings("ignore", message=".*resource_tracker.*")
 
 from flask import Flask, request
@@ -17,69 +17,68 @@ from .utils.logger import setup_logger, get_logger
 
 
 def create_app(config_class=Config):
-    """Flask应用工厂函数"""
+    """Flask application factory function"""
     app = Flask(__name__)
     app.config.from_object(config_class)
-    
-    # 设置JSON编码：确保中文直接显示（而不是 \uXXXX 格式）
-    # Flask >= 2.3 使用 app.json.ensure_ascii，旧版本使用 JSON_AS_ASCII 配置
+
+    # JSON encoding: ensure non-ASCII characters are emitted directly (not as \uXXXX).
+    # Flask >= 2.3 uses app.json.ensure_ascii; older versions use the JSON_AS_ASCII config.
     if hasattr(app, 'json') and hasattr(app.json, 'ensure_ascii'):
         app.json.ensure_ascii = False
-    
-    # 设置日志
+
+    # Configure logging
     logger = setup_logger('mirofish')
-    
-    # 只在 reloader 子进程中打印启动信息（避免 debug 模式下打印两次）
+
+    # Only print startup info in the reloader child process (avoids double-printing in debug mode)
     is_reloader_process = os.environ.get('WERKZEUG_RUN_MAIN') == 'true'
     debug_mode = app.config.get('DEBUG', False)
     should_log_startup = not debug_mode or is_reloader_process
-    
+
     if should_log_startup:
         logger.info("=" * 50)
-        logger.info("MiroFish Backend 启动中...")
+        logger.info("MiroFish Backend starting...")
         logger.info("=" * 50)
-    
-    # 启用CORS
+
+    # Enable CORS
     CORS(app, resources={r"/api/*": {"origins": "*"}})
 
     # Register API key authentication middleware
     from .middleware.api_key_auth import register_api_key_auth
     register_api_key_auth(app)
-    
-    # 注册模拟进程清理函数（确保服务器关闭时终止所有模拟进程）
+
+    # Register simulation process cleanup function (ensures all simulation processes are terminated on shutdown)
     from .services.simulation_runner import SimulationRunner
     SimulationRunner.register_cleanup()
     if should_log_startup:
-        logger.info("已注册模拟进程清理函数")
-    
-    # 请求日志中间件
+        logger.info("Simulation process cleanup function registered")
+
+    # Request logging middleware
     @app.before_request
     def log_request():
         logger = get_logger('mirofish.request')
-        logger.debug(f"请求: {request.method} {request.path}")
+        logger.debug(f"Request: {request.method} {request.path}")
         if request.content_type and 'json' in request.content_type:
-            logger.debug(f"请求体: {request.get_json(silent=True)}")
-    
+            logger.debug(f"Request body: {request.get_json(silent=True)}")
+
     @app.after_request
     def log_response(response):
         logger = get_logger('mirofish.request')
-        logger.debug(f"响应: {response.status_code}")
+        logger.debug(f"Response: {response.status_code}")
         return response
-    
-    # 注册蓝图
+
+    # Register blueprints
     from .api import graph_bp, simulation_bp, report_bp, pipeline_bp
     app.register_blueprint(graph_bp, url_prefix='/api/graph')
     app.register_blueprint(simulation_bp, url_prefix='/api/simulation')
     app.register_blueprint(report_bp, url_prefix='/api/report')
     app.register_blueprint(pipeline_bp, url_prefix='/api/pipeline')
-    
-    # 健康检查
+
+    # Health check
     @app.route('/health')
     def health():
         return {'status': 'ok', 'service': 'MiroFish Backend'}
-    
-    if should_log_startup:
-        logger.info("MiroFish Backend 启动完成")
-    
-    return app
 
+    if should_log_startup:
+        logger.info("MiroFish Backend startup complete")
+
+    return app

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -7,8 +7,10 @@ from flask import Blueprint
 graph_bp = Blueprint('graph', __name__)
 simulation_bp = Blueprint('simulation', __name__)
 report_bp = Blueprint('report', __name__)
+pipeline_bp = Blueprint('pipeline', __name__)
 
 from . import graph  # noqa: E402, F401
 from . import simulation  # noqa: E402, F401
 from . import report  # noqa: E402, F401
+from . import pipeline  # noqa: E402, F401
 

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,5 +1,5 @@
 """
-API路由模块
+API route module
 """
 
 from flask import Blueprint
@@ -13,4 +13,3 @@ from . import graph  # noqa: E402, F401
 from . import simulation  # noqa: E402, F401
 from . import report  # noqa: E402, F401
 from . import pipeline  # noqa: E402, F401
-

--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -1,6 +1,6 @@
 """
-图谱相关API路由
-采用项目上下文机制，服务端持久化状态
+Graph-related API routes
+Uses a project-context mechanism with state persisted on the server side.
 """
 
 import os
@@ -19,27 +19,27 @@ from ..utils.locale import t, get_locale, set_locale
 from ..models.task import TaskManager, TaskStatus
 from ..models.project import ProjectManager, ProjectStatus
 
-# 获取日志器
+# Get the logger
 logger = get_logger('mirofish.api')
 
 
 def allowed_file(filename: str) -> bool:
-    """检查文件扩展名是否允许"""
+    """Check whether the file extension is allowed"""
     if not filename or '.' not in filename:
         return False
     ext = os.path.splitext(filename)[1].lower().lstrip('.')
     return ext in Config.ALLOWED_EXTENSIONS
 
 
-# ============== 项目管理接口 ==============
+# ============== Project management endpoints ==============
 
 @graph_bp.route('/project/<project_id>', methods=['GET'])
 def get_project(project_id: str):
     """
-    获取项目详情
+    Get project details
     """
     project = ProjectManager.get_project(project_id)
-    
+
     if not project:
         return jsonify({
             "success": False,
@@ -55,11 +55,11 @@ def get_project(project_id: str):
 @graph_bp.route('/project/list', methods=['GET'])
 def list_projects():
     """
-    列出所有项目
+    List all projects
     """
     limit = request.args.get('limit', 50, type=int)
     projects = ProjectManager.list_projects(limit=limit)
-    
+
     return jsonify({
         "success": True,
         "data": [p.to_dict() for p in projects],
@@ -70,10 +70,10 @@ def list_projects():
 @graph_bp.route('/project/<project_id>', methods=['DELETE'])
 def delete_project(project_id: str):
     """
-    删除项目
+    Delete a project
     """
     success = ProjectManager.delete_project(project_id)
-    
+
     if not success:
         return jsonify({
             "success": False,
@@ -89,27 +89,27 @@ def delete_project(project_id: str):
 @graph_bp.route('/project/<project_id>/reset', methods=['POST'])
 def reset_project(project_id: str):
     """
-    重置项目状态（用于重新构建图谱）
+    Reset project state (used when rebuilding the graph)
     """
     project = ProjectManager.get_project(project_id)
-    
+
     if not project:
         return jsonify({
             "success": False,
             "error": t('api.projectNotFound', id=project_id)
         }), 404
 
-    # 重置到本体已生成状态
+    # Reset to the "ontology generated" state
     if project.ontology:
         project.status = ProjectStatus.ONTOLOGY_GENERATED
     else:
         project.status = ProjectStatus.CREATED
-    
+
     project.graph_id = None
     project.graph_build_task_id = None
     project.error = None
     ProjectManager.save_project(project)
-    
+
     return jsonify({
         "success": True,
         "message": t('api.projectReset', id=project_id),
@@ -117,22 +117,22 @@ def reset_project(project_id: str):
     })
 
 
-# ============== 接口1：上传文件并生成本体 ==============
+# ============== Endpoint 1: upload files and generate ontology ==============
 
 @graph_bp.route('/ontology/generate', methods=['POST'])
 def generate_ontology():
     """
-    接口1：上传文件，分析生成本体定义
-    
-    请求方式：multipart/form-data
-    
-    参数：
-        files: 上传的文件（PDF/MD/TXT），可多个
-        simulation_requirement: 模拟需求描述（必填）
-        project_name: 项目名称（可选）
-        additional_context: 额外说明（可选）
-        
-    返回：
+    Endpoint 1: upload files and analyze them to generate an ontology definition.
+
+    Request format: multipart/form-data
+
+    Parameters:
+        files: uploaded files (PDF/MD/TXT); multiple are allowed
+        simulation_requirement: simulation requirement description (required)
+        project_name: project name (optional)
+        additional_context: additional context (optional)
+
+    Response:
         {
             "success": true,
             "data": {
@@ -148,84 +148,84 @@ def generate_ontology():
         }
     """
     try:
-        logger.info("=== 开始生成本体定义 ===")
-        
-        # 获取参数
+        logger.info("=== Starting ontology definition generation ===")
+
+        # Get parameters
         simulation_requirement = request.form.get('simulation_requirement', '')
         project_name = request.form.get('project_name', 'Unnamed Project')
         additional_context = request.form.get('additional_context', '')
-        
-        logger.debug(f"项目名称: {project_name}")
-        logger.debug(f"模拟需求: {simulation_requirement[:100]}...")
-        
+
+        logger.debug(f"Project name: {project_name}")
+        logger.debug(f"Simulation requirement: {simulation_requirement[:100]}...")
+
         if not simulation_requirement:
             return jsonify({
                 "success": False,
                 "error": t('api.requireSimulationRequirement')
             }), 400
-        
-        # 获取上传的文件
+
+        # Get the uploaded files
         uploaded_files = request.files.getlist('files')
         if not uploaded_files or all(not f.filename for f in uploaded_files):
             return jsonify({
                 "success": False,
                 "error": t('api.requireFileUpload')
             }), 400
-        
-        # 创建项目
+
+        # Create the project
         project = ProjectManager.create_project(name=project_name)
         project.simulation_requirement = simulation_requirement
-        logger.info(f"创建项目: {project.project_id}")
-        
-        # 保存文件并提取文本
+        logger.info(f"Created project: {project.project_id}")
+
+        # Save files and extract text
         document_texts = []
         all_text = ""
-        
+
         for file in uploaded_files:
             if file and file.filename and allowed_file(file.filename):
-                # 保存文件到项目目录
+                # Save the file to the project directory
                 file_info = ProjectManager.save_file_to_project(
-                    project.project_id, 
-                    file, 
+                    project.project_id,
+                    file,
                     file.filename
                 )
                 project.files.append({
                     "filename": file_info["original_filename"],
                     "size": file_info["size"]
                 })
-                
-                # 提取文本
+
+                # Extract text
                 text = FileParser.extract_text(file_info["path"])
                 text = TextProcessor.preprocess_text(text)
                 document_texts.append(text)
                 all_text += f"\n\n=== {file_info['original_filename']} ===\n{text}"
-        
+
         if not document_texts:
             ProjectManager.delete_project(project.project_id)
             return jsonify({
                 "success": False,
                 "error": t('api.noDocProcessed')
             }), 400
-        
-        # 保存提取的文本
+
+        # Save the extracted text
         project.total_text_length = len(all_text)
         ProjectManager.save_extracted_text(project.project_id, all_text)
-        logger.info(f"文本提取完成，共 {len(all_text)} 字符")
-        
-        # 生成本体
-        logger.info("调用 LLM 生成本体定义...")
+        logger.info(f"Text extraction complete; {len(all_text)} characters")
+
+        # Generate the ontology
+        logger.info("Calling LLM to generate ontology definition...")
         generator = OntologyGenerator()
         ontology = generator.generate(
             document_texts=document_texts,
             simulation_requirement=simulation_requirement,
             additional_context=additional_context if additional_context else None
         )
-        
-        # 保存本体到项目
+
+        # Save the ontology to the project
         entity_count = len(ontology.get("entity_types", []))
         edge_count = len(ontology.get("edge_types", []))
-        logger.info(f"本体生成完成: {entity_count} 个实体类型, {edge_count} 个关系类型")
-        
+        logger.info(f"Ontology generation complete: {entity_count} entity types, {edge_count} relation types")
+
         project.ontology = {
             "entity_types": ontology.get("entity_types", []),
             "edge_types": ontology.get("edge_types", [])
@@ -233,8 +233,8 @@ def generate_ontology():
         project.analysis_summary = ontology.get("analysis_summary", "")
         project.status = ProjectStatus.ONTOLOGY_GENERATED
         ProjectManager.save_project(project)
-        logger.info(f"=== 本体生成完成 === 项目ID: {project.project_id}")
-        
+        logger.info(f"=== Ontology generation complete === project_id: {project.project_id}")
+
         return jsonify({
             "success": True,
             "data": {
@@ -246,7 +246,7 @@ def generate_ontology():
                 "total_text_length": project.total_text_length
             }
         })
-        
+
     except Exception as e:
         return jsonify({
             "success": False,
@@ -255,57 +255,57 @@ def generate_ontology():
         }), 500
 
 
-# ============== 接口2：构建图谱 ==============
+# ============== Endpoint 2: build the graph ==============
 
 @graph_bp.route('/build', methods=['POST'])
 def build_graph():
     """
-    接口2：根据project_id构建图谱
-    
-    请求（JSON）：
+    Endpoint 2: build a graph from a project_id.
+
+    Request (JSON):
         {
-            "project_id": "proj_xxxx",  // 必填，来自接口1
-            "graph_name": "图谱名称",    // 可选
-            "chunk_size": 500,          // 可选，默认500
-            "chunk_overlap": 50         // 可选，默认50
+            "project_id": "proj_xxxx",  // required, from endpoint 1
+            "graph_name": "graph name",  // optional
+            "chunk_size": 500,           // optional, default 500
+            "chunk_overlap": 50          // optional, default 50
         }
-        
-    返回：
+
+    Response:
         {
             "success": true,
             "data": {
                 "project_id": "proj_xxxx",
                 "task_id": "task_xxxx",
-                "message": "图谱构建任务已启动"
+                "message": "Graph build task started"
             }
         }
     """
     try:
-        logger.info("=== 开始构建图谱 ===")
-        
-        # 检查配置
+        logger.info("=== Starting graph build ===")
+
+        # Check configuration
         errors = []
         if not Config.ZEP_API_KEY:
             errors.append(t('api.zepApiKeyMissing'))
         if errors:
-            logger.error(f"配置错误: {errors}")
+            logger.error(f"Configuration error: {errors}")
             return jsonify({
                 "success": False,
                 "error": t('api.configError', details="; ".join(errors))
             }), 500
-        
-        # 解析请求
+
+        # Parse the request
         data = request.get_json() or {}
         project_id = data.get('project_id')
-        logger.debug(f"请求参数: project_id={project_id}")
-        
+        logger.debug(f"Request parameters: project_id={project_id}")
+
         if not project_id:
             return jsonify({
                 "success": False,
                 "error": t('api.requireProjectId')
             }), 400
-        
-        # 获取项目
+
+        # Get the project
         project = ProjectManager.get_project(project_id)
         if not project:
             return jsonify({
@@ -313,116 +313,116 @@ def build_graph():
                 "error": t('api.projectNotFound', id=project_id)
             }), 404
 
-        # 检查项目状态
-        force = data.get('force', False)  # 强制重新构建
-        
+        # Check the project status
+        force = data.get('force', False)  # force a rebuild
+
         if project.status == ProjectStatus.CREATED:
             return jsonify({
                 "success": False,
                 "error": t('api.ontologyNotGenerated')
             }), 400
-        
+
         if project.status == ProjectStatus.GRAPH_BUILDING and not force:
             return jsonify({
                 "success": False,
                 "error": t('api.graphBuilding'),
                 "task_id": project.graph_build_task_id
             }), 400
-        
-        # 如果强制重建，重置状态
+
+        # If force-rebuilding, reset the state
         if force and project.status in [ProjectStatus.GRAPH_BUILDING, ProjectStatus.FAILED, ProjectStatus.GRAPH_COMPLETED]:
             project.status = ProjectStatus.ONTOLOGY_GENERATED
             project.graph_id = None
             project.graph_build_task_id = None
             project.error = None
-        
-        # 获取配置
+
+        # Get configuration
         graph_name = data.get('graph_name', project.name or 'MiroFish Graph')
         chunk_size = data.get('chunk_size', project.chunk_size or Config.DEFAULT_CHUNK_SIZE)
         chunk_overlap = data.get('chunk_overlap', project.chunk_overlap or Config.DEFAULT_CHUNK_OVERLAP)
-        
-        # 更新项目配置
+
+        # Update project configuration
         project.chunk_size = chunk_size
         project.chunk_overlap = chunk_overlap
-        
-        # 获取提取的文本
+
+        # Get the extracted text
         text = ProjectManager.get_extracted_text(project_id)
         if not text:
             return jsonify({
                 "success": False,
                 "error": t('api.textNotFound')
             }), 400
-        
-        # 获取本体
+
+        # Get the ontology
         ontology = project.ontology
         if not ontology:
             return jsonify({
                 "success": False,
                 "error": t('api.ontologyNotFound')
             }), 400
-        
-        # 创建异步任务
+
+        # Create the async task
         task_manager = TaskManager()
-        task_id = task_manager.create_task(f"构建图谱: {graph_name}")
-        logger.info(f"创建图谱构建任务: task_id={task_id}, project_id={project_id}")
-        
-        # 更新项目状态
+        task_id = task_manager.create_task(f"Build graph: {graph_name}")
+        logger.info(f"Created graph build task: task_id={task_id}, project_id={project_id}")
+
+        # Update project state
         project.status = ProjectStatus.GRAPH_BUILDING
         project.graph_build_task_id = task_id
         ProjectManager.save_project(project)
-        
+
         # Capture locale before spawning background thread
         current_locale = get_locale()
 
-        # 启动后台任务
+        # Start the background task
         def build_task():
             set_locale(current_locale)
             build_logger = get_logger('mirofish.build')
             try:
-                build_logger.info(f"[{task_id}] 开始构建图谱...")
+                build_logger.info(f"[{task_id}] Starting graph build...")
                 task_manager.update_task(
-                    task_id, 
+                    task_id,
                     status=TaskStatus.PROCESSING,
                     message=t('progress.initGraphService')
                 )
-                
-                # 创建图谱构建服务
+
+                # Create the graph build service
                 builder = GraphBuilderService(api_key=Config.ZEP_API_KEY)
-                
-                # 分块
+
+                # Chunk the text
                 task_manager.update_task(
                     task_id,
                     message=t('progress.textChunking'),
                     progress=5
                 )
                 chunks = TextProcessor.split_text(
-                    text, 
-                    chunk_size=chunk_size, 
+                    text,
+                    chunk_size=chunk_size,
                     overlap=chunk_overlap
                 )
                 total_chunks = len(chunks)
-                
-                # 创建图谱
+
+                # Create the graph
                 task_manager.update_task(
                     task_id,
                     message=t('progress.creatingZepGraph'),
                     progress=10
                 )
                 graph_id = builder.create_graph(name=graph_name)
-                
-                # 更新项目的graph_id
+
+                # Update the project's graph_id
                 project.graph_id = graph_id
                 ProjectManager.save_project(project)
-                
-                # 设置本体
+
+                # Set the ontology
                 task_manager.update_task(
                     task_id,
                     message=t('progress.settingOntology'),
                     progress=15
                 )
                 builder.set_ontology(graph_id, ontology)
-                
-                # 添加文本（progress_callback 签名是 (msg, progress_ratio)）
+
+                # Add text (progress_callback signature is (msg, progress_ratio))
                 def add_progress_callback(msg, progress_ratio):
                     progress = 15 + int(progress_ratio * 40)  # 15% - 55%
                     task_manager.update_task(
@@ -430,27 +430,27 @@ def build_graph():
                         message=msg,
                         progress=progress
                     )
-                
+
                 task_manager.update_task(
                     task_id,
                     message=t('progress.addingChunks', count=total_chunks),
                     progress=15
                 )
-                
+
                 episode_uuids = builder.add_text_batches(
-                    graph_id, 
+                    graph_id,
                     chunks,
                     batch_size=3,
                     progress_callback=add_progress_callback
                 )
-                
-                # 等待Zep处理完成（查询每个episode的processed状态）
+
+                # Wait for Zep to finish processing (poll each episode's processed status)
                 task_manager.update_task(
                     task_id,
                     message=t('progress.waitingZepProcess'),
                     progress=55
                 )
-                
+
                 def wait_progress_callback(msg, progress_ratio):
                     progress = 55 + int(progress_ratio * 35)  # 55% - 90%
                     task_manager.update_task(
@@ -458,26 +458,26 @@ def build_graph():
                         message=msg,
                         progress=progress
                     )
-                
+
                 builder._wait_for_episodes(episode_uuids, wait_progress_callback)
-                
-                # 获取图谱数据
+
+                # Fetch the graph data
                 task_manager.update_task(
                     task_id,
                     message=t('progress.fetchingGraphData'),
                     progress=95
                 )
                 graph_data = builder.get_graph_data(graph_id)
-                
-                # 更新项目状态
+
+                # Update project state
                 project.status = ProjectStatus.GRAPH_COMPLETED
                 ProjectManager.save_project(project)
-                
+
                 node_count = graph_data.get("node_count", 0)
                 edge_count = graph_data.get("edge_count", 0)
-                build_logger.info(f"[{task_id}] 图谱构建完成: graph_id={graph_id}, 节点={node_count}, 边={edge_count}")
-                
-                # 完成
+                build_logger.info(f"[{task_id}] Graph build complete: graph_id={graph_id}, nodes={node_count}, edges={edge_count}")
+
+                # Done
                 task_manager.update_task(
                     task_id,
                     status=TaskStatus.COMPLETED,
@@ -491,27 +491,27 @@ def build_graph():
                         "chunk_count": total_chunks
                     }
                 )
-                
+
             except Exception as e:
-                # 更新项目状态为失败
-                build_logger.error(f"[{task_id}] 图谱构建失败: {str(e)}")
+                # Mark project state as failed
+                build_logger.error(f"[{task_id}] Graph build failed: {str(e)}")
                 build_logger.debug(traceback.format_exc())
-                
+
                 project.status = ProjectStatus.FAILED
                 project.error = str(e)
                 ProjectManager.save_project(project)
-                
+
                 task_manager.update_task(
                     task_id,
                     status=TaskStatus.FAILED,
                     message=t('progress.buildFailed', error=str(e)),
                     error=traceback.format_exc()
                 )
-        
-        # 启动后台线程
+
+        # Start the background thread
         thread = threading.Thread(target=build_task, daemon=True)
         thread.start()
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -520,7 +520,7 @@ def build_graph():
                 "message": t('api.graphBuildStarted', taskId=task_id)
             }
         })
-        
+
     except Exception as e:
         return jsonify({
             "success": False,
@@ -529,21 +529,21 @@ def build_graph():
         }), 500
 
 
-# ============== 任务查询接口 ==============
+# ============== Task query endpoints ==============
 
 @graph_bp.route('/task/<task_id>', methods=['GET'])
 def get_task(task_id: str):
     """
-    查询任务状态
+    Query task status
     """
     task = TaskManager().get_task(task_id)
-    
+
     if not task:
         return jsonify({
             "success": False,
             "error": t('api.taskNotFound', id=task_id)
         }), 404
-    
+
     return jsonify({
         "success": True,
         "data": task.to_dict()
@@ -553,10 +553,10 @@ def get_task(task_id: str):
 @graph_bp.route('/tasks', methods=['GET'])
 def list_tasks():
     """
-    列出所有任务
+    List all tasks
     """
     tasks = TaskManager().list_tasks()
-    
+
     return jsonify({
         "success": True,
         "data": [t.to_dict() for t in tasks],
@@ -564,12 +564,12 @@ def list_tasks():
     })
 
 
-# ============== 图谱数据接口 ==============
+# ============== Graph data endpoints ==============
 
 @graph_bp.route('/data/<graph_id>', methods=['GET'])
 def get_graph_data(graph_id: str):
     """
-    获取图谱数据（节点和边）
+    Get graph data (nodes and edges)
     """
     try:
         if not Config.ZEP_API_KEY:
@@ -577,15 +577,15 @@ def get_graph_data(graph_id: str):
                 "success": False,
                 "error": t('api.zepApiKeyMissing')
             }), 500
-        
+
         builder = GraphBuilderService(api_key=Config.ZEP_API_KEY)
         graph_data = builder.get_graph_data(graph_id)
-        
+
         return jsonify({
             "success": True,
             "data": graph_data
         })
-        
+
     except Exception as e:
         return jsonify({
             "success": False,
@@ -597,7 +597,7 @@ def get_graph_data(graph_id: str):
 @graph_bp.route('/delete/<graph_id>', methods=['DELETE'])
 def delete_graph(graph_id: str):
     """
-    删除Zep图谱
+    Delete a Zep graph
     """
     try:
         if not Config.ZEP_API_KEY:
@@ -605,15 +605,15 @@ def delete_graph(graph_id: str):
                 "success": False,
                 "error": t('api.zepApiKeyMissing')
             }), 500
-        
+
         builder = GraphBuilderService(api_key=Config.ZEP_API_KEY)
         builder.delete_graph(graph_id)
-        
+
         return jsonify({
             "success": True,
             "message": t('api.graphDeleted', id=graph_id)
         })
-        
+
     except Exception as e:
         return jsonify({
             "success": False,

--- a/backend/app/api/pipeline.py
+++ b/backend/app/api/pipeline.py
@@ -1,0 +1,784 @@
+"""
+Pipeline API — End-to-end prediction pipeline endpoint.
+
+Orchestrates the full MiroFish workflow in a single call:
+  1. Ontology generation (synchronous, LLM)
+  2. Graph build in Zep (async background task, polled to completion)
+  3. Simulation record creation
+  4. Simulation preparation (async background task, polled to completion)
+  5. Simulation launch (subprocess — worker polls until it finishes)
+  6. Report generation (LLM agent synthesizing simulation results)
+
+Pipeline status values
+----------------------
+running             — Stages 1-4 or 6 are executing in the worker thread
+simulation_running  — Simulation subprocess is active; worker is waiting for it
+completed           — All stages done (report generated)
+failed              — Any stage encountered an unrecoverable error
+
+Stage status values: pending | running | completed | failed
+
+State is persisted to disk (uploads/projects/<pipeline_id>/pipeline.json) so
+the /status endpoint works correctly even after a server restart.
+"""
+
+import os
+import json
+import time
+import uuid
+import threading
+import traceback
+from datetime import datetime
+from typing import Optional
+
+from flask import request, jsonify
+
+from . import pipeline_bp
+from ..config import Config
+from ..models.task import TaskManager, TaskStatus
+from ..models.project import ProjectManager, ProjectStatus
+from ..services.ontology_generator import OntologyGenerator
+from ..services.graph_builder import GraphBuilderService
+from ..services.simulation_manager import SimulationManager, SimulationStatus
+from ..services.report_agent import ReportAgent, ReportManager
+from ..services.simulation_runner import SimulationRunner, RunnerStatus
+from ..services.text_processor import TextProcessor
+from ..utils.file_parser import FileParser
+from ..utils.logger import get_logger
+from ..utils.locale import t, get_locale, set_locale
+
+logger = get_logger('mirofish.api.pipeline')
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PIPELINE_STAGES = [
+    "ontology_generate",
+    "graph_build",
+    "simulation_create",
+    "simulation_prepare",
+    "simulation_run",
+    "report_generate",
+]
+
+# Overall progress range attributed to each stage (start%, end%)
+STAGE_PROGRESS = {
+    "ontology_generate":  (0,  10),
+    "graph_build":        (10, 45),
+    "simulation_create":  (45, 50),
+    "simulation_prepare": (50, 75),
+    "simulation_run":     (75, 90),
+    "report_generate":    (90, 100),
+}
+
+# Stage-level status values
+STAGE_STATUS_PENDING   = "pending"
+STAGE_STATUS_RUNNING   = "running"
+STAGE_STATUS_COMPLETED = "completed"
+STAGE_STATUS_FAILED    = "failed"
+
+# Pipeline-level status values
+PIPELINE_STATUS_RUNNING            = "running"            # stages 1-4 in progress
+PIPELINE_STATUS_SIMULATION_RUNNING = "simulation_running" # simulation subprocess active
+PIPELINE_STATUS_COMPLETED          = "completed"          # simulation finished/stopped
+PIPELINE_STATUS_FAILED             = "failed"             # unrecoverable error
+
+# Runner statuses that indicate the simulation subprocess has finished
+_RUNNER_DONE_STATUSES = {
+    RunnerStatus.COMPLETED,
+    RunnerStatus.STOPPED,
+    RunnerStatus.FAILED,
+}
+
+
+# ---------------------------------------------------------------------------
+# Persistent state helpers
+# ---------------------------------------------------------------------------
+
+def _pipeline_file(pipeline_id: str) -> str:
+    """Return the path to the persisted pipeline state JSON file."""
+    project_dir = os.path.join(
+        os.path.dirname(__file__),
+        "../../uploads/projects",
+        pipeline_id,
+    )
+    os.makedirs(project_dir, exist_ok=True)
+    return os.path.join(project_dir, "pipeline.json")
+
+
+def _save_pipeline(state: dict) -> None:
+    """Write pipeline state to disk."""
+    state["updated_at"] = datetime.now().isoformat()
+    with open(_pipeline_file(state["pipeline_id"]), "w", encoding="utf-8") as f:
+        json.dump(state, f, ensure_ascii=False, indent=2)
+
+
+def _load_pipeline(pipeline_id: str) -> Optional[dict]:
+    """Load pipeline state from disk. Returns None if not found."""
+    path = _pipeline_file(pipeline_id)
+    if not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _initial_pipeline_state(
+    pipeline_id: str,
+    project_name: str,
+    simulation_requirement: str,
+) -> dict:
+    now = datetime.now().isoformat()
+    return {
+        "pipeline_id":            pipeline_id,
+        "project_id":             pipeline_id,
+        "project_name":           project_name,
+        "simulation_requirement": simulation_requirement,
+        "simulation_id":          None,
+        "pipeline_status":        PIPELINE_STATUS_RUNNING,
+        "current_stage":          "ontology_generate",
+        "progress":               0,
+        "stages_status":          {s: STAGE_STATUS_PENDING for s in PIPELINE_STAGES},
+        "graph_build_task_id":    None,
+        "prepare_task_id":        None,
+        "report_id":              None,
+        "error":                  None,
+        "created_at":             now,
+        "updated_at":             now,
+    }
+
+
+def _set_stage(state: dict, stage: str, status: str) -> None:
+    """Update a stage status and adjust global progress accordingly."""
+    state["stages_status"][stage] = status
+    if status == STAGE_STATUS_RUNNING:
+        state["current_stage"] = stage
+        start, _ = STAGE_PROGRESS[stage]
+        state["progress"] = start
+    elif status == STAGE_STATUS_COMPLETED:
+        _, end = STAGE_PROGRESS[stage]
+        state["progress"] = end
+    elif status == STAGE_STATUS_FAILED:
+        state["pipeline_status"] = PIPELINE_STATUS_FAILED
+    _save_pipeline(state)
+
+
+def _allowed_file(filename: str) -> bool:
+    if not filename or "." not in filename:
+        return False
+    ext = os.path.splitext(filename)[1].lower().lstrip(".")
+    return ext in Config.ALLOWED_EXTENSIONS
+
+
+# ---------------------------------------------------------------------------
+# Background worker
+# ---------------------------------------------------------------------------
+
+def _run_pipeline_worker(
+    state: dict,
+    all_text: str,
+    document_texts: list,
+    simulation_requirement: str,
+    additional_context: str,
+    chunk_size: int,
+    chunk_overlap: int,
+    enable_twitter: bool,
+    enable_reddit: bool,
+    platform: str,
+    max_rounds: Optional[int],
+    parallel_profile_count: int,
+    enable_graph_memory_update: bool,
+    locale: str,
+):
+    set_locale(locale)
+    project_id = state["pipeline_id"]
+    task_manager = TaskManager()
+
+    try:
+        # Stage 1 — Generate ontology
+        _set_stage(state, "ontology_generate", STAGE_STATUS_RUNNING)
+        logger.info(f"[Pipeline {project_id}] Stage 1: Generating ontology")
+
+        generator = OntologyGenerator()
+        ontology = generator.generate(
+            document_texts=document_texts,
+            simulation_requirement=simulation_requirement,
+            additional_context=additional_context if additional_context else None,
+        )
+
+        project = ProjectManager.get_project(project_id)
+        project.ontology = {
+            "entity_types": ontology.get("entity_types", []),
+            "edge_types":   ontology.get("edge_types", []),
+        }
+        project.analysis_summary = ontology.get("analysis_summary", "")
+        project.status = ProjectStatus.ONTOLOGY_GENERATED
+        ProjectManager.save_project(project)
+
+        _set_stage(state, "ontology_generate", STAGE_STATUS_COMPLETED)
+        logger.info(
+            f"[Pipeline {project_id}] Ontology done — "
+            f"{len(project.ontology['entity_types'])} entity types"
+        )
+
+        # Stage 2 — Build knowledge graph in Zep
+        _set_stage(state, "graph_build", STAGE_STATUS_RUNNING)
+        logger.info(f"[Pipeline {project_id}] Stage 2: Building graph in Zep")
+
+        if not Config.ZEP_API_KEY:
+            raise ValueError("ZEP_API_KEY is not configured; cannot build the graph.")
+
+        builder = GraphBuilderService()
+        graph_task_id = builder.build_graph_async(
+            text=all_text,
+            ontology=project.ontology,
+            graph_name=f"MiroFish — {project.name}",
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+        )
+
+        state["graph_build_task_id"] = graph_task_id
+        _save_pipeline(state)
+
+        # Poll every 5 seconds until the Zep graph build task finishes
+        while True:
+            task = task_manager.get_task(graph_task_id)
+            if task is None:
+                raise RuntimeError(
+                    f"Graph build task {graph_task_id} not found in TaskManager"
+                )
+
+            # Reflect partial progress inside this stage band
+            g_start, g_end = STAGE_PROGRESS["graph_build"]
+            state["progress"] = g_start + int((g_end - g_start) * task.progress / 100)
+            _save_pipeline(state)
+
+            if task.status == TaskStatus.COMPLETED:
+                graph_id = task.result.get("graph_id")
+                project = ProjectManager.get_project(project_id)
+                project.graph_id            = graph_id
+                project.graph_build_task_id = graph_task_id
+                project.status              = ProjectStatus.GRAPH_COMPLETED
+                ProjectManager.save_project(project)
+                break
+            elif task.status == TaskStatus.FAILED:
+                raise RuntimeError(f"Graph build failed: {task.error}")
+
+            time.sleep(5)
+
+        _set_stage(state, "graph_build", STAGE_STATUS_COMPLETED)
+        logger.info(f"[Pipeline {project_id}] Graph built: {graph_id}")
+
+        # Stage 3 — Create simulation record
+        _set_stage(state, "simulation_create", STAGE_STATUS_RUNNING)
+        logger.info(f"[Pipeline {project_id}] Stage 3: Creating simulation record")
+
+        sim_manager = SimulationManager()
+        sim_state = sim_manager.create_simulation(
+            project_id=project_id,
+            graph_id=graph_id,
+            enable_twitter=enable_twitter,
+            enable_reddit=enable_reddit,
+        )
+        simulation_id          = sim_state.simulation_id
+        state["simulation_id"] = simulation_id
+        _save_pipeline(state)
+
+        _set_stage(state, "simulation_create", STAGE_STATUS_COMPLETED)
+        logger.info(f"[Pipeline {project_id}] Simulation created: {simulation_id}")
+
+        # Stage 4 — Prepare simulation (profiles + config)
+        _set_stage(state, "simulation_prepare", STAGE_STATUS_RUNNING)
+        logger.info(
+            f"[Pipeline {project_id}] Stage 4: Preparing simulation profiles/config"
+        )
+
+        prepare_task_id          = task_manager.create_task(
+            task_type="simulation_prepare",
+            metadata={"simulation_id": simulation_id, "project_id": project_id},
+        )
+        state["prepare_task_id"] = prepare_task_id
+        _save_pipeline(state)
+
+        task_manager.update_task(
+            prepare_task_id,
+            status=TaskStatus.PROCESSING,
+            progress=0,
+            message="Starting simulation preparation",
+        )
+
+        p_start, p_end = STAGE_PROGRESS["simulation_prepare"]
+
+        def progress_callback(stage, progress, message, **kwargs):
+            # Map internal 4-sub-stage progress to the global band
+            sub_weights = {
+                "reading":             (0,  20),
+                "generating_profiles": (20, 70),
+                "generating_config":   (70, 90),
+                "copying_scripts":     (90, 100),
+            }
+            s, e      = sub_weights.get(stage, (0, 100))
+            t_prog    = int(s + (e - s) * progress / 100)
+            task_manager.update_task(prepare_task_id, progress=t_prog, message=message)
+
+            # Advance global pipeline progress within the preparation band
+            state["progress"] = p_start + int((p_end - p_start) * t_prog / 100)
+            _save_pipeline(state)
+
+        document_text = ProjectManager.get_extracted_text(project_id) or ""
+        result_state  = sim_manager.prepare_simulation(
+            simulation_id=simulation_id,
+            simulation_requirement=simulation_requirement,
+            document_text=document_text,
+            parallel_profile_count=parallel_profile_count,
+            progress_callback=progress_callback,
+        )
+
+        if result_state.status == SimulationStatus.FAILED:
+            raise RuntimeError(f"Simulation preparation failed: {result_state.error}")
+
+        task_manager.complete_task(prepare_task_id, result=result_state.to_simple_dict())
+        _set_stage(state, "simulation_prepare", STAGE_STATUS_COMPLETED)
+        logger.info(f"[Pipeline {project_id}] Simulation prepared: {simulation_id}")
+
+        # Stage 5 — Launch simulation subprocess
+        #
+        # IMPORTANT: start_simulation() only *launches* the OASIS process.
+        # The simulation keeps running independently through many rounds.
+        # The pipeline moves to PIPELINE_STATUS_SIMULATION_RUNNING, NOT completed.
+        # The /status endpoint resolves the final status from the runner state.
+        _set_stage(state, "simulation_run", STAGE_STATUS_RUNNING)
+        logger.info(
+            f"[Pipeline {project_id}] Stage 5: Launching simulation subprocess"
+        )
+
+        graph_id_for_memory = sim_state.graph_id if enable_graph_memory_update else None
+
+        SimulationRunner.start_simulation(
+            simulation_id=simulation_id,
+            platform=platform,
+            max_rounds=max_rounds,
+            enable_graph_memory_update=enable_graph_memory_update,
+            graph_id=graph_id_for_memory,
+        )
+
+        # Persist simulation status as RUNNING
+        refreshed = sim_manager.get_simulation(simulation_id)
+        if refreshed:
+            refreshed.status = SimulationStatus.RUNNING
+            sim_manager._save_simulation_state(refreshed)
+
+        # Mark simulation stage as running — subprocess has launched but is not done yet.
+        # pipeline_status -> simulation_running so /status can display live runner info.
+        # This worker thread stays alive and polls until the subprocess finishes,
+        # then proceeds directly to Stage 6 (report generation).
+        state["stages_status"]["simulation_run"] = STAGE_STATUS_RUNNING
+        state["progress"]                        = 75
+        state["pipeline_status"]                 = PIPELINE_STATUS_SIMULATION_RUNNING
+        _save_pipeline(state)
+
+        logger.info(
+            f"[Pipeline {project_id}] Simulation subprocess launched. "
+            "Worker is now waiting for it to finish before generating the report..."
+        )
+
+        # Poll every 15 seconds until the runner finishes
+        while True:
+            run_state = SimulationRunner.get_run_state(simulation_id)
+            if run_state is None or run_state.runner_status in _RUNNER_DONE_STATUSES:
+                break
+            time.sleep(15)
+
+        # Re-fetch final runner state
+        run_state = SimulationRunner.get_run_state(simulation_id)
+        if run_state and run_state.runner_status == RunnerStatus.FAILED:
+            raise RuntimeError("Simulation subprocess reported a FAILED status.")
+
+        _set_stage(state, "simulation_run", STAGE_STATUS_COMPLETED)
+        state["pipeline_status"] = PIPELINE_STATUS_RUNNING
+        _save_pipeline(state)
+        logger.info(f"[Pipeline {project_id}] Simulation finished. Starting report generation.")
+
+        # Stage 6 — Generate report using ReportAgent
+        _set_stage(state, "report_generate", STAGE_STATUS_RUNNING)
+        logger.info(f"[Pipeline {project_id}] Stage 6: Generating report")
+
+        report_id         = f"report_{uuid.uuid4().hex[:12]}"
+        state["report_id"] = report_id
+        _save_pipeline(state)
+
+        r_start, r_end = STAGE_PROGRESS["report_generate"]
+
+        def report_progress_callback(stage: str, progress: int, message: str) -> None:
+            state["progress"] = r_start + int((r_end - r_start) * progress / 100)
+            _save_pipeline(state)
+
+        project = ProjectManager.get_project(project_id)
+        agent   = ReportAgent(
+            graph_id=graph_id,
+            simulation_id=simulation_id,
+            simulation_requirement=simulation_requirement,
+        )
+        report = agent.generate_report(
+            progress_callback=report_progress_callback,
+            report_id=report_id,
+        )
+        ReportManager.save_report(report)
+
+        _set_stage(state, "report_generate", STAGE_STATUS_COMPLETED)
+        state["pipeline_status"] = PIPELINE_STATUS_COMPLETED
+        _save_pipeline(state)
+        logger.info(
+            f"[Pipeline {project_id}] Pipeline fully completed. "
+            f"Report: {report_id}"
+        )
+
+    except Exception as exc:
+        error_msg     = str(exc)
+        current_stage = state.get("current_stage", "ontology_generate")
+        logger.error(
+            f"[Pipeline {project_id}] Failed at stage '{current_stage}': "
+            f"{traceback.format_exc()}"
+        )
+        state["stages_status"][current_stage] = STAGE_STATUS_FAILED
+        state["pipeline_status"]              = PIPELINE_STATUS_FAILED
+        state["error"]                        = error_msg
+        _save_pipeline(state)
+
+        # Fail any in-flight prepare task
+        prepare_task_id = state.get("prepare_task_id")
+        if prepare_task_id:
+            try:
+                task = task_manager.get_task(prepare_task_id)
+                if task and task.status == TaskStatus.PROCESSING:
+                    task_manager.fail_task(prepare_task_id, error_msg)
+            except Exception:
+                pass
+
+
+# ─────────────────────────────────────────────────────
+# Endpoints
+# ─────────────────────────────────────────────────────
+
+
+@pipeline_bp.route("/start", methods=["POST"])
+def start_pipeline():
+    """
+    Start the full end-to-end prediction pipeline.
+
+    Accepts the same files and parameters as POST /api/graph/ontology/generate.
+    Returns immediately (202) with a pipeline_id; the workflow runs in background.
+
+    Request: multipart/form-data
+        files                       Required. PDF/MD/TXT files (one or more).
+        simulation_requirement      Required. Prediction goal description.
+        project_name                Optional. Display name (default: "Unnamed Project").
+        additional_context          Optional. Extra context for ontology generation.
+        chunk_size                  Optional. Text chunk size (default: 500).
+        chunk_overlap               Optional. Chunk overlap (default: 50).
+        enable_twitter              Optional. Enable Twitter platform (default: true).
+        enable_reddit               Optional. Enable Reddit platform (default: true).
+        platform                    Optional. "twitter" | "reddit" | "parallel" (default: parallel).
+        max_rounds                  Optional. Cap on simulation rounds.
+        parallel_profile_count      Optional. Parallel LLM profile generation (default: 5).
+        enable_graph_memory_update  Optional. Push agent actions to Zep graph (default: false).
+
+    Response 202:
+        {
+            "success": true,
+            "data": {
+                "pipeline_id": "proj_xxxxxxxxxxxx",
+                "project_id":  "proj_xxxxxxxxxxxx",
+                "status":      "running",
+                "message":     "...",
+                "status_url":  "/api/pipeline/proj_xxxx/status"
+            }
+        }
+    """
+    try:
+        # -- Text parameters
+        simulation_requirement = request.form.get("simulation_requirement", "").strip()
+        if not simulation_requirement:
+            return jsonify({"success": False, "error": t("api.requireSimulationRequirement")}), 400
+
+        project_name               = request.form.get("project_name", "Unnamed Project")
+        additional_context         = request.form.get("additional_context", "")
+        chunk_size                 = int(request.form.get("chunk_size",  Config.DEFAULT_CHUNK_SIZE))
+        chunk_overlap              = int(request.form.get("chunk_overlap", Config.DEFAULT_CHUNK_OVERLAP))
+        enable_twitter             = request.form.get("enable_twitter", "true").lower() == "true"
+        enable_reddit              = request.form.get("enable_reddit",  "true").lower() == "true"
+        platform                   = request.form.get("platform", "parallel")
+        parallel_profile_count     = int(request.form.get("parallel_profile_count", 5))
+        enable_graph_memory_update = (
+            request.form.get("enable_graph_memory_update", "false").lower() == "true"
+        )
+
+        max_rounds: Optional[int] = None
+        max_rounds_raw = request.form.get("max_rounds")
+        if max_rounds_raw:
+            max_rounds = int(max_rounds_raw)
+            if max_rounds <= 0:
+                return jsonify({"success": False, "error": t("api.maxRoundsPositive")}), 400
+
+        if platform not in ("twitter", "reddit", "parallel"):
+            return jsonify({"success": False, "error": t("api.invalidPlatform", platform=platform)}), 400
+
+        # -- Files
+        uploaded_files = request.files.getlist("files")
+        if not uploaded_files or all(not f.filename for f in uploaded_files):
+            return jsonify({"success": False, "error": t("api.requireFileUpload")}), 400
+
+        # -- Create project record
+        project    = ProjectManager.create_project(name=project_name)
+        project.simulation_requirement = simulation_requirement
+        project_id = project.project_id
+        logger.info(f"[Pipeline] New project created: {project_id}")
+
+        # -- Extract text from uploaded files
+        document_texts: list = []
+        all_text             = ""
+
+        for file in uploaded_files:
+            if file and file.filename and _allowed_file(file.filename):
+                file_info = ProjectManager.save_file_to_project(
+                    project_id, file, file.filename
+                )
+                project.files.append({
+                    "filename": file_info["original_filename"],
+                    "size":     file_info["size"],
+                })
+                text = TextProcessor.preprocess_text(
+                    FileParser.extract_text(file_info["path"])
+                )
+                document_texts.append(text)
+                all_text += f"\n\n=== {file_info['original_filename']} ===\n{text}"
+
+        if not document_texts:
+            ProjectManager.delete_project(project_id)
+            return jsonify({"success": False, "error": t("api.noDocProcessed")}), 400
+
+        project.total_text_length = len(all_text)
+        ProjectManager.save_extracted_text(project_id, all_text)
+        ProjectManager.save_project(project)
+
+        # -- Create and persist initial pipeline state
+        state = _initial_pipeline_state(project_id, project_name, simulation_requirement)
+        _save_pipeline(state)
+
+        # -- Launch background worker thread
+        current_locale = get_locale()
+        thread = threading.Thread(
+            target=_run_pipeline_worker,
+            args=(
+                state,
+                all_text,
+                document_texts,
+                simulation_requirement,
+                additional_context,
+                chunk_size,
+                chunk_overlap,
+                enable_twitter,
+                enable_reddit,
+                platform,
+                max_rounds,
+                parallel_profile_count,
+                enable_graph_memory_update,
+                current_locale,
+            ),
+            daemon=True,
+        )
+        thread.start()
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "pipeline_id": project_id,
+                "project_id":  project_id,
+                "status":      PIPELINE_STATUS_RUNNING,
+                "message":     "Pipeline started. Poll status_url for progress.",
+                "status_url":  f"/api/pipeline/{project_id}/status",
+            },
+        }), 202
+
+    except Exception as exc:
+        logger.error(f"[Pipeline] Error starting pipeline: {traceback.format_exc()}")
+        return jsonify({
+            "success": False,
+            "error": str(exc),
+            "traceback": traceback.format_exc(),
+        }), 500
+
+
+@pipeline_bp.route("/<pipeline_id>/status", methods=["GET"])
+def get_pipeline_status(pipeline_id: str):
+    """
+    Return the current status of a pipeline at any point in time.
+
+    The worker thread owns all status transitions. This endpoint is read-only
+    and simply reflects the persisted state plus live runner enrichment.
+
+    Response:
+        {
+            "success": true,
+            "data": {
+                "pipeline_id":               "proj_xxxx",
+                "project_id":                "proj_xxxx",
+                "simulation_id":             "sim_xxxx",
+                "pipeline_status":           "running|simulation_running|completed|failed",
+                "current_stage":             "simulation_run",
+                "progress":                  82,
+                "stages_status": {
+                    "ontology_generate":  "completed",
+                    "graph_build":        "completed",
+                    "simulation_create":  "completed",
+                    "simulation_prepare": "completed",
+                    "simulation_run":     "running",
+                    "report_generate":    "pending"
+                },
+                "graph_build_task_id":        "task_xxxx",
+                "graph_build_task":           { ...task detail... },
+                "prepare_task_id":            "task_xxxx",
+                "prepare_task":               { ...task detail... },
+                "simulation_status":          "running",
+                "runner_status":              "running",
+                "current_round":               5,
+                "total_rounds":                50,
+                "simulation_progress_percent": 10.0,
+                "report_id":                  "report_xxxx",
+                "report_status":              "generating|completed|failed",
+                "report_completed_at":        "...",
+                "report_error":               null,
+                "error":                      null,
+                "created_at":                 "...",
+                "updated_at":                 "..."
+            }
+        }
+    """
+    try:
+        state = _load_pipeline(pipeline_id)
+        if not state:
+            return jsonify({
+                "success": False,
+                "error": f"Pipeline '{pipeline_id}' no encontrado",
+            }), 404
+
+        task_manager = TaskManager()
+        result       = dict(state)
+
+        # Enrich with graph-build task detail
+        if state.get("graph_build_task_id"):
+            task = task_manager.get_task(state["graph_build_task_id"])
+            result["graph_build_task"] = task.to_dict() if task else None
+        else:
+            result["graph_build_task"] = None
+
+        # Enrich with preparation task detail
+        if state.get("prepare_task_id"):
+            task = task_manager.get_task(state["prepare_task_id"])
+            result["prepare_task"] = task.to_dict() if task else None
+        else:
+            result["prepare_task"] = None
+
+        # Enrich with live simulation / runner state
+        simulation_id = state.get("simulation_id")
+        if simulation_id:
+            sim_manager = SimulationManager()
+            sim_state   = sim_manager.get_simulation(simulation_id)
+
+            result["simulation_status"] = sim_state.status.value if sim_state else None
+            if sim_state:
+                result["entities_count"] = sim_state.entities_count
+                result["profiles_count"] = sim_state.profiles_count
+
+            run_state = SimulationRunner.get_run_state(simulation_id)
+            if run_state:
+                result["runner_status"] = run_state.runner_status.value
+                result["current_round"] = run_state.current_round
+                result["total_rounds"]  = run_state.total_rounds
+                result["simulation_progress_percent"] = (
+                    round(run_state.current_round / run_state.total_rounds * 100, 1)
+                    if run_state.total_rounds > 0 else 0
+                )
+            else:
+                result["runner_status"] = "idle"
+                result["current_round"] = 0
+                result["total_rounds"]  = 0
+                result["simulation_progress_percent"] = 0
+
+        else:
+            # Simulation has not been created yet
+            result["simulation_status"]           = None
+            result["runner_status"]               = None
+            result["current_round"]               = 0
+            result["total_rounds"]                = 0
+            result["simulation_progress_percent"] = 0
+
+        # Enrich with report state
+        report_id = state.get("report_id")
+        if report_id:
+            report = ReportManager.get_report(report_id)
+            if report:
+                result["report_id"]           = report_id
+                result["report_status"]       = report.status.value
+                result["report_completed_at"] = report.completed_at
+                result["report_error"]        = report.error
+            else:
+                # Report object not yet written to disk (generation just started)
+                result["report_id"]     = report_id
+                result["report_status"] = "generating"
+        else:
+            result["report_id"]     = None
+            result["report_status"] = None
+
+        return jsonify({"success": True, "data": result})
+
+    except Exception as exc:
+        logger.error(f"[Pipeline] Error in /status: {traceback.format_exc()}")
+        return jsonify({
+            "success": False,
+            "error": str(exc),
+            "traceback": traceback.format_exc(),
+        }), 500
+
+
+@pipeline_bp.route("/list", methods=["GET"])
+def list_pipelines():
+    """
+    List all persisted pipelines ordered by creation date (most recent first).
+
+    Query params:
+        limit — Maximum number of results to return (default: 20).
+    """
+    try:
+        limit = request.args.get("limit", 20, type=int)
+
+        uploads_projects = os.path.join(
+            os.path.dirname(__file__), "../../uploads/projects"
+        )
+        if not os.path.exists(uploads_projects):
+            return jsonify({"success": True, "data": [], "count": 0})
+
+        pipelines = []
+        for folder in os.listdir(uploads_projects):
+            pipeline_file = os.path.join(uploads_projects, folder, "pipeline.json")
+            if not os.path.exists(pipeline_file):
+                continue
+            try:
+                with open(pipeline_file, "r", encoding="utf-8") as f:
+                    p = json.load(f)
+                pipelines.append(p)
+            except Exception:
+                continue
+
+        pipelines.sort(key=lambda x: x.get("created_at", ""), reverse=True)
+        pipelines = pipelines[:limit]
+
+        return jsonify({
+            "success": True,
+            "data": pipelines,
+            "count": len(pipelines),
+        })
+
+    except Exception as exc:
+        logger.error(f"[Pipeline] Error in /list: {traceback.format_exc()}")
+        return jsonify({"success": False, "error": str(exc)}), 500

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -1,6 +1,6 @@
 """
-Report API路由
-提供模拟报告生成、获取、对话等接口
+Report API routes
+Provides endpoints for simulation report generation, retrieval, and chat.
 """
 
 import os
@@ -20,36 +20,36 @@ from ..utils.locale import t, get_locale, set_locale
 logger = get_logger('mirofish.api.report')
 
 
-# ============== 报告生成接口 ==============
+# ============== Report generation endpoints ==============
 
 @report_bp.route('/generate', methods=['POST'])
 def generate_report():
     """
-    生成模拟分析报告（异步任务）
-    
-    这是一个耗时操作，接口会立即返回task_id，
-    使用 GET /api/report/generate/status 查询进度
-    
-    请求（JSON）：
+    Generate a simulation analysis report (async task).
+
+    This is a long-running operation; the endpoint returns a task_id immediately.
+    Use GET /api/report/generate/status to query progress.
+
+    Request (JSON):
         {
-            "simulation_id": "sim_xxxx",    // 必填，模拟ID
-            "force_regenerate": false        // 可选，强制重新生成
+            "simulation_id": "sim_xxxx",    // required, simulation ID
+            "force_regenerate": false        // optional, force regeneration
         }
-    
-    返回：
+
+    Response:
         {
             "success": true,
             "data": {
                 "simulation_id": "sim_xxxx",
                 "task_id": "task_xxxx",
                 "status": "generating",
-                "message": "报告生成任务已启动"
+                "message": "Report generation task started"
             }
         }
     """
     try:
         data = request.get_json() or {}
-        
+
         simulation_id = data.get('simulation_id')
         if not simulation_id:
             return jsonify({
@@ -58,18 +58,18 @@ def generate_report():
             }), 400
 
         force_regenerate = data.get('force_regenerate', False)
-        
-        # 获取模拟信息
+
+        # Get simulation info
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
-        
+
         if not state:
             return jsonify({
                 "success": False,
                 "error": t('api.simulationNotFound', id=simulation_id)
             }), 404
 
-        # 检查是否已有报告
+        # Check whether a report already exists
         if not force_regenerate:
             existing_report = ReportManager.get_report_by_simulation(simulation_id)
             if existing_report and existing_report.status == ReportStatus.COMPLETED:
@@ -83,34 +83,34 @@ def generate_report():
                         "already_generated": True
                     }
                 })
-        
-        # 获取项目信息
+
+        # Get project info
         project = ProjectManager.get_project(state.project_id)
         if not project:
             return jsonify({
                 "success": False,
                 "error": t('api.projectNotFound', id=state.project_id)
             }), 404
-        
+
         graph_id = state.graph_id or project.graph_id
         if not graph_id:
             return jsonify({
                 "success": False,
                 "error": t('api.missingGraphIdEnsure')
             }), 400
-        
+
         simulation_requirement = project.simulation_requirement
         if not simulation_requirement:
             return jsonify({
                 "success": False,
                 "error": t('api.missingSimRequirement')
             }), 400
-        
-        # 提前生成 report_id，以便立即返回给前端
+
+        # Generate the report_id ahead of time so it can be returned to the front-end immediately
         import uuid
         report_id = f"report_{uuid.uuid4().hex[:12]}"
-        
-        # 创建异步任务
+
+        # Create the async task
         task_manager = TaskManager()
         task_id = task_manager.create_task(
             task_type="report_generate",
@@ -120,11 +120,11 @@ def generate_report():
                 "report_id": report_id
             }
         )
-        
+
         # Capture locale before spawning background thread
         current_locale = get_locale()
 
-        # 定义后台任务
+        # Define the background task
         def run_generate():
             set_locale(current_locale)
             try:
@@ -134,31 +134,31 @@ def generate_report():
                     progress=0,
                     message=t('api.initReportAgent')
                 )
-                
-                # 创建Report Agent
+
+                # Create the Report Agent
                 agent = ReportAgent(
                     graph_id=graph_id,
                     simulation_id=simulation_id,
                     simulation_requirement=simulation_requirement
                 )
-                
-                # 进度回调
+
+                # Progress callback
                 def progress_callback(stage, progress, message):
                     task_manager.update_task(
                         task_id,
                         progress=progress,
                         message=f"[{stage}] {message}"
                     )
-                
-                # 生成报告（传入预先生成的 report_id）
+
+                # Generate the report (passing the pre-generated report_id)
                 report = agent.generate_report(
                     progress_callback=progress_callback,
                     report_id=report_id
                 )
-                
-                # 保存报告
+
+                # Save the report
                 ReportManager.save_report(report)
-                
+
                 if report.status == ReportStatus.COMPLETED:
                     task_manager.complete_task(
                         task_id,
@@ -170,15 +170,15 @@ def generate_report():
                     )
                 else:
                     task_manager.fail_task(task_id, report.error or t('api.reportGenerateFailed'))
-                
+
             except Exception as e:
-                logger.error(f"报告生成失败: {str(e)}")
+                logger.error(f"Report generation failed: {str(e)}")
                 task_manager.fail_task(task_id, str(e))
-        
-        # 启动后台线程
+
+        # Start the background thread
         thread = threading.Thread(target=run_generate, daemon=True)
         thread.start()
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -190,9 +190,9 @@ def generate_report():
                 "already_generated": False
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"启动报告生成任务失败: {str(e)}")
+        logger.error(f"Failed to start report generation task: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -203,15 +203,15 @@ def generate_report():
 @report_bp.route('/generate/status', methods=['POST'])
 def get_generate_status():
     """
-    查询报告生成任务进度
-    
-    请求（JSON）：
+    Query report-generation task progress.
+
+    Request (JSON):
         {
-            "task_id": "task_xxxx",         // 可选，generate返回的task_id
-            "simulation_id": "sim_xxxx"     // 可选，模拟ID
+            "task_id": "task_xxxx",         // optional, task_id returned by generate
+            "simulation_id": "sim_xxxx"     // optional, simulation ID
         }
-    
-    返回：
+
+    Response:
         {
             "success": true,
             "data": {
@@ -224,11 +224,11 @@ def get_generate_status():
     """
     try:
         data = request.get_json() or {}
-        
+
         task_id = data.get('task_id')
         simulation_id = data.get('simulation_id')
-        
-        # 如果提供了simulation_id，先检查是否已有完成的报告
+
+        # If a simulation_id was provided, first check whether a completed report already exists
         if simulation_id:
             existing_report = ReportManager.get_report_by_simulation(simulation_id)
             if existing_report and existing_report.status == ReportStatus.COMPLETED:
@@ -243,43 +243,43 @@ def get_generate_status():
                         "already_completed": True
                     }
                 })
-        
+
         if not task_id:
             return jsonify({
                 "success": False,
                 "error": t('api.requireTaskOrSimId')
             }), 400
-        
+
         task_manager = TaskManager()
         task = task_manager.get_task(task_id)
-        
+
         if not task:
             return jsonify({
                 "success": False,
                 "error": t('api.taskNotFound', id=task_id)
             }), 404
-        
+
         return jsonify({
             "success": True,
             "data": task.to_dict()
         })
-        
+
     except Exception as e:
-        logger.error(f"查询任务状态失败: {str(e)}")
+        logger.error(f"Failed to query task status: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e)
         }), 500
 
 
-# ============== 报告获取接口 ==============
+# ============== Report retrieval endpoints ==============
 
 @report_bp.route('/<report_id>', methods=['GET'])
 def get_report(report_id: str):
     """
-    获取报告详情
-    
-    返回：
+    Get report details.
+
+    Response:
         {
             "success": true,
             "data": {
@@ -295,20 +295,20 @@ def get_report(report_id: str):
     """
     try:
         report = ReportManager.get_report(report_id)
-        
+
         if not report:
             return jsonify({
                 "success": False,
                 "error": t('api.reportNotFound', id=report_id)
             }), 404
-        
+
         return jsonify({
             "success": True,
             "data": report.to_dict()
         })
-        
+
     except Exception as e:
-        logger.error(f"获取报告失败: {str(e)}")
+        logger.error(f"Failed to fetch report: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -319,9 +319,9 @@ def get_report(report_id: str):
 @report_bp.route('/by-simulation/<simulation_id>', methods=['GET'])
 def get_report_by_simulation(simulation_id: str):
     """
-    根据模拟ID获取报告
-    
-    返回：
+    Get a report by simulation ID.
+
+    Response:
         {
             "success": true,
             "data": {
@@ -332,22 +332,22 @@ def get_report_by_simulation(simulation_id: str):
     """
     try:
         report = ReportManager.get_report_by_simulation(simulation_id)
-        
+
         if not report:
             return jsonify({
                 "success": False,
                 "error": t('api.noReportForSim', id=simulation_id),
                 "has_report": False
             }), 404
-        
+
         return jsonify({
             "success": True,
             "data": report.to_dict(),
             "has_report": True
         })
-        
+
     except Exception as e:
-        logger.error(f"获取报告失败: {str(e)}")
+        logger.error(f"Failed to fetch report: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -358,13 +358,13 @@ def get_report_by_simulation(simulation_id: str):
 @report_bp.route('/list', methods=['GET'])
 def list_reports():
     """
-    列出所有报告
-    
-    Query参数：
-        simulation_id: 按模拟ID过滤（可选）
-        limit: 返回数量限制（默认50）
-    
-    返回：
+    List all reports.
+
+    Query parameters:
+        simulation_id: filter by simulation ID (optional)
+        limit: maximum number of items to return (default 50)
+
+    Response:
         {
             "success": true,
             "data": [...],
@@ -374,20 +374,20 @@ def list_reports():
     try:
         simulation_id = request.args.get('simulation_id')
         limit = request.args.get('limit', 50, type=int)
-        
+
         reports = ReportManager.list_reports(
             simulation_id=simulation_id,
             limit=limit
         )
-        
+
         return jsonify({
             "success": True,
             "data": [r.to_dict() for r in reports],
             "count": len(reports)
         })
-        
+
     except Exception as e:
-        logger.error(f"列出报告失败: {str(e)}")
+        logger.error(f"Failed to list reports: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -398,42 +398,42 @@ def list_reports():
 @report_bp.route('/<report_id>/download', methods=['GET'])
 def download_report(report_id: str):
     """
-    下载报告（Markdown格式）
-    
-    返回Markdown文件
+    Download a report (Markdown format).
+
+    Returns a Markdown file.
     """
     try:
         report = ReportManager.get_report(report_id)
-        
+
         if not report:
             return jsonify({
                 "success": False,
                 "error": t('api.reportNotFound', id=report_id)
             }), 404
-        
+
         md_path = ReportManager._get_report_markdown_path(report_id)
-        
+
         if not os.path.exists(md_path):
-            # 如果MD文件不存在，生成一个临时文件
+            # If the MD file does not exist, generate a temporary one
             import tempfile
             with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
                 f.write(report.markdown_content)
                 temp_path = f.name
-            
+
             return send_file(
                 temp_path,
                 as_attachment=True,
                 download_name=f"{report_id}.md"
             )
-        
+
         return send_file(
             md_path,
             as_attachment=True,
             download_name=f"{report_id}.md"
         )
-        
+
     except Exception as e:
-        logger.error(f"下载报告失败: {str(e)}")
+        logger.error(f"Failed to download report: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -443,23 +443,23 @@ def download_report(report_id: str):
 
 @report_bp.route('/<report_id>', methods=['DELETE'])
 def delete_report(report_id: str):
-    """删除报告"""
+    """Delete a report"""
     try:
         success = ReportManager.delete_report(report_id)
-        
+
         if not success:
             return jsonify({
                 "success": False,
                 "error": t('api.reportNotFound', id=report_id)
             }), 404
-        
+
         return jsonify({
             "success": True,
             "message": t('api.reportDeleted', id=report_id)
         })
-        
+
     except Exception as e:
-        logger.error(f"删除报告失败: {str(e)}")
+        logger.error(f"Failed to delete report: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -467,42 +467,42 @@ def delete_report(report_id: str):
         }), 500
 
 
-# ============== Report Agent对话接口 ==============
+# ============== Report Agent chat endpoint ==============
 
 @report_bp.route('/chat', methods=['POST'])
 def chat_with_report_agent():
     """
-    与Report Agent对话
-    
-    Report Agent可以在对话中自主调用检索工具来回答问题
-    
-    请求（JSON）：
+    Chat with the Report Agent.
+
+    The Report Agent can autonomously call retrieval tools during chat to answer questions.
+
+    Request (JSON):
         {
-            "simulation_id": "sim_xxxx",        // 必填，模拟ID
-            "message": "请解释一下舆情走向",    // 必填，用户消息
-            "chat_history": [                   // 可选，对话历史
+            "simulation_id": "sim_xxxx",        // required, simulation ID
+            "message": "Please explain the sentiment trend",  // required, user message
+            "chat_history": [                   // optional, chat history
                 {"role": "user", "content": "..."},
                 {"role": "assistant", "content": "..."}
             ]
         }
-    
-    返回：
+
+    Response:
         {
             "success": true,
             "data": {
-                "response": "Agent回复...",
-                "tool_calls": [调用的工具列表],
-                "sources": [信息来源]
+                "response": "Agent reply...",
+                "tool_calls": [list of invoked tools],
+                "sources": [information sources]
             }
         }
     """
     try:
         data = request.get_json() or {}
-        
+
         simulation_id = data.get('simulation_id')
         message = data.get('message')
         chat_history = data.get('chat_history', [])
-        
+
         if not simulation_id:
             return jsonify({
                 "success": False,
@@ -514,11 +514,11 @@ def chat_with_report_agent():
                 "success": False,
                 "error": t('api.requireMessage')
             }), 400
-        
-        # 获取模拟和项目信息
+
+        # Get simulation and project info
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
-        
+
         if not state:
             return jsonify({
                 "success": False,
@@ -531,32 +531,32 @@ def chat_with_report_agent():
                 "success": False,
                 "error": t('api.projectNotFound', id=state.project_id)
             }), 404
-        
+
         graph_id = state.graph_id or project.graph_id
         if not graph_id:
             return jsonify({
                 "success": False,
                 "error": t('api.missingGraphId')
             }), 400
-        
+
         simulation_requirement = project.simulation_requirement or ""
-        
-        # 创建Agent并进行对话
+
+        # Create the Agent and start the conversation
         agent = ReportAgent(
             graph_id=graph_id,
             simulation_id=simulation_id,
             simulation_requirement=simulation_requirement
         )
-        
+
         result = agent.chat(message=message, chat_history=chat_history)
-        
+
         return jsonify({
             "success": True,
             "data": result
         })
-        
+
     except Exception as e:
-        logger.error(f"对话失败: {str(e)}")
+        logger.error(f"Chat failed: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -564,42 +564,42 @@ def chat_with_report_agent():
         }), 500
 
 
-# ============== 报告进度与分章节接口 ==============
+# ============== Report progress and section endpoints ==============
 
 @report_bp.route('/<report_id>/progress', methods=['GET'])
 def get_report_progress(report_id: str):
     """
-    获取报告生成进度（实时）
-    
-    返回：
+    Get report-generation progress (live).
+
+    Response:
         {
             "success": true,
             "data": {
                 "status": "generating",
                 "progress": 45,
-                "message": "正在生成章节: 关键发现",
-                "current_section": "关键发现",
-                "completed_sections": ["执行摘要", "模拟背景"],
+                "message": "Generating section: Key Findings",
+                "current_section": "Key Findings",
+                "completed_sections": ["Executive Summary", "Simulation Background"],
                 "updated_at": "2025-12-09T..."
             }
         }
     """
     try:
         progress = ReportManager.get_progress(report_id)
-        
+
         if not progress:
             return jsonify({
                 "success": False,
                 "error": t('api.reportProgressNotAvail', id=report_id)
             }), 404
-        
+
         return jsonify({
             "success": True,
             "data": progress
         })
-        
+
     except Exception as e:
-        logger.error(f"获取报告进度失败: {str(e)}")
+        logger.error(f"Failed to fetch report progress: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -610,11 +610,12 @@ def get_report_progress(report_id: str):
 @report_bp.route('/<report_id>/sections', methods=['GET'])
 def get_report_sections(report_id: str):
     """
-    获取已生成的章节列表（分章节输出）
-    
-    前端可以轮询此接口获取已生成的章节内容，无需等待整个报告完成
-    
-    返回：
+    Get the list of generated sections (per-section output).
+
+    The front-end can poll this endpoint for already-generated section content
+    without having to wait for the entire report to finish.
+
+    Response:
         {
             "success": true,
             "data": {
@@ -623,7 +624,7 @@ def get_report_sections(report_id: str):
                     {
                         "filename": "section_01.md",
                         "section_index": 1,
-                        "content": "## 执行摘要\\n\\n..."
+                        "content": "## Executive Summary\\n\\n..."
                     },
                     ...
                 ],
@@ -634,11 +635,11 @@ def get_report_sections(report_id: str):
     """
     try:
         sections = ReportManager.get_generated_sections(report_id)
-        
-        # 获取报告状态
+
+        # Get the report status
         report = ReportManager.get_report(report_id)
         is_complete = report is not None and report.status == ReportStatus.COMPLETED
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -648,9 +649,9 @@ def get_report_sections(report_id: str):
                 "is_complete": is_complete
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"获取章节列表失败: {str(e)}")
+        logger.error(f"Failed to fetch sections list: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -661,29 +662,29 @@ def get_report_sections(report_id: str):
 @report_bp.route('/<report_id>/section/<int:section_index>', methods=['GET'])
 def get_single_section(report_id: str, section_index: int):
     """
-    获取单个章节内容
-    
-    返回：
+    Get the content of a single section.
+
+    Response:
         {
             "success": true,
             "data": {
                 "filename": "section_01.md",
-                "content": "## 执行摘要\\n\\n..."
+                "content": "## Executive Summary\\n\\n..."
             }
         }
     """
     try:
         section_path = ReportManager._get_section_path(report_id, section_index)
-        
+
         if not os.path.exists(section_path):
             return jsonify({
                 "success": False,
                 "error": t('api.sectionNotFound', index=f"{section_index:02d}")
             }), 404
-        
+
         with open(section_path, 'r', encoding='utf-8') as f:
             content = f.read()
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -692,9 +693,9 @@ def get_single_section(report_id: str, section_index: int):
                 "content": content
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"获取章节内容失败: {str(e)}")
+        logger.error(f"Failed to fetch section content: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -702,16 +703,16 @@ def get_single_section(report_id: str, section_index: int):
         }), 500
 
 
-# ============== 报告状态检查接口 ==============
+# ============== Report status check endpoint ==============
 
 @report_bp.route('/check/<simulation_id>', methods=['GET'])
 def check_report_status(simulation_id: str):
     """
-    检查模拟是否有报告，以及报告状态
-    
-    用于前端判断是否解锁Interview功能
-    
-    返回：
+    Check whether a simulation has a report and the report's status.
+
+    Used by the front-end to decide whether to unlock the Interview feature.
+
+    Response:
         {
             "success": true,
             "data": {
@@ -725,14 +726,14 @@ def check_report_status(simulation_id: str):
     """
     try:
         report = ReportManager.get_report_by_simulation(simulation_id)
-        
+
         has_report = report is not None
         report_status = report.status.value if report else None
         report_id = report.report_id if report else None
-        
-        # 只有报告完成后才解锁interview
+
+        # Only unlock interview once the report is complete
         interview_unlocked = has_report and report.status == ReportStatus.COMPLETED
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -743,9 +744,9 @@ def check_report_status(simulation_id: str):
                 "interview_unlocked": interview_unlocked
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"检查报告状态失败: {str(e)}")
+        logger.error(f"Failed to check report status: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -753,22 +754,22 @@ def check_report_status(simulation_id: str):
         }), 500
 
 
-# ============== Agent 日志接口 ==============
+# ============== Agent log endpoints ==============
 
 @report_bp.route('/<report_id>/agent-log', methods=['GET'])
 def get_agent_log(report_id: str):
     """
-    获取 Report Agent 的详细执行日志
-    
-    实时获取报告生成过程中的每一步动作，包括：
-    - 报告开始、规划开始/完成
-    - 每个章节的开始、工具调用、LLM响应、完成
-    - 报告完成或失败
-    
-    Query参数：
-        from_line: 从第几行开始读取（可选，默认0，用于增量获取）
-    
-    返回：
+    Get the Report Agent's detailed execution log.
+
+    Provides each step of the report-generation process in real time, including:
+    - Report start, planning start/finish
+    - Each section's start, tool calls, LLM responses, and completion
+    - Report completion or failure
+
+    Query parameters:
+        from_line: line number to start reading from (optional, default 0; used for incremental fetching)
+
+    Response:
         {
             "success": true,
             "data": {
@@ -779,7 +780,7 @@ def get_agent_log(report_id: str):
                         "report_id": "report_xxxx",
                         "action": "tool_call",
                         "stage": "generating",
-                        "section_title": "执行摘要",
+                        "section_title": "Executive Summary",
                         "section_index": 1,
                         "details": {
                             "tool_name": "insight_forge",
@@ -797,16 +798,16 @@ def get_agent_log(report_id: str):
     """
     try:
         from_line = request.args.get('from_line', 0, type=int)
-        
+
         log_data = ReportManager.get_agent_log(report_id, from_line=from_line)
-        
+
         return jsonify({
             "success": True,
             "data": log_data
         })
-        
+
     except Exception as e:
-        logger.error(f"获取Agent日志失败: {str(e)}")
+        logger.error(f"Failed to fetch Agent log: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -817,9 +818,9 @@ def get_agent_log(report_id: str):
 @report_bp.route('/<report_id>/agent-log/stream', methods=['GET'])
 def stream_agent_log(report_id: str):
     """
-    获取完整的 Agent 日志（一次性获取全部）
-    
-    返回：
+    Get the complete Agent log (returned all at once).
+
+    Response:
         {
             "success": true,
             "data": {
@@ -830,7 +831,7 @@ def stream_agent_log(report_id: str):
     """
     try:
         logs = ReportManager.get_agent_log_stream(report_id)
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -838,9 +839,9 @@ def stream_agent_log(report_id: str):
                 "count": len(logs)
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"获取Agent日志失败: {str(e)}")
+        logger.error(f"Failed to fetch Agent log: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -848,27 +849,27 @@ def stream_agent_log(report_id: str):
         }), 500
 
 
-# ============== 控制台日志接口 ==============
+# ============== Console log endpoints ==============
 
 @report_bp.route('/<report_id>/console-log', methods=['GET'])
 def get_console_log(report_id: str):
     """
-    获取 Report Agent 的控制台输出日志
-    
-    实时获取报告生成过程中的控制台输出（INFO、WARNING等），
-    这与 agent-log 接口返回的结构化 JSON 日志不同，
-    是纯文本格式的控制台风格日志。
-    
-    Query参数：
-        from_line: 从第几行开始读取（可选，默认0，用于增量获取）
-    
-    返回：
+    Get the Report Agent's console output log.
+
+    Provides the console output (INFO, WARNING, etc.) emitted during report generation.
+    Unlike the structured JSON log returned by the agent-log endpoint,
+    this is plain-text console-style log output.
+
+    Query parameters:
+        from_line: line number to start reading from (optional, default 0; used for incremental fetching)
+
+    Response:
         {
             "success": true,
             "data": {
                 "logs": [
-                    "[19:46:14] INFO: 搜索完成: 找到 15 条相关事实",
-                    "[19:46:14] INFO: 图谱搜索: graph_id=xxx, query=...",
+                    "[19:46:14] INFO: Search complete: found 15 relevant facts",
+                    "[19:46:14] INFO: Graph search: graph_id=xxx, query=...",
                     ...
                 ],
                 "total_lines": 100,
@@ -879,16 +880,16 @@ def get_console_log(report_id: str):
     """
     try:
         from_line = request.args.get('from_line', 0, type=int)
-        
+
         log_data = ReportManager.get_console_log(report_id, from_line=from_line)
-        
+
         return jsonify({
             "success": True,
             "data": log_data
         })
-        
+
     except Exception as e:
-        logger.error(f"获取控制台日志失败: {str(e)}")
+        logger.error(f"Failed to fetch console log: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -899,9 +900,9 @@ def get_console_log(report_id: str):
 @report_bp.route('/<report_id>/console-log/stream', methods=['GET'])
 def stream_console_log(report_id: str):
     """
-    获取完整的控制台日志（一次性获取全部）
-    
-    返回：
+    Get the complete console log (returned all at once).
+
+    Response:
         {
             "success": true,
             "data": {
@@ -912,7 +913,7 @@ def stream_console_log(report_id: str):
     """
     try:
         logs = ReportManager.get_console_log_stream(report_id)
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -920,9 +921,9 @@ def stream_console_log(report_id: str):
                 "count": len(logs)
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"获取控制台日志失败: {str(e)}")
+        logger.error(f"Failed to fetch console log: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -930,49 +931,49 @@ def stream_console_log(report_id: str):
         }), 500
 
 
-# ============== 工具调用接口（供调试使用）==============
+# ============== Tool invocation endpoints (for debugging) ==============
 
 @report_bp.route('/tools/search', methods=['POST'])
 def search_graph_tool():
     """
-    图谱搜索工具接口（供调试使用）
-    
-    请求（JSON）：
+    Graph search tool endpoint (for debugging).
+
+    Request (JSON):
         {
             "graph_id": "mirofish_xxxx",
-            "query": "搜索查询",
+            "query": "search query",
             "limit": 10
         }
     """
     try:
         data = request.get_json() or {}
-        
+
         graph_id = data.get('graph_id')
         query = data.get('query')
         limit = data.get('limit', 10)
-        
+
         if not graph_id or not query:
             return jsonify({
                 "success": False,
                 "error": t('api.requireGraphIdAndQuery')
             }), 400
-        
+
         from ..services.zep_tools import ZepToolsService
-        
+
         tools = ZepToolsService()
         result = tools.search_graph(
             graph_id=graph_id,
             query=query,
             limit=limit
         )
-        
+
         return jsonify({
             "success": True,
             "data": result.to_dict()
         })
-        
+
     except Exception as e:
-        logger.error(f"图谱搜索失败: {str(e)}")
+        logger.error(f"Graph search failed: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -983,36 +984,36 @@ def search_graph_tool():
 @report_bp.route('/tools/statistics', methods=['POST'])
 def get_graph_statistics_tool():
     """
-    图谱统计工具接口（供调试使用）
-    
-    请求（JSON）：
+    Graph statistics tool endpoint (for debugging).
+
+    Request (JSON):
         {
             "graph_id": "mirofish_xxxx"
         }
     """
     try:
         data = request.get_json() or {}
-        
+
         graph_id = data.get('graph_id')
-        
+
         if not graph_id:
             return jsonify({
                 "success": False,
                 "error": t('api.requireGraphId')
             }), 400
-        
+
         from ..services.zep_tools import ZepToolsService
-        
+
         tools = ZepToolsService()
         result = tools.get_graph_statistics(graph_id)
-        
+
         return jsonify({
             "success": True,
             "data": result
         })
-        
+
     except Exception as e:
-        logger.error(f"获取图谱统计失败: {str(e)}")
+        logger.error(f"Failed to fetch graph statistics: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -1,6 +1,6 @@
 """
-模拟相关API路由
-Step2: Zep实体读取与过滤、OASIS模拟准备与运行（全程自动化）
+Simulation-related API routes
+Step 2: Zep entity reading and filtering, OASIS simulation preparation and execution (fully automated)
 """
 
 import os
@@ -20,41 +20,42 @@ from ..models.project import ProjectManager
 logger = get_logger('mirofish.api.simulation')
 
 
-# Interview prompt 优化前缀
-# 添加此前缀可以避免Agent调用工具，直接用文本回复
-INTERVIEW_PROMPT_PREFIX = "结合你的人设、所有的过往记忆与行动，不调用任何工具直接用文本回复我："
+# Interview prompt optimization prefix.
+# Adding this prefix prevents the Agent from invoking tools and makes it reply directly with text.
+INTERVIEW_PROMPT_PREFIX = "Drawing on your persona, all your past memories and actions, reply to me directly in text without invoking any tools: "
 
 
 def optimize_interview_prompt(prompt: str) -> str:
     """
-    优化Interview提问，添加前缀避免Agent调用工具
-    
+    Optimize an Interview question by adding a prefix that prevents the Agent from calling tools.
+
     Args:
-        prompt: 原始提问
-        
+        prompt: original question
+
     Returns:
-        优化后的提问
+        Optimized question
     """
     if not prompt:
         return prompt
-    # 避免重复添加前缀
+    # Avoid adding the prefix more than once
     if prompt.startswith(INTERVIEW_PROMPT_PREFIX):
         return prompt
     return f"{INTERVIEW_PROMPT_PREFIX}{prompt}"
 
 
-# ============== 实体读取接口 ==============
+# ============== Entity reading endpoints ==============
 
 @simulation_bp.route('/entities/<graph_id>', methods=['GET'])
 def get_graph_entities(graph_id: str):
     """
-    获取图谱中的所有实体（已过滤）
-    
-    只返回符合预定义实体类型的节点（Labels不只是Entity的节点）
-    
-    Query参数：
-        entity_types: 逗号分隔的实体类型列表（可选，用于进一步过滤）
-        enrich: 是否获取相关边信息（默认true）
+    Get all entities in a graph (already filtered).
+
+    Only returns nodes that match a predefined entity type (i.e. nodes whose Labels are
+    not just "Entity").
+
+    Query parameters:
+        entity_types: comma-separated list of entity types (optional, for further filtering)
+        enrich: whether to fetch related edge information (default true)
     """
     try:
         if not Config.ZEP_API_KEY:
@@ -62,27 +63,27 @@ def get_graph_entities(graph_id: str):
                 "success": False,
                 "error": t('api.zepApiKeyMissing')
             }), 500
-        
+
         entity_types_str = request.args.get('entity_types', '')
         entity_types = [t.strip() for t in entity_types_str.split(',') if t.strip()] if entity_types_str else None
         enrich = request.args.get('enrich', 'true').lower() == 'true'
-        
-        logger.info(f"获取图谱实体: graph_id={graph_id}, entity_types={entity_types}, enrich={enrich}")
-        
+
+        logger.info(f"Fetching graph entities: graph_id={graph_id}, entity_types={entity_types}, enrich={enrich}")
+
         reader = ZepEntityReader()
         result = reader.filter_defined_entities(
             graph_id=graph_id,
             defined_entity_types=entity_types,
             enrich_with_edges=enrich
         )
-        
+
         return jsonify({
             "success": True,
             "data": result.to_dict()
         })
-        
+
     except Exception as e:
-        logger.error(f"获取图谱实体失败: {str(e)}")
+        logger.error(f"Failed to fetch graph entities: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -92,30 +93,30 @@ def get_graph_entities(graph_id: str):
 
 @simulation_bp.route('/entities/<graph_id>/<entity_uuid>', methods=['GET'])
 def get_entity_detail(graph_id: str, entity_uuid: str):
-    """获取单个实体的详细信息"""
+    """Get detailed information for a single entity"""
     try:
         if not Config.ZEP_API_KEY:
             return jsonify({
                 "success": False,
                 "error": t('api.zepApiKeyMissing')
             }), 500
-        
+
         reader = ZepEntityReader()
         entity = reader.get_entity_with_context(graph_id, entity_uuid)
-        
+
         if not entity:
             return jsonify({
                 "success": False,
                 "error": t('api.entityNotFound', id=entity_uuid)
             }), 404
-        
+
         return jsonify({
             "success": True,
             "data": entity.to_dict()
         })
-        
+
     except Exception as e:
-        logger.error(f"获取实体详情失败: {str(e)}")
+        logger.error(f"Failed to fetch entity details: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -125,23 +126,23 @@ def get_entity_detail(graph_id: str, entity_uuid: str):
 
 @simulation_bp.route('/entities/<graph_id>/by-type/<entity_type>', methods=['GET'])
 def get_entities_by_type(graph_id: str, entity_type: str):
-    """获取指定类型的所有实体"""
+    """Get all entities of a specific type"""
     try:
         if not Config.ZEP_API_KEY:
             return jsonify({
                 "success": False,
                 "error": t('api.zepApiKeyMissing')
             }), 500
-        
+
         enrich = request.args.get('enrich', 'true').lower() == 'true'
-        
+
         reader = ZepEntityReader()
         entities = reader.get_entities_by_type(
             graph_id=graph_id,
             entity_type=entity_type,
             enrich_with_edges=enrich
         )
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -150,9 +151,9 @@ def get_entities_by_type(graph_id: str, entity_type: str):
                 "entities": [e.to_dict() for e in entities]
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"获取实体失败: {str(e)}")
+        logger.error(f"Failed to fetch entities: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -160,24 +161,25 @@ def get_entities_by_type(graph_id: str, entity_type: str):
         }), 500
 
 
-# ============== 模拟管理接口 ==============
+# ============== Simulation management endpoints ==============
 
 @simulation_bp.route('/create', methods=['POST'])
 def create_simulation():
     """
-    创建新的模拟
-    
-    注意：max_rounds等参数由LLM智能生成，无需手动设置
-    
-    请求（JSON）：
+    Create a new simulation.
+
+    Note: parameters such as max_rounds are generated intelligently by the LLM and
+    do not need to be set manually.
+
+    Request (JSON):
         {
-            "project_id": "proj_xxxx",      // 必填
-            "graph_id": "mirofish_xxxx",    // 可选，如不提供则从project获取
-            "enable_twitter": true,          // 可选，默认true
-            "enable_reddit": true            // 可选，默认true
+            "project_id": "proj_xxxx",      // required
+            "graph_id": "mirofish_xxxx",    // optional; if omitted, fetched from the project
+            "enable_twitter": true,          // optional, default true
+            "enable_reddit": true            // optional, default true
         }
-    
-    返回：
+
+    Response:
         {
             "success": true,
             "data": {
@@ -193,28 +195,28 @@ def create_simulation():
     """
     try:
         data = request.get_json() or {}
-        
+
         project_id = data.get('project_id')
         if not project_id:
             return jsonify({
                 "success": False,
                 "error": t('api.requireProjectId')
             }), 400
-        
+
         project = ProjectManager.get_project(project_id)
         if not project:
             return jsonify({
                 "success": False,
                 "error": t('api.projectNotFound', id=project_id)
             }), 404
-        
+
         graph_id = data.get('graph_id') or project.graph_id
         if not graph_id:
             return jsonify({
                 "success": False,
                 "error": t('api.graphNotBuilt')
             }), 400
-        
+
         manager = SimulationManager()
         state = manager.create_simulation(
             project_id=project_id,
@@ -222,14 +224,14 @@ def create_simulation():
             enable_twitter=data.get('enable_twitter', True),
             enable_reddit=data.get('enable_reddit', True),
         )
-        
+
         return jsonify({
             "success": True,
             "data": state.to_dict()
         })
-        
+
     except Exception as e:
-        logger.error(f"创建模拟失败: {str(e)}")
+        logger.error(f"Failed to create simulation: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -239,38 +241,39 @@ def create_simulation():
 
 def _check_simulation_prepared(simulation_id: str) -> tuple:
     """
-    检查模拟是否已经准备完成
-    
-    检查条件：
-    1. state.json 存在且 status 为 "ready"
-    2. 必要文件存在：reddit_profiles.json, twitter_profiles.csv, simulation_config.json
-    
-    注意：运行脚本(run_*.py)保留在 backend/scripts/ 目录，不再复制到模拟目录
-    
+    Check whether a simulation has finished its preparation step.
+
+    Conditions checked:
+    1. state.json exists and its status is "ready".
+    2. The required files exist: reddit_profiles.json, twitter_profiles.csv, simulation_config.json.
+
+    Note: the run scripts (run_*.py) live in backend/scripts/ and are no longer
+    copied into the simulation directory.
+
     Args:
-        simulation_id: 模拟ID
-        
+        simulation_id: simulation ID
+
     Returns:
         (is_prepared: bool, info: dict)
     """
     import os
     from ..config import Config
-    
+
     simulation_dir = os.path.join(Config.OASIS_SIMULATION_DATA_DIR, simulation_id)
-    
-    # 检查目录是否存在
+
+    # Check whether the directory exists
     if not os.path.exists(simulation_dir):
-        return False, {"reason": "模拟目录不存在"}
-    
-    # 必要文件列表（不包括脚本，脚本位于 backend/scripts/）
+        return False, {"reason": "Simulation directory does not exist"}
+
+    # Required files (excluding scripts; scripts live in backend/scripts/)
     required_files = [
         "state.json",
         "simulation_config.json",
         "reddit_profiles.json",
         "twitter_profiles.csv"
     ]
-    
-    # 检查文件是否存在
+
+    # Check whether the files exist
     existing_files = []
     missing_files = []
     for f in required_files:
@@ -279,48 +282,48 @@ def _check_simulation_prepared(simulation_id: str) -> tuple:
             existing_files.append(f)
         else:
             missing_files.append(f)
-    
+
     if missing_files:
         return False, {
-            "reason": "缺少必要文件",
+            "reason": "Missing required files",
             "missing_files": missing_files,
             "existing_files": existing_files
         }
-    
-    # 检查state.json中的状态
+
+    # Inspect the status in state.json
     state_file = os.path.join(simulation_dir, "state.json")
     try:
         import json
         with open(state_file, 'r', encoding='utf-8') as f:
             state_data = json.load(f)
-        
+
         status = state_data.get("status", "")
         config_generated = state_data.get("config_generated", False)
-        
-        # 详细日志
-        logger.debug(f"检测模拟准备状态: {simulation_id}, status={status}, config_generated={config_generated}")
-        
-        # 如果 config_generated=True 且文件存在，认为准备完成
-        # 以下状态都说明准备工作已完成：
-        # - ready: 准备完成，可以运行
-        # - preparing: 如果 config_generated=True 说明已完成
-        # - running: 正在运行，说明准备早就完成了
-        # - completed: 运行完成，说明准备早就完成了
-        # - stopped: 已停止，说明准备早就完成了
-        # - failed: 运行失败（但准备是完成的）
+
+        # Detailed log
+        logger.debug(f"Checking simulation preparation status: {simulation_id}, status={status}, config_generated={config_generated}")
+
+        # If config_generated=True and the files exist, treat preparation as complete.
+        # The following statuses all indicate that preparation has finished:
+        # - ready: prepared and ready to run
+        # - preparing: if config_generated=True, treat as already done
+        # - running: currently running, so preparation finished long ago
+        # - completed: finished running, so preparation finished long ago
+        # - stopped: stopped, so preparation finished long ago
+        # - failed: run failed (but preparation itself was complete)
         prepared_statuses = ["ready", "preparing", "running", "completed", "stopped", "failed"]
         if status in prepared_statuses and config_generated:
-            # 获取文件统计信息
+            # Get file statistics
             profiles_file = os.path.join(simulation_dir, "reddit_profiles.json")
             config_file = os.path.join(simulation_dir, "simulation_config.json")
-            
+
             profiles_count = 0
             if os.path.exists(profiles_file):
                 with open(profiles_file, 'r', encoding='utf-8') as f:
                     profiles_data = json.load(f)
                     profiles_count = len(profiles_data) if isinstance(profiles_data, list) else 0
-            
-            # 如果状态是preparing但文件已完成，自动更新状态为ready
+
+            # If status is "preparing" but the files are ready, automatically promote it to "ready".
             if status == "preparing":
                 try:
                     state_data["status"] = "ready"
@@ -328,12 +331,12 @@ def _check_simulation_prepared(simulation_id: str) -> tuple:
                     state_data["updated_at"] = datetime.now().isoformat()
                     with open(state_file, 'w', encoding='utf-8') as f:
                         json.dump(state_data, f, ensure_ascii=False, indent=2)
-                    logger.info(f"自动更新模拟状态: {simulation_id} preparing -> ready")
+                    logger.info(f"Auto-updated simulation status: {simulation_id} preparing -> ready")
                     status = "ready"
                 except Exception as e:
-                    logger.warning(f"自动更新状态失败: {e}")
-            
-            logger.info(f"模拟 {simulation_id} 检测结果: 已准备完成 (status={status}, config_generated={config_generated})")
+                    logger.warning(f"Auto status update failed: {e}")
+
+            logger.info(f"Simulation {simulation_id} check result: preparation complete (status={status}, config_generated={config_generated})")
             return True, {
                 "status": status,
                 "entities_count": state_data.get("entities_count", 0),
@@ -345,55 +348,55 @@ def _check_simulation_prepared(simulation_id: str) -> tuple:
                 "existing_files": existing_files
             }
         else:
-            logger.warning(f"模拟 {simulation_id} 检测结果: 未准备完成 (status={status}, config_generated={config_generated})")
+            logger.warning(f"Simulation {simulation_id} check result: preparation incomplete (status={status}, config_generated={config_generated})")
             return False, {
-                "reason": f"状态不在已准备列表中或config_generated为false: status={status}, config_generated={config_generated}",
+                "reason": f"Status is not in the prepared list, or config_generated is false: status={status}, config_generated={config_generated}",
                 "status": status,
                 "config_generated": config_generated
             }
-            
+
     except Exception as e:
-        return False, {"reason": f"读取状态文件失败: {str(e)}"}
+        return False, {"reason": f"Failed to read state file: {str(e)}"}
 
 
 @simulation_bp.route('/prepare', methods=['POST'])
 def prepare_simulation():
     """
-    准备模拟环境（异步任务，LLM智能生成所有参数）
-    
-    这是一个耗时操作，接口会立即返回task_id，
-    使用 GET /api/simulation/prepare/status 查询进度
-    
-    特性：
-    - 自动检测已完成的准备工作，避免重复生成
-    - 如果已准备完成，直接返回已有结果
-    - 支持强制重新生成（force_regenerate=true）
-    
-    步骤：
-    1. 检查是否已有完成的准备工作
-    2. 从Zep图谱读取并过滤实体
-    3. 为每个实体生成OASIS Agent Profile（带重试机制）
-    4. LLM智能生成模拟配置（带重试机制）
-    5. 保存配置文件和预设脚本
-    
-    请求（JSON）：
+    Prepare the simulation environment (async task; the LLM generates all parameters intelligently).
+
+    This is a long-running operation; the endpoint returns a task_id immediately.
+    Use GET /api/simulation/prepare/status to query progress.
+
+    Features:
+    - Automatically detects already-completed preparation work to avoid regenerating it.
+    - If preparation is already complete, returns the existing result directly.
+    - Supports forced regeneration (force_regenerate=true).
+
+    Steps:
+    1. Check whether preparation has already been completed.
+    2. Read and filter entities from the Zep graph.
+    3. Generate an OASIS Agent Profile for each entity (with retry).
+    4. Have the LLM intelligently generate the simulation configuration (with retry).
+    5. Save configuration files and preset scripts.
+
+    Request (JSON):
         {
-            "simulation_id": "sim_xxxx",                   // 必填，模拟ID
-            "entity_types": ["Student", "PublicFigure"],  // 可选，指定实体类型
-            "use_llm_for_profiles": true,                 // 可选，是否用LLM生成人设
-            "parallel_profile_count": 5,                  // 可选，并行生成人设数量，默认5
-            "force_regenerate": false                     // 可选，强制重新生成，默认false
+            "simulation_id": "sim_xxxx",                  // required, simulation ID
+            "entity_types": ["Student", "PublicFigure"],  // optional, restrict to specific entity types
+            "use_llm_for_profiles": true,                 // optional, whether to use the LLM to generate personas
+            "parallel_profile_count": 5,                  // optional, parallel persona-generation count, default 5
+            "force_regenerate": false                     // optional, force regeneration, default false
         }
-    
-    返回：
+
+    Response:
         {
             "success": true,
             "data": {
                 "simulation_id": "sim_xxxx",
-                "task_id": "task_xxxx",           // 新任务时返回
+                "task_id": "task_xxxx",           // returned for new tasks
                 "status": "preparing|ready",
-                "message": "准备任务已启动|已有完成的准备工作",
-                "already_prepared": true|false    // 是否已准备完成
+                "message": "Preparation task started | preparation already complete",
+                "already_prepared": true|false    // whether preparation was already done
             }
         }
     """
@@ -401,37 +404,37 @@ def prepare_simulation():
     import os
     from ..models.task import TaskManager, TaskStatus
     from ..config import Config
-    
+
     try:
         data = request.get_json() or {}
-        
+
         simulation_id = data.get('simulation_id')
         if not simulation_id:
             return jsonify({
                 "success": False,
                 "error": t('api.requireSimulationId')
             }), 400
-        
+
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
-        
+
         if not state:
             return jsonify({
                 "success": False,
                 "error": t('api.simulationNotFound', id=simulation_id)
             }), 404
-        
-        # 检查是否强制重新生成
+
+        # Check whether forced regeneration was requested
         force_regenerate = data.get('force_regenerate', False)
-        logger.info(f"开始处理 /prepare 请求: simulation_id={simulation_id}, force_regenerate={force_regenerate}")
-        
-        # 检查是否已经准备完成（避免重复生成）
+        logger.info(f"Handling /prepare request: simulation_id={simulation_id}, force_regenerate={force_regenerate}")
+
+        # Check whether preparation is already complete (avoid duplicate generation)
         if not force_regenerate:
-            logger.debug(f"检查模拟 {simulation_id} 是否已准备完成...")
+            logger.debug(f"Checking whether simulation {simulation_id} is already prepared...")
             is_prepared, prepare_info = _check_simulation_prepared(simulation_id)
-            logger.debug(f"检查结果: is_prepared={is_prepared}, prepare_info={prepare_info}")
+            logger.debug(f"Check result: is_prepared={is_prepared}, prepare_info={prepare_info}")
             if is_prepared:
-                logger.info(f"模拟 {simulation_id} 已准备完成，跳过重复生成")
+                logger.info(f"Simulation {simulation_id} is already prepared; skipping regeneration")
                 return jsonify({
                     "success": True,
                     "data": {
@@ -443,51 +446,51 @@ def prepare_simulation():
                     }
                 })
             else:
-                logger.info(f"模拟 {simulation_id} 未准备完成，将启动准备任务")
-        
-        # 从项目获取必要信息
+                logger.info(f"Simulation {simulation_id} is not prepared; will start preparation task")
+
+        # Get required information from the project
         project = ProjectManager.get_project(state.project_id)
         if not project:
             return jsonify({
                 "success": False,
                 "error": t('api.projectNotFound', id=state.project_id)
             }), 404
-        
-        # 获取模拟需求
+
+        # Get the simulation requirement
         simulation_requirement = project.simulation_requirement or ""
         if not simulation_requirement:
             return jsonify({
                 "success": False,
                 "error": t('api.projectMissingRequirement')
             }), 400
-        
-        # 获取文档文本
+
+        # Get the document text
         document_text = ProjectManager.get_extracted_text(state.project_id) or ""
-        
+
         entity_types_list = data.get('entity_types')
         use_llm_for_profiles = data.get('use_llm_for_profiles', True)
         parallel_profile_count = data.get('parallel_profile_count', 5)
-        
-        # ========== 同步获取实体数量（在后台任务启动前） ==========
-        # 这样前端在调用prepare后立即就能获取到预期Agent总数
+
+        # ========== Synchronously fetch the entity count (before launching the background task) ==========
+        # This way the front-end can immediately retrieve the expected total Agent count after calling prepare.
         try:
-            logger.info(f"同步获取实体数量: graph_id={state.graph_id}")
+            logger.info(f"Synchronously fetching entity count: graph_id={state.graph_id}")
             reader = ZepEntityReader()
-            # 快速读取实体（不需要边信息，只统计数量）
+            # Fast entity read (we don't need edge info; we're only counting)
             filtered_preview = reader.filter_defined_entities(
                 graph_id=state.graph_id,
                 defined_entity_types=entity_types_list,
-                enrich_with_edges=False  # 不获取边信息，加快速度
+                enrich_with_edges=False  # skip edges to speed things up
             )
-            # 保存实体数量到状态（供前端立即获取）
+            # Save the entity count to the state so the front-end can fetch it immediately
             state.entities_count = filtered_preview.filtered_count
             state.entity_types = list(filtered_preview.entity_types)
-            logger.info(f"预期实体数量: {filtered_preview.filtered_count}, 类型: {filtered_preview.entity_types}")
+            logger.info(f"Expected entity count: {filtered_preview.filtered_count}, types: {filtered_preview.entity_types}")
         except Exception as e:
-            logger.warning(f"同步获取实体数量失败（将在后台任务中重试）: {e}")
-            # 失败不影响后续流程，后台任务会重新获取
-        
-        # 创建异步任务
+            logger.warning(f"Synchronous entity-count fetch failed (will retry in the background task): {e}")
+            # Failure here doesn't block the rest of the flow; the background task will refetch.
+
+        # Create the async task
         task_manager = TaskManager()
         task_id = task_manager.create_task(
             task_type="simulation_prepare",
@@ -496,15 +499,15 @@ def prepare_simulation():
                 "project_id": state.project_id
             }
         )
-        
-        # 更新模拟状态（包含预先获取的实体数量）
+
+        # Update simulation state (including the pre-fetched entity count)
         state.status = SimulationStatus.PREPARING
         manager._save_simulation_state(state)
-        
+
         # Capture locale before spawning background thread
         current_locale = get_locale()
 
-        # 定义后台任务
+        # Define the background task
         def run_prepare():
             set_locale(current_locale)
             try:
@@ -514,35 +517,35 @@ def prepare_simulation():
                     progress=0,
                     message=t('progress.startPreparingEnv')
                 )
-                
-                # 准备模拟（带进度回调）
-                # 存储阶段进度详情
+
+                # Prepare the simulation (with progress callback)
+                # Store per-stage progress details
                 stage_details = {}
-                
+
                 def progress_callback(stage, progress, message, **kwargs):
-                    # 计算总进度
+                    # Compute total progress
                     stage_weights = {
                         "reading": (0, 20),           # 0-20%
                         "generating_profiles": (20, 70),  # 20-70%
                         "generating_config": (70, 90),    # 70-90%
                         "copying_scripts": (90, 100)       # 90-100%
                     }
-                    
+
                     start, end = stage_weights.get(stage, (0, 100))
                     current_progress = int(start + (end - start) * progress / 100)
-                    
-                    # 构建详细进度信息
+
+                    # Build detailed progress info
                     stage_names = {
                         "reading": t('progress.readingGraphEntities'),
                         "generating_profiles": t('progress.generatingProfiles'),
                         "generating_config": t('progress.generatingSimConfig'),
                         "copying_scripts": t('progress.preparingScripts')
                     }
-                    
+
                     stage_index = list(stage_weights.keys()).index(stage) + 1 if stage in stage_weights else 1
                     total_stages = len(stage_weights)
-                    
-                    # 更新阶段详情
+
+                    # Update stage details
                     stage_details[stage] = {
                         "stage_name": stage_names.get(stage, stage),
                         "stage_progress": progress,
@@ -550,8 +553,8 @@ def prepare_simulation():
                         "total": kwargs.get("total", 0),
                         "item_name": kwargs.get("item_name", "")
                     }
-                    
-                    # 构建详细进度信息
+
+                    # Build detailed progress info
                     detail = stage_details[stage]
                     progress_detail_data = {
                         "current_stage": stage,
@@ -563,8 +566,8 @@ def prepare_simulation():
                         "total_items": detail["total"],
                         "item_description": message
                     }
-                    
-                    # 构建简洁消息
+
+                    # Build a concise message
                     if detail["total"] > 0:
                         detailed_message = (
                             f"[{stage_index}/{total_stages}] {stage_names.get(stage, stage)}: "
@@ -572,14 +575,14 @@ def prepare_simulation():
                         )
                     else:
                         detailed_message = f"[{stage_index}/{total_stages}] {stage_names.get(stage, stage)}: {message}"
-                    
+
                     task_manager.update_task(
                         task_id,
                         progress=current_progress,
                         message=detailed_message,
                         progress_detail=progress_detail_data
                     )
-                
+
                 result_state = manager.prepare_simulation(
                     simulation_id=simulation_id,
                     simulation_requirement=simulation_requirement,
@@ -589,28 +592,28 @@ def prepare_simulation():
                     progress_callback=progress_callback,
                     parallel_profile_count=parallel_profile_count
                 )
-                
-                # 任务完成
+
+                # Task complete
                 task_manager.complete_task(
                     task_id,
                     result=result_state.to_simple_dict()
                 )
-                
+
             except Exception as e:
-                logger.error(f"准备模拟失败: {str(e)}")
+                logger.error(f"Simulation preparation failed: {str(e)}")
                 task_manager.fail_task(task_id, str(e))
-                
-                # 更新模拟状态为失败
+
+                # Mark simulation state as failed
                 state = manager.get_simulation(simulation_id)
                 if state:
                     state.status = SimulationStatus.FAILED
                     state.error = str(e)
                     manager._save_simulation_state(state)
-        
-        # 启动后台线程
+
+        # Start the background thread
         thread = threading.Thread(target=run_prepare, daemon=True)
         thread.start()
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -619,19 +622,19 @@ def prepare_simulation():
                 "status": "preparing",
                 "message": t('api.prepareStarted'),
                 "already_prepared": False,
-                "expected_entities_count": state.entities_count,  # 预期的Agent总数
-                "entity_types": state.entity_types  # 实体类型列表
+                "expected_entities_count": state.entities_count,  # expected total Agent count
+                "entity_types": state.entity_types  # list of entity types
             }
         })
-        
+
     except ValueError as e:
         return jsonify({
             "success": False,
             "error": str(e)
         }), 404
-        
+
     except Exception as e:
-        logger.error(f"启动准备任务失败: {str(e)}")
+        logger.error(f"Failed to start preparation task: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -642,19 +645,19 @@ def prepare_simulation():
 @simulation_bp.route('/prepare/status', methods=['POST'])
 def get_prepare_status():
     """
-    查询准备任务进度
-    
-    支持两种查询方式：
-    1. 通过task_id查询正在进行的任务进度
-    2. 通过simulation_id检查是否已有完成的准备工作
-    
-    请求（JSON）：
+    Query preparation task progress.
+
+    Two query modes are supported:
+    1. Query the progress of an in-flight task by task_id.
+    2. Use simulation_id to check whether preparation is already complete.
+
+    Request (JSON):
         {
-            "task_id": "task_xxxx",          // 可选，prepare返回的task_id
-            "simulation_id": "sim_xxxx"      // 可选，模拟ID（用于检查已完成的准备）
+            "task_id": "task_xxxx",          // optional, task_id returned by prepare
+            "simulation_id": "sim_xxxx"      // optional, simulation ID (used to check for already-completed preparation)
         }
-    
-    返回：
+
+    Response:
         {
             "success": true,
             "data": {
@@ -662,20 +665,20 @@ def get_prepare_status():
                 "status": "processing|completed|ready",
                 "progress": 45,
                 "message": "...",
-                "already_prepared": true|false,  // 是否已有完成的准备
-                "prepare_info": {...}            // 已准备完成时的详细信息
+                "already_prepared": true|false,  // whether preparation is already complete
+                "prepare_info": {...}            // detailed info when preparation is already complete
             }
         }
     """
     from ..models.task import TaskManager
-    
+
     try:
         data = request.get_json() or {}
-        
+
         task_id = data.get('task_id')
         simulation_id = data.get('simulation_id')
-        
-        # 如果提供了simulation_id，先检查是否已准备完成
+
+        # If a simulation_id was provided, first check whether preparation is complete
         if simulation_id:
             is_prepared, prepare_info = _check_simulation_prepared(simulation_id)
             if is_prepared:
@@ -690,11 +693,11 @@ def get_prepare_status():
                         "prepare_info": prepare_info
                     }
                 })
-        
-        # 如果没有task_id，返回错误
+
+        # If there is no task_id, return an error
         if not task_id:
             if simulation_id:
-                # 有simulation_id但未准备完成
+                # simulation_id was provided but preparation isn't complete
                 return jsonify({
                     "success": True,
                     "data": {
@@ -709,12 +712,12 @@ def get_prepare_status():
                 "success": False,
                 "error": t('api.requireTaskOrSimId')
             }), 400
-        
+
         task_manager = TaskManager()
         task = task_manager.get_task(task_id)
-        
+
         if not task:
-            # 任务不存在，但如果有simulation_id，检查是否已准备完成
+            # The task doesn't exist; if a simulation_id was provided, check whether preparation is complete
             if simulation_id:
                 is_prepared, prepare_info = _check_simulation_prepared(simulation_id)
                 if is_prepared:
@@ -730,22 +733,22 @@ def get_prepare_status():
                             "prepare_info": prepare_info
                         }
                     })
-            
+
             return jsonify({
                 "success": False,
                 "error": t('api.taskNotFound', id=task_id)
             }), 404
-        
+
         task_dict = task.to_dict()
         task_dict["already_prepared"] = False
-        
+
         return jsonify({
             "success": True,
             "data": task_dict
         })
-        
+
     except Exception as e:
-        logger.error(f"查询任务状态失败: {str(e)}")
+        logger.error(f"Failed to query task status: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e)
@@ -754,30 +757,30 @@ def get_prepare_status():
 
 @simulation_bp.route('/<simulation_id>', methods=['GET'])
 def get_simulation(simulation_id: str):
-    """获取模拟状态"""
+    """Get simulation status"""
     try:
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
-        
+
         if not state:
             return jsonify({
                 "success": False,
                 "error": t('api.simulationNotFound', id=simulation_id)
             }), 404
-        
+
         result = state.to_dict()
-        
-        # 如果模拟已准备好，附加运行说明
+
+        # If the simulation is ready, include the run instructions
         if state.status == SimulationStatus.READY:
             result["run_instructions"] = manager.get_run_instructions(simulation_id)
-        
+
         return jsonify({
             "success": True,
             "data": result
         })
-        
+
     except Exception as e:
-        logger.error(f"获取模拟状态失败: {str(e)}")
+        logger.error(f"Failed to fetch simulation status: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -788,25 +791,25 @@ def get_simulation(simulation_id: str):
 @simulation_bp.route('/list', methods=['GET'])
 def list_simulations():
     """
-    列出所有模拟
-    
-    Query参数：
-        project_id: 按项目ID过滤（可选）
+    List all simulations.
+
+    Query parameters:
+        project_id: filter by project ID (optional)
     """
     try:
         project_id = request.args.get('project_id')
-        
+
         manager = SimulationManager()
         simulations = manager.list_simulations(project_id=project_id)
-        
+
         return jsonify({
             "success": True,
             "data": [s.to_dict() for s in simulations],
             "count": len(simulations)
         })
-        
+
     except Exception as e:
-        logger.error(f"列出模拟失败: {str(e)}")
+        logger.error(f"Failed to list simulations: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -816,42 +819,42 @@ def list_simulations():
 
 def _get_report_id_for_simulation(simulation_id: str) -> str:
     """
-    获取 simulation 对应的最新 report_id
-    
-    遍历 reports 目录，找出 simulation_id 匹配的 report，
-    如果有多个则返回最新的（按 created_at 排序）
-    
+    Get the most recent report_id corresponding to a simulation.
+
+    Iterates over the reports directory to find reports matching the given simulation_id.
+    If multiple match, returns the most recent (sorted by created_at).
+
     Args:
-        simulation_id: 模拟ID
-        
+        simulation_id: simulation ID
+
     Returns:
-        report_id 或 None
+        report_id, or None
     """
     import json
     from datetime import datetime
-    
-    # reports 目录路径：backend/uploads/reports
-    # __file__ 是 app/api/simulation.py，需要向上两级到 backend/
+
+    # Reports directory path: backend/uploads/reports
+    # __file__ is app/api/simulation.py, so go up two levels to backend/
     reports_dir = os.path.join(os.path.dirname(__file__), '../../uploads/reports')
     if not os.path.exists(reports_dir):
         return None
-    
+
     matching_reports = []
-    
+
     try:
         for report_folder in os.listdir(reports_dir):
             report_path = os.path.join(reports_dir, report_folder)
             if not os.path.isdir(report_path):
                 continue
-            
+
             meta_file = os.path.join(report_path, "meta.json")
             if not os.path.exists(meta_file):
                 continue
-            
+
             try:
                 with open(meta_file, 'r', encoding='utf-8') as f:
                     meta = json.load(f)
-                
+
                 if meta.get("simulation_id") == simulation_id:
                     matching_reports.append({
                         "report_id": meta.get("report_id"),
@@ -860,38 +863,39 @@ def _get_report_id_for_simulation(simulation_id: str) -> str:
                     })
             except Exception:
                 continue
-        
+
         if not matching_reports:
             return None
-        
-        # 按创建时间倒序排序，返回最新的
+
+        # Sort by creation time descending and return the most recent
         matching_reports.sort(key=lambda x: x.get("created_at", ""), reverse=True)
         return matching_reports[0].get("report_id")
-        
+
     except Exception as e:
-        logger.warning(f"查找 simulation {simulation_id} 的 report 失败: {e}")
+        logger.warning(f"Failed to find report for simulation {simulation_id}: {e}")
         return None
 
 
 @simulation_bp.route('/history', methods=['GET'])
 def get_simulation_history():
     """
-    获取历史模拟列表（带项目详情）
-    
-    用于首页历史项目展示，返回包含项目名称、描述等丰富信息的模拟列表
-    
-    Query参数：
-        limit: 返回数量限制（默认20）
-    
-    返回：
+    Get the historical simulations list (with project details).
+
+    Used to display historical projects on the home page; returns a simulation list
+    enriched with project name, description, and other detailed information.
+
+    Query parameters:
+        limit: maximum number of items to return (default 20)
+
+    Response:
         {
             "success": true,
             "data": [
                 {
                     "simulation_id": "sim_xxxx",
                     "project_id": "proj_xxxx",
-                    "project_name": "武大舆情分析",
-                    "simulation_requirement": "如果武汉大学发布...",
+                    "project_name": "Wuhan University sentiment analysis",
+                    "simulation_requirement": "If Wuhan University publishes...",
                     "status": "completed",
                     "entities_count": 68,
                     "profiles_count": 68,
@@ -910,76 +914,76 @@ def get_simulation_history():
     """
     try:
         limit = request.args.get('limit', 20, type=int)
-        
+
         manager = SimulationManager()
         simulations = manager.list_simulations()[:limit]
-        
-        # 增强模拟数据，只从 Simulation 文件读取
+
+        # Enrich the simulation data, reading only from Simulation files
         enriched_simulations = []
         for sim in simulations:
             sim_dict = sim.to_dict()
-            
-            # 获取模拟配置信息（从 simulation_config.json 读取 simulation_requirement）
+
+            # Get simulation config (read simulation_requirement from simulation_config.json)
             config = manager.get_simulation_config(sim.simulation_id)
             if config:
                 sim_dict["simulation_requirement"] = config.get("simulation_requirement", "")
                 time_config = config.get("time_config", {})
                 sim_dict["total_simulation_hours"] = time_config.get("total_simulation_hours", 0)
-                # 推荐轮数（后备值）
+                # Recommended round count (fallback value)
                 recommended_rounds = int(
-                    time_config.get("total_simulation_hours", 0) * 60 / 
+                    time_config.get("total_simulation_hours", 0) * 60 /
                     max(time_config.get("minutes_per_round", 60), 1)
                 )
             else:
                 sim_dict["simulation_requirement"] = ""
                 sim_dict["total_simulation_hours"] = 0
                 recommended_rounds = 0
-            
-            # 获取运行状态（从 run_state.json 读取用户设置的实际轮数）
+
+            # Get run state (read the user-set total_rounds from run_state.json)
             run_state = SimulationRunner.get_run_state(sim.simulation_id)
             if run_state:
                 sim_dict["current_round"] = run_state.current_round
                 sim_dict["runner_status"] = run_state.runner_status.value
-                # 使用用户设置的 total_rounds，若无则使用推荐轮数
+                # Use the user-set total_rounds; if missing, fall back to the recommended count
                 sim_dict["total_rounds"] = run_state.total_rounds if run_state.total_rounds > 0 else recommended_rounds
             else:
                 sim_dict["current_round"] = 0
                 sim_dict["runner_status"] = "idle"
                 sim_dict["total_rounds"] = recommended_rounds
-            
-            # 获取关联项目的文件列表（最多3个）
+
+            # Get the file list of the associated project (up to 3)
             project = ProjectManager.get_project(sim.project_id)
             if project and hasattr(project, 'files') and project.files:
                 sim_dict["files"] = [
-                    {"filename": f.get("filename", "未知文件")} 
+                    {"filename": f.get("filename", "Unknown file")}
                     for f in project.files[:3]
                 ]
             else:
                 sim_dict["files"] = []
-            
-            # 获取关联的 report_id（查找该 simulation 最新的 report）
+
+            # Get the associated report_id (find the most recent report for this simulation)
             sim_dict["report_id"] = _get_report_id_for_simulation(sim.simulation_id)
-            
-            # 添加版本号
+
+            # Add version
             sim_dict["version"] = "v1.0.2"
-            
-            # 格式化日期
+
+            # Format the date
             try:
                 created_date = sim_dict.get("created_at", "")[:10]
                 sim_dict["created_date"] = created_date
             except:
                 sim_dict["created_date"] = ""
-            
+
             enriched_simulations.append(sim_dict)
-        
+
         return jsonify({
             "success": True,
             "data": enriched_simulations,
             "count": len(enriched_simulations)
         })
-        
+
     except Exception as e:
-        logger.error(f"获取历史模拟失败: {str(e)}")
+        logger.error(f"Failed to fetch historical simulations: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -990,17 +994,17 @@ def get_simulation_history():
 @simulation_bp.route('/<simulation_id>/profiles', methods=['GET'])
 def get_simulation_profiles(simulation_id: str):
     """
-    获取模拟的Agent Profile
-    
-    Query参数：
-        platform: 平台类型（reddit/twitter，默认reddit）
+    Get the simulation's Agent Profiles.
+
+    Query parameters:
+        platform: platform type (reddit/twitter, default reddit)
     """
     try:
         platform = request.args.get('platform', 'reddit')
-        
+
         manager = SimulationManager()
         profiles = manager.get_profiles(simulation_id, platform=platform)
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -1009,15 +1013,15 @@ def get_simulation_profiles(simulation_id: str):
                 "profiles": profiles
             }
         })
-        
+
     except ValueError as e:
         return jsonify({
             "success": False,
             "error": str(e)
         }), 404
-        
+
     except Exception as e:
-        logger.error(f"获取Profile失败: {str(e)}")
+        logger.error(f"Failed to fetch profiles: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1028,25 +1032,25 @@ def get_simulation_profiles(simulation_id: str):
 @simulation_bp.route('/<simulation_id>/profiles/realtime', methods=['GET'])
 def get_simulation_profiles_realtime(simulation_id: str):
     """
-    实时获取模拟的Agent Profile（用于在生成过程中实时查看进度）
-    
-    与 /profiles 接口的区别：
-    - 直接读取文件，不经过 SimulationManager
-    - 适用于生成过程中的实时查看
-    - 返回额外的元数据（如文件修改时间、是否正在生成等）
-    
-    Query参数：
-        platform: 平台类型（reddit/twitter，默认reddit）
-    
-    返回：
+    Get simulation Agent Profiles in real time (for monitoring progress during generation).
+
+    Differences from /profiles:
+    - Reads files directly, bypassing SimulationManager.
+    - Suitable for real-time inspection during generation.
+    - Returns extra metadata (e.g. file modification time, whether generation is in progress).
+
+    Query parameters:
+        platform: platform type (reddit/twitter, default reddit)
+
+    Response:
         {
             "success": true,
             "data": {
                 "simulation_id": "sim_xxxx",
                 "platform": "reddit",
                 "count": 15,
-                "total_expected": 93,  // 预期总数（如果有）
-                "is_generating": true,  // 是否正在生成
+                "total_expected": 93,  // expected total (when available)
+                "is_generating": true,  // whether generation is in progress
                 "file_exists": true,
                 "file_modified_at": "2025-12-04T18:20:00",
                 "profiles": [...]
@@ -1056,35 +1060,35 @@ def get_simulation_profiles_realtime(simulation_id: str):
     import json
     import csv
     from datetime import datetime
-    
+
     try:
         platform = request.args.get('platform', 'reddit')
-        
-        # 获取模拟目录
+
+        # Get the simulation directory
         sim_dir = os.path.join(Config.OASIS_SIMULATION_DATA_DIR, simulation_id)
-        
+
         if not os.path.exists(sim_dir):
             return jsonify({
                 "success": False,
                 "error": t('api.simulationNotFound', id=simulation_id)
             }), 404
-        
-        # 确定文件路径
+
+        # Determine the file path
         if platform == "reddit":
             profiles_file = os.path.join(sim_dir, "reddit_profiles.json")
         else:
             profiles_file = os.path.join(sim_dir, "twitter_profiles.csv")
-        
-        # 检查文件是否存在
+
+        # Check whether the file exists
         file_exists = os.path.exists(profiles_file)
         profiles = []
         file_modified_at = None
-        
+
         if file_exists:
-            # 获取文件修改时间
+            # Get the file modification time
             file_stat = os.stat(profiles_file)
             file_modified_at = datetime.fromtimestamp(file_stat.st_mtime).isoformat()
-            
+
             try:
                 if platform == "reddit":
                     with open(profiles_file, 'r', encoding='utf-8') as f:
@@ -1094,13 +1098,13 @@ def get_simulation_profiles_realtime(simulation_id: str):
                         reader = csv.DictReader(f)
                         profiles = list(reader)
             except (json.JSONDecodeError, Exception) as e:
-                logger.warning(f"读取 profiles 文件失败（可能正在写入中）: {e}")
+                logger.warning(f"Failed to read profiles file (may be mid-write): {e}")
                 profiles = []
-        
-        # 检查是否正在生成（通过 state.json 判断）
+
+        # Determine whether generation is in progress (via state.json)
         is_generating = False
         total_expected = None
-        
+
         state_file = os.path.join(sim_dir, "state.json")
         if os.path.exists(state_file):
             try:
@@ -1111,7 +1115,7 @@ def get_simulation_profiles_realtime(simulation_id: str):
                     total_expected = state_data.get("entities_count")
             except Exception:
                 pass
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -1125,9 +1129,9 @@ def get_simulation_profiles_realtime(simulation_id: str):
                 "profiles": profiles
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"实时获取Profile失败: {str(e)}")
+        logger.error(f"Real-time profile fetch failed: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1138,65 +1142,65 @@ def get_simulation_profiles_realtime(simulation_id: str):
 @simulation_bp.route('/<simulation_id>/config/realtime', methods=['GET'])
 def get_simulation_config_realtime(simulation_id: str):
     """
-    实时获取模拟配置（用于在生成过程中实时查看进度）
-    
-    与 /config 接口的区别：
-    - 直接读取文件，不经过 SimulationManager
-    - 适用于生成过程中的实时查看
-    - 返回额外的元数据（如文件修改时间、是否正在生成等）
-    - 即使配置还没生成完也能返回部分信息
-    
-    返回：
+    Get the simulation configuration in real time (for monitoring progress during generation).
+
+    Differences from /config:
+    - Reads files directly, bypassing SimulationManager.
+    - Suitable for real-time inspection during generation.
+    - Returns extra metadata (e.g. file modification time, whether generation is in progress).
+    - Returns partial information even when configuration generation has not yet finished.
+
+    Response:
         {
             "success": true,
             "data": {
                 "simulation_id": "sim_xxxx",
                 "file_exists": true,
                 "file_modified_at": "2025-12-04T18:20:00",
-                "is_generating": true,  // 是否正在生成
-                "generation_stage": "generating_config",  // 当前生成阶段
-                "config": {...}  // 配置内容（如果存在）
+                "is_generating": true,  // whether generation is in progress
+                "generation_stage": "generating_config",  // current generation stage
+                "config": {...}  // configuration content (if it exists)
             }
         }
     """
     import json
     from datetime import datetime
-    
+
     try:
-        # 获取模拟目录
+        # Get the simulation directory
         sim_dir = os.path.join(Config.OASIS_SIMULATION_DATA_DIR, simulation_id)
-        
+
         if not os.path.exists(sim_dir):
             return jsonify({
                 "success": False,
                 "error": t('api.simulationNotFound', id=simulation_id)
             }), 404
-        
-        # 配置文件路径
+
+        # Configuration file path
         config_file = os.path.join(sim_dir, "simulation_config.json")
-        
-        # 检查文件是否存在
+
+        # Check whether the file exists
         file_exists = os.path.exists(config_file)
         config = None
         file_modified_at = None
-        
+
         if file_exists:
-            # 获取文件修改时间
+            # Get the file modification time
             file_stat = os.stat(config_file)
             file_modified_at = datetime.fromtimestamp(file_stat.st_mtime).isoformat()
-            
+
             try:
                 with open(config_file, 'r', encoding='utf-8') as f:
                     config = json.load(f)
             except (json.JSONDecodeError, Exception) as e:
-                logger.warning(f"读取 config 文件失败（可能正在写入中）: {e}")
+                logger.warning(f"Failed to read config file (may be mid-write): {e}")
                 config = None
-        
-        # 检查是否正在生成（通过 state.json 判断）
+
+        # Determine whether generation is in progress (via state.json)
         is_generating = False
         generation_stage = None
         config_generated = False
-        
+
         state_file = os.path.join(sim_dir, "state.json")
         if os.path.exists(state_file):
             try:
@@ -1205,8 +1209,8 @@ def get_simulation_config_realtime(simulation_id: str):
                     status = state_data.get("status", "")
                     is_generating = status == "preparing"
                     config_generated = state_data.get("config_generated", False)
-                    
-                    # 判断当前阶段
+
+                    # Determine the current stage
                     if is_generating:
                         if state_data.get("profiles_generated", False):
                             generation_stage = "generating_config"
@@ -1216,8 +1220,8 @@ def get_simulation_config_realtime(simulation_id: str):
                         generation_stage = "completed"
             except Exception:
                 pass
-        
-        # 构建返回数据
+
+        # Build the response
         response_data = {
             "simulation_id": simulation_id,
             "file_exists": file_exists,
@@ -1227,8 +1231,8 @@ def get_simulation_config_realtime(simulation_id: str):
             "config_generated": config_generated,
             "config": config
         }
-        
-        # 如果配置存在，提取一些关键统计信息
+
+        # If the configuration exists, extract some key statistics
         if config:
             response_data["summary"] = {
                 "total_agents": len(config.get("agent_configs", [])),
@@ -1240,14 +1244,14 @@ def get_simulation_config_realtime(simulation_id: str):
                 "generated_at": config.get("generated_at"),
                 "llm_model": config.get("llm_model")
             }
-        
+
         return jsonify({
             "success": True,
             "data": response_data
         })
-        
+
     except Exception as e:
-        logger.error(f"实时获取Config失败: {str(e)}")
+        logger.error(f"Real-time config fetch failed: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1258,32 +1262,32 @@ def get_simulation_config_realtime(simulation_id: str):
 @simulation_bp.route('/<simulation_id>/config', methods=['GET'])
 def get_simulation_config(simulation_id: str):
     """
-    获取模拟配置（LLM智能生成的完整配置）
-    
-    返回包含：
-        - time_config: 时间配置（模拟时长、轮次、高峰/低谷时段）
-        - agent_configs: 每个Agent的活动配置（活跃度、发言频率、立场等）
-        - event_config: 事件配置（初始帖子、热点话题）
-        - platform_configs: 平台配置
-        - generation_reasoning: LLM的配置推理说明
+    Get the simulation configuration (full configuration generated intelligently by the LLM).
+
+    Includes:
+        - time_config: time configuration (simulation duration, rounds, peak/off-peak windows)
+        - agent_configs: per-Agent activity configuration (activity level, posting rate, stance, etc.)
+        - event_config: event configuration (initial posts, hot topics)
+        - platform_configs: platform configuration
+        - generation_reasoning: the LLM's explanation of its configuration choices
     """
     try:
         manager = SimulationManager()
         config = manager.get_simulation_config(simulation_id)
-        
+
         if not config:
             return jsonify({
                 "success": False,
                 "error": t('api.configNotFound')
             }), 404
-        
+
         return jsonify({
             "success": True,
             "data": config
         })
-        
+
     except Exception as e:
-        logger.error(f"获取配置失败: {str(e)}")
+        logger.error(f"Failed to fetch configuration: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1293,26 +1297,26 @@ def get_simulation_config(simulation_id: str):
 
 @simulation_bp.route('/<simulation_id>/config/download', methods=['GET'])
 def download_simulation_config(simulation_id: str):
-    """下载模拟配置文件"""
+    """Download the simulation configuration file"""
     try:
         manager = SimulationManager()
         sim_dir = manager._get_simulation_dir(simulation_id)
         config_path = os.path.join(sim_dir, "simulation_config.json")
-        
+
         if not os.path.exists(config_path):
             return jsonify({
                 "success": False,
                 "error": t('api.configFileNotFound')
             }), 404
-        
+
         return send_file(
             config_path,
             as_attachment=True,
             download_name="simulation_config.json"
         )
-        
+
     except Exception as e:
-        logger.error(f"下载配置失败: {str(e)}")
+        logger.error(f"Failed to download configuration: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1323,48 +1327,48 @@ def download_simulation_config(simulation_id: str):
 @simulation_bp.route('/script/<script_name>/download', methods=['GET'])
 def download_simulation_script(script_name: str):
     """
-    下载模拟运行脚本文件（通用脚本，位于 backend/scripts/）
-    
-    script_name可选值：
+    Download a simulation run script (shared scripts living in backend/scripts/).
+
+    Allowed values for script_name:
         - run_twitter_simulation.py
         - run_reddit_simulation.py
         - run_parallel_simulation.py
         - action_logger.py
     """
     try:
-        # 脚本位于 backend/scripts/ 目录
+        # Scripts live in the backend/scripts/ directory
         scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../scripts'))
-        
-        # 验证脚本名称
+
+        # Validate the script name
         allowed_scripts = [
             "run_twitter_simulation.py",
-            "run_reddit_simulation.py", 
+            "run_reddit_simulation.py",
             "run_parallel_simulation.py",
             "action_logger.py"
         ]
-        
+
         if script_name not in allowed_scripts:
             return jsonify({
                 "success": False,
                 "error": t('api.unknownScript', name=script_name, allowed=allowed_scripts)
             }), 400
-        
+
         script_path = os.path.join(scripts_dir, script_name)
-        
+
         if not os.path.exists(script_path):
             return jsonify({
                 "success": False,
                 "error": t('api.scriptFileNotFound', name=script_name)
             }), 404
-        
+
         return send_file(
             script_path,
             as_attachment=True,
             download_name=script_name
         )
-        
+
     except Exception as e:
-        logger.error(f"下载脚本失败: {str(e)}")
+        logger.error(f"Failed to download script: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1372,61 +1376,61 @@ def download_simulation_script(script_name: str):
         }), 500
 
 
-# ============== Profile生成接口（独立使用） ==============
+# ============== Profile generation endpoint (standalone) ==============
 
 @simulation_bp.route('/generate-profiles', methods=['POST'])
 def generate_profiles():
     """
-    直接从图谱生成OASIS Agent Profile（不创建模拟）
-    
-    请求（JSON）：
+    Generate OASIS Agent Profiles directly from the graph (without creating a simulation).
+
+    Request (JSON):
         {
-            "graph_id": "mirofish_xxxx",     // 必填
-            "entity_types": ["Student"],      // 可选
-            "use_llm": true,                  // 可选
-            "platform": "reddit"              // 可选
+            "graph_id": "mirofish_xxxx",     // required
+            "entity_types": ["Student"],      // optional
+            "use_llm": true,                  // optional
+            "platform": "reddit"              // optional
         }
     """
     try:
         data = request.get_json() or {}
-        
+
         graph_id = data.get('graph_id')
         if not graph_id:
             return jsonify({
                 "success": False,
                 "error": t('api.requireGraphId')
             }), 400
-        
+
         entity_types = data.get('entity_types')
         use_llm = data.get('use_llm', True)
         platform = data.get('platform', 'reddit')
-        
+
         reader = ZepEntityReader()
         filtered = reader.filter_defined_entities(
             graph_id=graph_id,
             defined_entity_types=entity_types,
             enrich_with_edges=True
         )
-        
+
         if filtered.filtered_count == 0:
             return jsonify({
                 "success": False,
                 "error": t('api.noMatchingEntities')
             }), 400
-        
+
         generator = OasisProfileGenerator()
         profiles = generator.generate_profiles_from_entities(
             entities=filtered.entities,
             use_llm=use_llm
         )
-        
+
         if platform == "reddit":
             profiles_data = [p.to_reddit_format() for p in profiles]
         elif platform == "twitter":
             profiles_data = [p.to_twitter_format() for p in profiles]
         else:
             profiles_data = [p.to_dict() for p in profiles]
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -1436,9 +1440,9 @@ def generate_profiles():
                 "profiles": profiles_data
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"生成Profile失败: {str(e)}")
+        logger.error(f"Failed to generate profiles: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1446,35 +1450,35 @@ def generate_profiles():
         }), 500
 
 
-# ============== 模拟运行控制接口 ==============
+# ============== Simulation run-control endpoints ==============
 
 @simulation_bp.route('/start', methods=['POST'])
 def start_simulation():
     """
-    开始运行模拟
+    Start running a simulation.
 
-    请求（JSON）：
+    Request (JSON):
         {
-            "simulation_id": "sim_xxxx",          // 必填，模拟ID
-            "platform": "parallel",                // 可选: twitter / reddit / parallel (默认)
-            "max_rounds": 100,                     // 可选: 最大模拟轮数，用于截断过长的模拟
-            "enable_graph_memory_update": false,   // 可选: 是否将Agent活动动态更新到Zep图谱记忆
-            "force": false                         // 可选: 强制重新开始（会停止运行中的模拟并清理日志）
+            "simulation_id": "sim_xxxx",          // required, simulation ID
+            "platform": "parallel",                // optional: twitter / reddit / parallel (default)
+            "max_rounds": 100,                     // optional: maximum number of simulation rounds; truncates over-long simulations
+            "enable_graph_memory_update": false,   // optional: whether to dynamically push Agent activity into the Zep graph memory
+            "force": false                         // optional: force-restart (stops a running simulation and clears its logs)
         }
 
-    关于 force 参数：
-        - 启用后，如果模拟正在运行或已完成，会先停止并清理运行日志
-        - 清理的内容包括：run_state.json, actions.jsonl, simulation.log 等
-        - 不会清理配置文件（simulation_config.json）和 profile 文件
-        - 适用于需要重新运行模拟的场景
+    About the `force` parameter:
+        - When enabled, if the simulation is running or already finished, it is stopped first and its run logs cleared.
+        - Cleared content includes: run_state.json, actions.jsonl, simulation.log, etc.
+        - Configuration files (simulation_config.json) and profile files are not cleared.
+        - Useful for scenarios where the simulation needs to be re-run.
 
-    关于 enable_graph_memory_update：
-        - 启用后，模拟中所有Agent的活动（发帖、评论、点赞等）都会实时更新到Zep图谱
-        - 这可以让图谱"记住"模拟过程，用于后续分析或AI对话
-        - 需要模拟关联的项目有有效的 graph_id
-        - 采用批量更新机制，减少API调用次数
+    About `enable_graph_memory_update`:
+        - When enabled, all Agent activity in the simulation (posts, comments, likes, etc.) is pushed to the Zep graph in real time.
+        - This lets the graph "remember" the simulation for later analysis or AI chat.
+        - The simulation's associated project must have a valid graph_id.
+        - Uses a batch-update mechanism to reduce API call counts.
 
-    返回：
+    Response:
         {
             "success": true,
             "data": {
@@ -1484,8 +1488,8 @@ def start_simulation():
                 "twitter_running": true,
                 "reddit_running": true,
                 "started_at": "2025-12-01T10:00:00",
-                "graph_memory_update_enabled": true,  // 是否启用了图谱记忆更新
-                "force_restarted": true               // 是否是强制重新开始
+                "graph_memory_update_enabled": true,  // whether graph-memory updates are enabled
+                "force_restarted": true               // whether this was a forced restart
             }
         }
     """
@@ -1500,11 +1504,11 @@ def start_simulation():
             }), 400
 
         platform = data.get('platform', 'parallel')
-        max_rounds = data.get('max_rounds')  # 可选：最大模拟轮数
-        enable_graph_memory_update = data.get('enable_graph_memory_update', False)  # 可选：是否启用图谱记忆更新
-        force = data.get('force', False)  # 可选：强制重新开始
+        max_rounds = data.get('max_rounds')  # optional: maximum simulation rounds
+        enable_graph_memory_update = data.get('enable_graph_memory_update', False)  # optional: whether to enable graph-memory updates
+        force = data.get('force', False)  # optional: force restart
 
-        # 验证 max_rounds 参数
+        # Validate the max_rounds parameter
         if max_rounds is not None:
             try:
                 max_rounds = int(max_rounds)
@@ -1525,7 +1529,7 @@ def start_simulation():
                 "error": t('api.invalidPlatform', platform=platform)
             }), 400
 
-        # 检查模拟是否已准备好
+        # Check whether the simulation is ready
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
 
@@ -1536,71 +1540,71 @@ def start_simulation():
             }), 404
 
         force_restarted = False
-        
-        # 智能处理状态：如果准备工作已完成，允许重新启动
+
+        # State handling: if preparation is complete, allow a restart
         if state.status != SimulationStatus.READY:
-            # 检查准备工作是否已完成
+            # Check whether preparation has finished
             is_prepared, prepare_info = _check_simulation_prepared(simulation_id)
 
             if is_prepared:
-                # 准备工作已完成，检查是否有正在运行的进程
+                # Preparation is complete; check whether a process is currently running
                 if state.status == SimulationStatus.RUNNING:
-                    # 检查模拟进程是否真的在运行
+                    # Check whether the simulation process is actually running
                     run_state = SimulationRunner.get_run_state(simulation_id)
                     if run_state and run_state.runner_status.value == "running":
-                        # 进程确实在运行
+                        # The process really is running
                         if force:
-                            # 强制模式：停止运行中的模拟
-                            logger.info(f"强制模式：停止运行中的模拟 {simulation_id}")
+                            # Force mode: stop the running simulation
+                            logger.info(f"Force mode: stopping running simulation {simulation_id}")
                             try:
                                 SimulationRunner.stop_simulation(simulation_id)
                             except Exception as e:
-                                logger.warning(f"停止模拟时出现警告: {str(e)}")
+                                logger.warning(f"Warning while stopping simulation: {str(e)}")
                         else:
                             return jsonify({
                                 "success": False,
                                 "error": t('api.simRunningForceHint')
                             }), 400
 
-                # 如果是强制模式，清理运行日志
+                # In force mode, clear the run logs
                 if force:
-                    logger.info(f"强制模式：清理模拟日志 {simulation_id}")
+                    logger.info(f"Force mode: cleaning up simulation logs {simulation_id}")
                     cleanup_result = SimulationRunner.cleanup_simulation_logs(simulation_id)
                     if not cleanup_result.get("success"):
-                        logger.warning(f"清理日志时出现警告: {cleanup_result.get('errors')}")
+                        logger.warning(f"Warning while cleaning logs: {cleanup_result.get('errors')}")
                     force_restarted = True
 
-                # 进程不存在或已结束，重置状态为 ready
-                logger.info(f"模拟 {simulation_id} 准备工作已完成，重置状态为 ready（原状态: {state.status.value}）")
+                # The process doesn't exist or has already exited; reset state to "ready"
+                logger.info(f"Simulation {simulation_id} preparation is complete; resetting state to ready (previous status: {state.status.value})")
                 state.status = SimulationStatus.READY
                 manager._save_simulation_state(state)
             else:
-                # 准备工作未完成
+                # Preparation isn't complete
                 return jsonify({
                     "success": False,
                     "error": t('api.simNotReady', status=state.status.value)
                 }), 400
-        
-        # 获取图谱ID（用于图谱记忆更新）
+
+        # Get the graph ID (used for graph-memory updates)
         graph_id = None
         if enable_graph_memory_update:
-            # 从模拟状态或项目中获取 graph_id
+            # Get graph_id from the simulation state or the project
             graph_id = state.graph_id
             if not graph_id:
-                # 尝试从项目中获取
+                # Try to get it from the project
                 project = ProjectManager.get_project(state.project_id)
                 if project:
                     graph_id = project.graph_id
-            
+
             if not graph_id:
                 return jsonify({
                     "success": False,
                     "error": t('api.graphIdRequiredForMemory')
                 }), 400
-            
-            logger.info(f"启用图谱记忆更新: simulation_id={simulation_id}, graph_id={graph_id}")
-        
-        # 启动模拟
+
+            logger.info(f"Graph-memory updates enabled: simulation_id={simulation_id}, graph_id={graph_id}")
+
+        # Start the simulation
         run_state = SimulationRunner.start_simulation(
             simulation_id=simulation_id,
             platform=platform,
@@ -1608,11 +1612,11 @@ def start_simulation():
             enable_graph_memory_update=enable_graph_memory_update,
             graph_id=graph_id
         )
-        
-        # 更新模拟状态
+
+        # Update simulation state
         state.status = SimulationStatus.RUNNING
         manager._save_simulation_state(state)
-        
+
         response_data = run_state.to_dict()
         if max_rounds:
             response_data['max_rounds_applied'] = max_rounds
@@ -1620,20 +1624,20 @@ def start_simulation():
         response_data['force_restarted'] = force_restarted
         if enable_graph_memory_update:
             response_data['graph_id'] = graph_id
-        
+
         return jsonify({
             "success": True,
             "data": response_data
         })
-        
+
     except ValueError as e:
         return jsonify({
             "success": False,
             "error": str(e)
         }), 400
-        
+
     except Exception as e:
-        logger.error(f"启动模拟失败: {str(e)}")
+        logger.error(f"Failed to start simulation: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1644,14 +1648,14 @@ def start_simulation():
 @simulation_bp.route('/stop', methods=['POST'])
 def stop_simulation():
     """
-    停止模拟
-    
-    请求（JSON）：
+    Stop a simulation.
+
+    Request (JSON):
         {
-            "simulation_id": "sim_xxxx"  // 必填，模拟ID
+            "simulation_id": "sim_xxxx"  // required, simulation ID
         }
-    
-    返回：
+
+    Response:
         {
             "success": true,
             "data": {
@@ -1663,36 +1667,36 @@ def stop_simulation():
     """
     try:
         data = request.get_json() or {}
-        
+
         simulation_id = data.get('simulation_id')
         if not simulation_id:
             return jsonify({
                 "success": False,
                 "error": t('api.requireSimulationId')
             }), 400
-        
+
         run_state = SimulationRunner.stop_simulation(simulation_id)
-        
-        # 更新模拟状态
+
+        # Update simulation state
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
         if state:
             state.status = SimulationStatus.PAUSED
             manager._save_simulation_state(state)
-        
+
         return jsonify({
             "success": True,
             "data": run_state.to_dict()
         })
-        
+
     except ValueError as e:
         return jsonify({
             "success": False,
             "error": str(e)
         }), 400
-        
+
     except Exception as e:
-        logger.error(f"停止模拟失败: {str(e)}")
+        logger.error(f"Failed to stop simulation: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1700,14 +1704,14 @@ def stop_simulation():
         }), 500
 
 
-# ============== 实时状态监控接口 ==============
+# ============== Real-time status monitoring endpoints ==============
 
 @simulation_bp.route('/<simulation_id>/run-status', methods=['GET'])
 def get_run_status(simulation_id: str):
     """
-    获取模拟运行实时状态（用于前端轮询）
-    
-    返回：
+    Get the simulation's real-time run status (used for front-end polling).
+
+    Response:
         {
             "success": true,
             "data": {
@@ -1730,7 +1734,7 @@ def get_run_status(simulation_id: str):
     """
     try:
         run_state = SimulationRunner.get_run_state(simulation_id)
-        
+
         if not run_state:
             return jsonify({
                 "success": True,
@@ -1745,14 +1749,14 @@ def get_run_status(simulation_id: str):
                     "total_actions_count": 0,
                 }
             })
-        
+
         return jsonify({
             "success": True,
             "data": run_state.to_dict()
         })
-        
+
     except Exception as e:
-        logger.error(f"获取运行状态失败: {str(e)}")
+        logger.error(f"Failed to fetch run status: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1763,14 +1767,14 @@ def get_run_status(simulation_id: str):
 @simulation_bp.route('/<simulation_id>/run-status/detail', methods=['GET'])
 def get_run_status_detail(simulation_id: str):
     """
-    获取模拟运行详细状态（包含所有动作）
-    
-    用于前端展示实时动态
-    
-    Query参数：
-        platform: 过滤平台（twitter/reddit，可选）
-    
-    返回：
+    Get the simulation's detailed run status (including all actions).
+
+    Used by the front-end to display real-time activity.
+
+    Query parameters:
+        platform: filter by platform (twitter/reddit, optional)
+
+    Response:
         {
             "success": true,
             "data": {
@@ -1792,15 +1796,15 @@ def get_run_status_detail(simulation_id: str):
                     },
                     ...
                 ],
-                "twitter_actions": [...],  # Twitter 平台的所有动作
-                "reddit_actions": [...]    # Reddit 平台的所有动作
+                "twitter_actions": [...],  # all actions on Twitter
+                "reddit_actions": [...]    # all actions on Reddit
             }
         }
     """
     try:
         run_state = SimulationRunner.get_run_state(simulation_id)
         platform_filter = request.args.get('platform')
-        
+
         if not run_state:
             return jsonify({
                 "success": True,
@@ -1812,48 +1816,48 @@ def get_run_status_detail(simulation_id: str):
                     "reddit_actions": []
                 }
             })
-        
-        # 获取完整的动作列表
+
+        # Get the full action list
         all_actions = SimulationRunner.get_all_actions(
             simulation_id=simulation_id,
             platform=platform_filter
         )
-        
-        # 分平台获取动作
+
+        # Get actions per platform
         twitter_actions = SimulationRunner.get_all_actions(
             simulation_id=simulation_id,
             platform="twitter"
         ) if not platform_filter or platform_filter == "twitter" else []
-        
+
         reddit_actions = SimulationRunner.get_all_actions(
             simulation_id=simulation_id,
             platform="reddit"
         ) if not platform_filter or platform_filter == "reddit" else []
-        
-        # 获取当前轮次的动作（recent_actions 只展示最新一轮）
+
+        # Get the current round's actions (recent_actions only shows the latest round)
         current_round = run_state.current_round
         recent_actions = SimulationRunner.get_all_actions(
             simulation_id=simulation_id,
             platform=platform_filter,
             round_num=current_round
         ) if current_round > 0 else []
-        
-        # 获取基础状态信息
+
+        # Get base status info
         result = run_state.to_dict()
         result["all_actions"] = [a.to_dict() for a in all_actions]
         result["twitter_actions"] = [a.to_dict() for a in twitter_actions]
         result["reddit_actions"] = [a.to_dict() for a in reddit_actions]
         result["rounds_count"] = len(run_state.rounds)
-        # recent_actions 只展示当前最新一轮两个平台的内容
+        # recent_actions shows only the current latest round across both platforms
         result["recent_actions"] = [a.to_dict() for a in recent_actions]
-        
+
         return jsonify({
             "success": True,
             "data": result
         })
-        
+
     except Exception as e:
-        logger.error(f"获取详细状态失败: {str(e)}")
+        logger.error(f"Failed to fetch detailed status: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1864,16 +1868,16 @@ def get_run_status_detail(simulation_id: str):
 @simulation_bp.route('/<simulation_id>/actions', methods=['GET'])
 def get_simulation_actions(simulation_id: str):
     """
-    获取模拟中的Agent动作历史
-    
-    Query参数：
-        limit: 返回数量（默认100）
-        offset: 偏移量（默认0）
-        platform: 过滤平台（twitter/reddit）
-        agent_id: 过滤Agent ID
-        round_num: 过滤轮次
-    
-    返回：
+    Get the Agent action history for a simulation.
+
+    Query parameters:
+        limit: number of items to return (default 100)
+        offset: offset (default 0)
+        platform: filter by platform (twitter/reddit)
+        agent_id: filter by Agent ID
+        round_num: filter by round number
+
+    Response:
         {
             "success": true,
             "data": {
@@ -1888,7 +1892,7 @@ def get_simulation_actions(simulation_id: str):
         platform = request.args.get('platform')
         agent_id = request.args.get('agent_id', type=int)
         round_num = request.args.get('round_num', type=int)
-        
+
         actions = SimulationRunner.get_actions(
             simulation_id=simulation_id,
             limit=limit,
@@ -1897,7 +1901,7 @@ def get_simulation_actions(simulation_id: str):
             agent_id=agent_id,
             round_num=round_num
         )
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -1905,9 +1909,9 @@ def get_simulation_actions(simulation_id: str):
                 "actions": [a.to_dict() for a in actions]
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"获取动作历史失败: {str(e)}")
+        logger.error(f"Failed to fetch action history: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1918,26 +1922,26 @@ def get_simulation_actions(simulation_id: str):
 @simulation_bp.route('/<simulation_id>/timeline', methods=['GET'])
 def get_simulation_timeline(simulation_id: str):
     """
-    获取模拟时间线（按轮次汇总）
-    
-    用于前端展示进度条和时间线视图
-    
-    Query参数：
-        start_round: 起始轮次（默认0）
-        end_round: 结束轮次（默认全部）
-    
-    返回每轮的汇总信息
+    Get the simulation timeline (aggregated by round).
+
+    Used by the front-end to display the progress bar and timeline view.
+
+    Query parameters:
+        start_round: starting round (default 0)
+        end_round: ending round (default all)
+
+    Returns a per-round summary.
     """
     try:
         start_round = request.args.get('start_round', 0, type=int)
         end_round = request.args.get('end_round', type=int)
-        
+
         timeline = SimulationRunner.get_timeline(
             simulation_id=simulation_id,
             start_round=start_round,
             end_round=end_round
         )
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -1945,9 +1949,9 @@ def get_simulation_timeline(simulation_id: str):
                 "timeline": timeline
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"获取时间线失败: {str(e)}")
+        logger.error(f"Failed to fetch timeline: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1958,13 +1962,13 @@ def get_simulation_timeline(simulation_id: str):
 @simulation_bp.route('/<simulation_id>/agent-stats', methods=['GET'])
 def get_agent_stats(simulation_id: str):
     """
-    获取每个Agent的统计信息
-    
-    用于前端展示Agent活跃度排行、动作分布等
+    Get per-Agent statistics.
+
+    Used by the front-end to display Agent activity rankings, action distributions, etc.
     """
     try:
         stats = SimulationRunner.get_agent_stats(simulation_id)
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -1972,9 +1976,9 @@ def get_agent_stats(simulation_id: str):
                 "stats": stats
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"获取Agent统计失败: {str(e)}")
+        logger.error(f"Failed to fetch Agent statistics: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -1982,33 +1986,33 @@ def get_agent_stats(simulation_id: str):
         }), 500
 
 
-# ============== 数据库查询接口 ==============
+# ============== Database query endpoints ==============
 
 @simulation_bp.route('/<simulation_id>/posts', methods=['GET'])
 def get_simulation_posts(simulation_id: str):
     """
-    获取模拟中的帖子
-    
-    Query参数：
-        platform: 平台类型（twitter/reddit）
-        limit: 返回数量（默认50）
-        offset: 偏移量
-    
-    返回帖子列表（从SQLite数据库读取）
+    Get the posts in a simulation.
+
+    Query parameters:
+        platform: platform type (twitter/reddit)
+        limit: number of items to return (default 50)
+        offset: offset
+
+    Returns a list of posts (read from the SQLite database).
     """
     try:
         platform = request.args.get('platform', 'reddit')
         limit = request.args.get('limit', 50, type=int)
         offset = request.args.get('offset', 0, type=int)
-        
+
         sim_dir = os.path.join(
             os.path.dirname(__file__),
             f'../../uploads/simulations/{simulation_id}'
         )
-        
+
         db_file = f"{platform}_simulation.db"
         db_path = os.path.join(sim_dir, db_file)
-        
+
         if not os.path.exists(db_path):
             return jsonify({
                 "success": True,
@@ -2019,30 +2023,30 @@ def get_simulation_posts(simulation_id: str):
                     "message": t('api.dbNotExist')
                 }
             })
-        
+
         import sqlite3
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
-        
+
         try:
             cursor.execute("""
-                SELECT * FROM post 
-                ORDER BY created_at DESC 
+                SELECT * FROM post
+                ORDER BY created_at DESC
                 LIMIT ? OFFSET ?
             """, (limit, offset))
-            
+
             posts = [dict(row) for row in cursor.fetchall()]
-            
+
             cursor.execute("SELECT COUNT(*) FROM post")
             total = cursor.fetchone()[0]
-            
+
         except sqlite3.OperationalError:
             posts = []
             total = 0
-        
+
         conn.close()
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -2052,9 +2056,9 @@ def get_simulation_posts(simulation_id: str):
                 "posts": posts
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"获取帖子失败: {str(e)}")
+        logger.error(f"Failed to fetch posts: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -2065,25 +2069,25 @@ def get_simulation_posts(simulation_id: str):
 @simulation_bp.route('/<simulation_id>/comments', methods=['GET'])
 def get_simulation_comments(simulation_id: str):
     """
-    获取模拟中的评论（仅Reddit）
-    
-    Query参数：
-        post_id: 过滤帖子ID（可选）
-        limit: 返回数量
-        offset: 偏移量
+    Get the comments in a simulation (Reddit only).
+
+    Query parameters:
+        post_id: filter by post ID (optional)
+        limit: number of items to return
+        offset: offset
     """
     try:
         post_id = request.args.get('post_id')
         limit = request.args.get('limit', 50, type=int)
         offset = request.args.get('offset', 0, type=int)
-        
+
         sim_dir = os.path.join(
             os.path.dirname(__file__),
             f'../../uploads/simulations/{simulation_id}'
         )
-        
+
         db_path = os.path.join(sim_dir, "reddit_simulation.db")
-        
+
         if not os.path.exists(db_path):
             return jsonify({
                 "success": True,
@@ -2092,34 +2096,34 @@ def get_simulation_comments(simulation_id: str):
                     "comments": []
                 }
             })
-        
+
         import sqlite3
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
-        
+
         try:
             if post_id:
                 cursor.execute("""
-                    SELECT * FROM comment 
+                    SELECT * FROM comment
                     WHERE post_id = ?
-                    ORDER BY created_at DESC 
+                    ORDER BY created_at DESC
                     LIMIT ? OFFSET ?
                 """, (post_id, limit, offset))
             else:
                 cursor.execute("""
-                    SELECT * FROM comment 
-                    ORDER BY created_at DESC 
+                    SELECT * FROM comment
+                    ORDER BY created_at DESC
                     LIMIT ? OFFSET ?
                 """, (limit, offset))
-            
+
             comments = [dict(row) for row in cursor.fetchall()]
-            
+
         except sqlite3.OperationalError:
             comments = []
-        
+
         conn.close()
-        
+
         return jsonify({
             "success": True,
             "data": {
@@ -2127,9 +2131,9 @@ def get_simulation_comments(simulation_id: str):
                 "comments": comments
             }
         })
-        
+
     except Exception as e:
-        logger.error(f"获取评论失败: {str(e)}")
+        logger.error(f"Failed to fetch comments: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -2137,31 +2141,32 @@ def get_simulation_comments(simulation_id: str):
         }), 500
 
 
-# ============== Interview 采访接口 ==============
+# ============== Interview endpoints ==============
 
 @simulation_bp.route('/interview', methods=['POST'])
 def interview_agent():
     """
-    采访单个Agent
+    Interview a single Agent.
 
-    注意：此功能需要模拟环境处于运行状态（完成模拟循环后进入等待命令模式）
+    Note: this feature requires the simulation environment to be running
+    (after finishing the simulation loop and entering wait-for-command mode).
 
-    请求（JSON）：
+    Request (JSON):
         {
-            "simulation_id": "sim_xxxx",       // 必填，模拟ID
-            "agent_id": 0,                     // 必填，Agent ID
-            "prompt": "你对这件事有什么看法？",  // 必填，采访问题
-            "platform": "twitter",             // 可选，指定平台（twitter/reddit）
-                                               // 不指定时：双平台模拟同时采访两个平台
-            "timeout": 60                      // 可选，超时时间（秒），默认60
+            "simulation_id": "sim_xxxx",       // required, simulation ID
+            "agent_id": 0,                     // required, Agent ID
+            "prompt": "What's your view on this?",  // required, interview question
+            "platform": "twitter",             // optional, target platform (twitter/reddit)
+                                               // if omitted: dual-platform simulations interview both platforms simultaneously
+            "timeout": 60                      // optional, timeout in seconds (default 60)
         }
 
-    返回（不指定platform，双平台模式）：
+    Response (without `platform`, dual-platform mode):
         {
             "success": true,
             "data": {
                 "agent_id": 0,
-                "prompt": "你对这件事有什么看法？",
+                "prompt": "What's your view on this?",
                 "result": {
                     "agent_id": 0,
                     "prompt": "...",
@@ -2174,15 +2179,15 @@ def interview_agent():
             }
         }
 
-    返回（指定platform）：
+    Response (with `platform` specified):
         {
             "success": true,
             "data": {
                 "agent_id": 0,
-                "prompt": "你对这件事有什么看法？",
+                "prompt": "What's your view on this?",
                 "result": {
                     "agent_id": 0,
-                    "response": "我认为...",
+                    "response": "I think...",
                     "platform": "twitter",
                     "timestamp": "2025-12-08T10:00:00"
                 },
@@ -2192,48 +2197,48 @@ def interview_agent():
     """
     try:
         data = request.get_json() or {}
-        
+
         simulation_id = data.get('simulation_id')
         agent_id = data.get('agent_id')
         prompt = data.get('prompt')
-        platform = data.get('platform')  # 可选：twitter/reddit/None
+        platform = data.get('platform')  # optional: twitter/reddit/None
         timeout = data.get('timeout', 60)
-        
+
         if not simulation_id:
             return jsonify({
                 "success": False,
                 "error": t('api.requireSimulationId')
             }), 400
-        
+
         if agent_id is None:
             return jsonify({
                 "success": False,
                 "error": t('api.requireAgentId')
             }), 400
-        
+
         if not prompt:
             return jsonify({
                 "success": False,
                 "error": t('api.requirePrompt')
             }), 400
-        
-        # 验证platform参数
+
+        # Validate the platform parameter
         if platform and platform not in ("twitter", "reddit"):
             return jsonify({
                 "success": False,
                 "error": t('api.invalidInterviewPlatform')
             }), 400
-        
-        # 检查环境状态
+
+        # Check the environment status
         if not SimulationRunner.check_env_alive(simulation_id):
             return jsonify({
                 "success": False,
                 "error": t('api.envNotRunning')
             }), 400
-        
-        # 优化prompt，添加前缀避免Agent调用工具
+
+        # Optimize the prompt by adding the prefix that prevents the Agent from calling tools
         optimized_prompt = optimize_interview_prompt(prompt)
-        
+
         result = SimulationRunner.interview_agent(
             simulation_id=simulation_id,
             agent_id=agent_id,
@@ -2246,21 +2251,21 @@ def interview_agent():
             "success": result.get("success", False),
             "data": result
         })
-        
+
     except ValueError as e:
         return jsonify({
             "success": False,
             "error": str(e)
         }), 400
-        
+
     except TimeoutError as e:
         return jsonify({
             "success": False,
             "error": t('api.interviewTimeout', error=str(e))
         }), 504
-        
+
     except Exception as e:
-        logger.error(f"Interview失败: {str(e)}")
+        logger.error(f"Interview failed: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -2271,30 +2276,30 @@ def interview_agent():
 @simulation_bp.route('/interview/batch', methods=['POST'])
 def interview_agents_batch():
     """
-    批量采访多个Agent
+    Interview multiple Agents in batch.
 
-    注意：此功能需要模拟环境处于运行状态
+    Note: this feature requires the simulation environment to be running.
 
-    请求（JSON）：
+    Request (JSON):
         {
-            "simulation_id": "sim_xxxx",       // 必填，模拟ID
-            "interviews": [                    // 必填，采访列表
+            "simulation_id": "sim_xxxx",       // required, simulation ID
+            "interviews": [                    // required, list of interviews
                 {
                     "agent_id": 0,
-                    "prompt": "你对A有什么看法？",
-                    "platform": "twitter"      // 可选，指定该Agent的采访平台
+                    "prompt": "What's your view on A?",
+                    "platform": "twitter"      // optional, the interview platform for this Agent
                 },
                 {
                     "agent_id": 1,
-                    "prompt": "你对B有什么看法？"  // 不指定platform则使用默认值
+                    "prompt": "What's your view on B?"  // if platform is omitted, the default is used
                 }
             ],
-            "platform": "reddit",              // 可选，默认平台（被每项的platform覆盖）
-                                               // 不指定时：双平台模拟每个Agent同时采访两个平台
-            "timeout": 120                     // 可选，超时时间（秒），默认120
+            "platform": "reddit",              // optional, default platform (overridden by each item's platform)
+                                               // if omitted: dual-platform simulations interview each Agent on both platforms simultaneously
+            "timeout": 120                     // optional, timeout in seconds (default 120)
         }
 
-    返回：
+    Response:
         {
             "success": true,
             "data": {
@@ -2317,7 +2322,7 @@ def interview_agents_batch():
 
         simulation_id = data.get('simulation_id')
         interviews = data.get('interviews')
-        platform = data.get('platform')  # 可选：twitter/reddit/None
+        platform = data.get('platform')  # optional: twitter/reddit/None
         timeout = data.get('timeout', 120)
 
         if not simulation_id:
@@ -2332,14 +2337,14 @@ def interview_agents_batch():
                 "error": t('api.requireInterviews')
             }), 400
 
-        # 验证platform参数
+        # Validate the platform parameter
         if platform and platform not in ("twitter", "reddit"):
             return jsonify({
                 "success": False,
                 "error": t('api.invalidInterviewPlatform')
             }), 400
 
-        # 验证每个采访项
+        # Validate each interview item
         for i, interview in enumerate(interviews):
             if 'agent_id' not in interview:
                 return jsonify({
@@ -2351,7 +2356,7 @@ def interview_agents_batch():
                     "success": False,
                     "error": t('api.interviewListMissingPrompt', index=i+1)
                 }), 400
-            # 验证每项的platform（如果有）
+            # Validate each item's platform (when present)
             item_platform = interview.get('platform')
             if item_platform and item_platform not in ("twitter", "reddit"):
                 return jsonify({
@@ -2359,14 +2364,14 @@ def interview_agents_batch():
                     "error": t('api.interviewListInvalidPlatform', index=i+1)
                 }), 400
 
-        # 检查环境状态
+        # Check the environment status
         if not SimulationRunner.check_env_alive(simulation_id):
             return jsonify({
                 "success": False,
                 "error": t('api.envNotRunning')
             }), 400
 
-        # 优化每个采访项的prompt，添加前缀避免Agent调用工具
+        # Optimize each item's prompt with the prefix that prevents the Agent from calling tools
         optimized_interviews = []
         for interview in interviews:
             optimized_interview = interview.copy()
@@ -2398,7 +2403,7 @@ def interview_agents_batch():
         }), 504
 
     except Exception as e:
-        logger.error(f"批量Interview失败: {str(e)}")
+        logger.error(f"Batch interview failed: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -2409,20 +2414,20 @@ def interview_agents_batch():
 @simulation_bp.route('/interview/all', methods=['POST'])
 def interview_all_agents():
     """
-    全局采访 - 使用相同问题采访所有Agent
+    Global interview - ask the same question to all Agents.
 
-    注意：此功能需要模拟环境处于运行状态
+    Note: this feature requires the simulation environment to be running.
 
-    请求（JSON）：
+    Request (JSON):
         {
-            "simulation_id": "sim_xxxx",            // 必填，模拟ID
-            "prompt": "你对这件事整体有什么看法？",  // 必填，采访问题（所有Agent使用相同问题）
-            "platform": "reddit",                   // 可选，指定平台（twitter/reddit）
-                                                    // 不指定时：双平台模拟每个Agent同时采访两个平台
-            "timeout": 180                          // 可选，超时时间（秒），默认180
+            "simulation_id": "sim_xxxx",            // required, simulation ID
+            "prompt": "What's your overall take on this?",  // required, interview question (asked to all Agents)
+            "platform": "reddit",                   // optional, target platform (twitter/reddit)
+                                                    // if omitted: dual-platform simulations interview each Agent on both platforms simultaneously
+            "timeout": 180                          // optional, timeout in seconds (default 180)
         }
 
-    返回：
+    Response:
         {
             "success": true,
             "data": {
@@ -2444,7 +2449,7 @@ def interview_all_agents():
 
         simulation_id = data.get('simulation_id')
         prompt = data.get('prompt')
-        platform = data.get('platform')  # 可选：twitter/reddit/None
+        platform = data.get('platform')  # optional: twitter/reddit/None
         timeout = data.get('timeout', 180)
 
         if not simulation_id:
@@ -2459,21 +2464,21 @@ def interview_all_agents():
                 "error": t('api.requirePrompt')
             }), 400
 
-        # 验证platform参数
+        # Validate the platform parameter
         if platform and platform not in ("twitter", "reddit"):
             return jsonify({
                 "success": False,
                 "error": t('api.invalidInterviewPlatform')
             }), 400
 
-        # 检查环境状态
+        # Check the environment status
         if not SimulationRunner.check_env_alive(simulation_id):
             return jsonify({
                 "success": False,
                 "error": t('api.envNotRunning')
             }), 400
 
-        # 优化prompt，添加前缀避免Agent调用工具
+        # Optimize the prompt by adding the prefix that prevents the Agent from calling tools
         optimized_prompt = optimize_interview_prompt(prompt)
 
         result = SimulationRunner.interview_all_agents(
@@ -2501,7 +2506,7 @@ def interview_all_agents():
         }), 504
 
     except Exception as e:
-        logger.error(f"全局Interview失败: {str(e)}")
+        logger.error(f"Global interview failed: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -2512,20 +2517,20 @@ def interview_all_agents():
 @simulation_bp.route('/interview/history', methods=['POST'])
 def get_interview_history():
     """
-    获取Interview历史记录
+    Get the interview history.
 
-    从模拟数据库中读取所有Interview记录
+    Reads all interview records from the simulation database.
 
-    请求（JSON）：
+    Request (JSON):
         {
-            "simulation_id": "sim_xxxx",  // 必填，模拟ID
-            "platform": "reddit",          // 可选，平台类型（reddit/twitter）
-                                           // 不指定则返回两个平台的所有历史
-            "agent_id": 0,                 // 可选，只获取该Agent的采访历史
-            "limit": 100                   // 可选，返回数量，默认100
+            "simulation_id": "sim_xxxx",  // required, simulation ID
+            "platform": "reddit",          // optional, platform type (reddit/twitter)
+                                           // if omitted, returns history for both platforms
+            "agent_id": 0,                 // optional, only fetch this Agent's interview history
+            "limit": 100                   // optional, items to return (default 100)
         }
 
-    返回：
+    Response:
         {
             "success": true,
             "data": {
@@ -2533,8 +2538,8 @@ def get_interview_history():
                 "history": [
                     {
                         "agent_id": 0,
-                        "response": "我认为...",
-                        "prompt": "你对这件事有什么看法？",
+                        "response": "I think...",
+                        "prompt": "What's your view on this?",
                         "timestamp": "2025-12-08T10:00:00",
                         "platform": "reddit"
                     },
@@ -2545,12 +2550,12 @@ def get_interview_history():
     """
     try:
         data = request.get_json() or {}
-        
+
         simulation_id = data.get('simulation_id')
-        platform = data.get('platform')  # 不指定则返回两个平台的历史
+        platform = data.get('platform')  # if omitted, return history for both platforms
         agent_id = data.get('agent_id')
         limit = data.get('limit', 100)
-        
+
         if not simulation_id:
             return jsonify({
                 "success": False,
@@ -2573,7 +2578,7 @@ def get_interview_history():
         })
 
     except Exception as e:
-        logger.error(f"获取Interview历史失败: {str(e)}")
+        logger.error(f"Failed to fetch interview history: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -2584,16 +2589,16 @@ def get_interview_history():
 @simulation_bp.route('/env-status', methods=['POST'])
 def get_env_status():
     """
-    获取模拟环境状态
+    Get the simulation environment status.
 
-    检查模拟环境是否存活（可以接收Interview命令）
+    Checks whether the simulation environment is alive (able to receive Interview commands).
 
-    请求（JSON）：
+    Request (JSON):
         {
-            "simulation_id": "sim_xxxx"  // 必填，模拟ID
+            "simulation_id": "sim_xxxx"  // required, simulation ID
         }
 
-    返回：
+    Response:
         {
             "success": true,
             "data": {
@@ -2601,15 +2606,15 @@ def get_env_status():
                 "env_alive": true,
                 "twitter_available": true,
                 "reddit_available": true,
-                "message": "环境正在运行，可以接收Interview命令"
+                "message": "The environment is running and can accept Interview commands"
             }
         }
     """
     try:
         data = request.get_json() or {}
-        
+
         simulation_id = data.get('simulation_id')
-        
+
         if not simulation_id:
             return jsonify({
                 "success": False,
@@ -2617,8 +2622,8 @@ def get_env_status():
             }), 400
 
         env_alive = SimulationRunner.check_env_alive(simulation_id)
-        
-        # 获取更详细的状态信息
+
+        # Get more detailed status info
         env_status = SimulationRunner.get_env_status_detail(simulation_id)
 
         if env_alive:
@@ -2638,7 +2643,7 @@ def get_env_status():
         })
 
     except Exception as e:
-        logger.error(f"获取环境状态失败: {str(e)}")
+        logger.error(f"Failed to fetch environment status: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),
@@ -2649,24 +2654,26 @@ def get_env_status():
 @simulation_bp.route('/close-env', methods=['POST'])
 def close_simulation_env():
     """
-    关闭模拟环境
-    
-    向模拟发送关闭环境命令，使其优雅退出等待命令模式。
-    
-    注意：这不同于 /stop 接口，/stop 会强制终止进程，
-    而此接口会让模拟优雅地关闭环境并退出。
-    
-    请求（JSON）：
+    Close the simulation environment.
+
+    Sends a close-environment command to the simulation so it gracefully exits its
+    wait-for-command mode.
+
+    Note: this differs from /stop. /stop forcibly terminates the process,
+    whereas this endpoint asks the simulation to gracefully shut down its environment
+    and exit.
+
+    Request (JSON):
         {
-            "simulation_id": "sim_xxxx",  // 必填，模拟ID
-            "timeout": 30                  // 可选，超时时间（秒），默认30
+            "simulation_id": "sim_xxxx",  // required, simulation ID
+            "timeout": 30                  // optional, timeout in seconds (default 30)
         }
-    
-    返回：
+
+    Response:
         {
             "success": true,
             "data": {
-                "message": "环境关闭命令已发送",
+                "message": "Close-environment command sent",
                 "result": {...},
                 "timestamp": "2025-12-08T10:00:01"
             }
@@ -2674,41 +2681,41 @@ def close_simulation_env():
     """
     try:
         data = request.get_json() or {}
-        
+
         simulation_id = data.get('simulation_id')
         timeout = data.get('timeout', 30)
-        
+
         if not simulation_id:
             return jsonify({
                 "success": False,
                 "error": t('api.requireSimulationId')
             }), 400
-        
+
         result = SimulationRunner.close_simulation_env(
             simulation_id=simulation_id,
             timeout=timeout
         )
-        
-        # 更新模拟状态
+
+        # Update simulation state
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
         if state:
             state.status = SimulationStatus.COMPLETED
             manager._save_simulation_state(state)
-        
+
         return jsonify({
             "success": result.get("success", False),
             "data": result
         })
-        
+
     except ValueError as e:
         return jsonify({
             "success": False,
             "error": str(e)
         }), 400
-        
+
     except Exception as e:
-        logger.error(f"关闭环境失败: {str(e)}")
+        logger.error(f"Failed to close environment: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,6 +34,11 @@ class Config:
     
     # Zep配置
     ZEP_API_KEY = os.environ.get('ZEP_API_KEY')
+
+    # Service authentication
+    # When set, all /api/* requests must include a matching X-API-Key header.
+    # Leave unset (or empty) to run in permissive dev mode (no auth enforced).
+    MIROFISH_API_KEY = os.environ.get('MIROFISH_API_KEY')
     
     # 文件上传配置
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50MB

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,59 +1,59 @@
 """
-配置管理
-统一从项目根目录的 .env 文件加载配置
+Configuration management
+Loads configuration from the project root .env file in a unified way.
 """
 
 import os
 from dotenv import load_dotenv
 
-# 加载项目根目录的 .env 文件
-# 路径: MiroFish/.env (相对于 backend/app/config.py)
+# Load the project root .env file.
+# Path: MiroFish/.env (relative to backend/app/config.py)
 project_root_env = os.path.join(os.path.dirname(__file__), '../../.env')
 
 if os.path.exists(project_root_env):
     load_dotenv(project_root_env, override=True)
 else:
-    # 如果根目录没有 .env，尝试加载环境变量（用于生产环境）
+    # If there is no .env at the project root, try loading environment variables (used in production).
     load_dotenv(override=True)
 
 
 class Config:
-    """Flask配置类"""
-    
-    # Flask配置
+    """Flask configuration class"""
+
+    # Flask configuration
     SECRET_KEY = os.environ.get('SECRET_KEY', 'mirofish-secret-key')
     DEBUG = os.environ.get('FLASK_DEBUG', 'True').lower() == 'true'
-    
-    # JSON配置 - 禁用ASCII转义，让中文直接显示（而不是 \uXXXX 格式）
+
+    # JSON configuration - disable ASCII escaping so non-ASCII characters render directly (not as \uXXXX).
     JSON_AS_ASCII = False
-    
-    # LLM配置（统一使用OpenAI格式）
+
+    # LLM configuration (uniformly using OpenAI format)
     LLM_API_KEY = os.environ.get('LLM_API_KEY')
     LLM_BASE_URL = os.environ.get('LLM_BASE_URL', 'https://api.openai.com/v1')
     LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'gpt-4o-mini')
-    
-    # Zep配置
+
+    # Zep configuration
     ZEP_API_KEY = os.environ.get('ZEP_API_KEY')
 
     # Service authentication
     # When set, all /api/* requests must include a matching X-API-Key header.
     # Leave unset (or empty) to run in permissive dev mode (no auth enforced).
     MIROFISH_API_KEY = os.environ.get('MIROFISH_API_KEY')
-    
-    # 文件上传配置
+
+    # File upload configuration
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50MB
     UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), '../uploads')
     ALLOWED_EXTENSIONS = {'pdf', 'md', 'txt', 'markdown'}
-    
-    # 文本处理配置
-    DEFAULT_CHUNK_SIZE = 500  # 默认切块大小
-    DEFAULT_CHUNK_OVERLAP = 50  # 默认重叠大小
-    
-    # OASIS模拟配置
+
+    # Text processing configuration
+    DEFAULT_CHUNK_SIZE = 500  # default chunk size
+    DEFAULT_CHUNK_OVERLAP = 50  # default overlap size
+
+    # OASIS simulation configuration
     OASIS_DEFAULT_MAX_ROUNDS = int(os.environ.get('OASIS_DEFAULT_MAX_ROUNDS', '10'))
     OASIS_SIMULATION_DATA_DIR = os.path.join(os.path.dirname(__file__), '../uploads/simulations')
-    
-    # OASIS平台可用动作配置
+
+    # OASIS platform-available action configuration
     OASIS_TWITTER_ACTIONS = [
         'CREATE_POST', 'LIKE_POST', 'REPOST', 'FOLLOW', 'DO_NOTHING', 'QUOTE_POST'
     ]
@@ -62,19 +62,18 @@ class Config:
         'LIKE_COMMENT', 'DISLIKE_COMMENT', 'SEARCH_POSTS', 'SEARCH_USER',
         'TREND', 'REFRESH', 'DO_NOTHING', 'FOLLOW', 'MUTE'
     ]
-    
-    # Report Agent配置
+
+    # Report Agent configuration
     REPORT_AGENT_MAX_TOOL_CALLS = int(os.environ.get('REPORT_AGENT_MAX_TOOL_CALLS', '5'))
     REPORT_AGENT_MAX_REFLECTION_ROUNDS = int(os.environ.get('REPORT_AGENT_MAX_REFLECTION_ROUNDS', '2'))
     REPORT_AGENT_TEMPERATURE = float(os.environ.get('REPORT_AGENT_TEMPERATURE', '0.5'))
-    
+
     @classmethod
     def validate(cls):
-        """验证必要配置"""
+        """Validate required configuration"""
         errors = []
         if not cls.LLM_API_KEY:
-            errors.append("LLM_API_KEY 未配置")
+            errors.append("LLM_API_KEY is not configured")
         if not cls.ZEP_API_KEY:
-            errors.append("ZEP_API_KEY 未配置")
+            errors.append("ZEP_API_KEY is not configured")
         return errors
-

--- a/backend/app/middleware/api_key_auth.py
+++ b/backend/app/middleware/api_key_auth.py
@@ -1,0 +1,50 @@
+"""
+API key authentication middleware for MiroFish.
+
+Validates the X-API-Key header on all requests except health-check paths.
+When MIROFISH_API_KEY is not set, auth is skipped with a warning (permissive
+dev mode so the service still works out-of-the-box without configuration).
+"""
+
+import hmac
+from flask import Flask, request, jsonify
+
+from ..config import Config
+from ..utils.logger import get_logger
+
+logger = get_logger("mirofish.auth")
+
+# Paths that bypass authentication
+_EXEMPT_PREFIXES = ("/health",)
+
+
+def register_api_key_auth(app: Flask) -> None:
+    """Register the X-API-Key before_request guard on *app*."""
+
+    @app.before_request
+    def _check_api_key():
+        # Skip exempt paths (health-check, etc.)
+        for prefix in _EXEMPT_PREFIXES:
+            if request.path.startswith(prefix):
+                return None
+
+        configured_key: str | None = Config.MIROFISH_API_KEY
+
+        # No key configured → permissive dev mode
+        if not configured_key:
+            logger.warning(
+                "MIROFISH_API_KEY is not set — skipping auth (dev/permissive mode). "
+                "Set MIROFISH_API_KEY in .env to enable authentication."
+            )
+            return None
+
+        provided = request.headers.get("X-API-Key", "")
+
+        # Timing-safe comparison to prevent timing attacks
+        if not hmac.compare_digest(provided.encode("utf-8"), configured_key.encode("utf-8")):
+            logger.warning(
+                "Rejected request to %s — invalid or missing X-API-Key", request.path
+            )
+            return jsonify({"error": "Unauthorized", "message": "Invalid or missing X-API-Key"}), 401
+
+        return None

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,9 +1,8 @@
 """
-数据模型模块
+Data models module
 """
 
 from .task import TaskManager, TaskStatus
 from .project import Project, ProjectStatus, ProjectManager
 
 __all__ = ['TaskManager', 'TaskStatus', 'Project', 'ProjectStatus', 'ProjectManager']
-

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -1,6 +1,7 @@
 """
-项目上下文管理
-用于在服务端持久化项目状态，避免前端在接口间传递大量数据
+Project context management
+Used to persist project state on the server side, avoiding shipping large amounts of data
+through the front-end across API calls.
 """
 
 import os
@@ -15,45 +16,45 @@ from ..config import Config
 
 
 class ProjectStatus(str, Enum):
-    """项目状态"""
-    CREATED = "created"              # 刚创建，文件已上传
-    ONTOLOGY_GENERATED = "ontology_generated"  # 本体已生成
-    GRAPH_BUILDING = "graph_building"    # 图谱构建中
-    GRAPH_COMPLETED = "graph_completed"  # 图谱构建完成
-    FAILED = "failed"                # 失败
+    """Project status"""
+    CREATED = "created"              # just created, files uploaded
+    ONTOLOGY_GENERATED = "ontology_generated"  # ontology generated
+    GRAPH_BUILDING = "graph_building"    # graph being built
+    GRAPH_COMPLETED = "graph_completed"  # graph build complete
+    FAILED = "failed"                # failed
 
 
 @dataclass
 class Project:
-    """项目数据模型"""
+    """Project data model"""
     project_id: str
     name: str
     status: ProjectStatus
     created_at: str
     updated_at: str
-    
-    # 文件信息
+
+    # File information
     files: List[Dict[str, str]] = field(default_factory=list)  # [{filename, path, size}]
     total_text_length: int = 0
-    
-    # 本体信息（接口1生成后填充）
+
+    # Ontology information (populated after endpoint 1 generates it)
     ontology: Optional[Dict[str, Any]] = None
     analysis_summary: Optional[str] = None
-    
-    # 图谱信息（接口2完成后填充）
+
+    # Graph information (populated after endpoint 2 completes)
     graph_id: Optional[str] = None
     graph_build_task_id: Optional[str] = None
-    
-    # 配置
+
+    # Configuration
     simulation_requirement: Optional[str] = None
     chunk_size: int = 500
     chunk_overlap: int = 50
-    
-    # 错误信息
+
+    # Error information
     error: Optional[str] = None
-    
+
     def to_dict(self) -> Dict[str, Any]:
-        """转换为字典"""
+        """Convert to a dict"""
         return {
             "project_id": self.project_id,
             "name": self.name,
@@ -71,14 +72,14 @@ class Project:
             "chunk_overlap": self.chunk_overlap,
             "error": self.error
         }
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'Project':
-        """从字典创建"""
+        """Create from a dict"""
         status = data.get('status', 'created')
         if isinstance(status, str):
             status = ProjectStatus(status)
-        
+
         return cls(
             project_id=data['project_id'],
             name=data.get('name', 'Unnamed Project'),
@@ -99,52 +100,52 @@ class Project:
 
 
 class ProjectManager:
-    """项目管理器 - 负责项目的持久化存储和检索"""
-    
-    # 项目存储根目录
+    """Project manager - responsible for persistent storage and retrieval of projects"""
+
+    # Project storage root directory
     PROJECTS_DIR = os.path.join(Config.UPLOAD_FOLDER, 'projects')
-    
+
     @classmethod
     def _ensure_projects_dir(cls):
-        """确保项目目录存在"""
+        """Make sure the projects directory exists"""
         os.makedirs(cls.PROJECTS_DIR, exist_ok=True)
-    
+
     @classmethod
     def _get_project_dir(cls, project_id: str) -> str:
-        """获取项目目录路径"""
+        """Get the path to a project's directory"""
         return os.path.join(cls.PROJECTS_DIR, project_id)
-    
+
     @classmethod
     def _get_project_meta_path(cls, project_id: str) -> str:
-        """获取项目元数据文件路径"""
+        """Get the path to a project's metadata file"""
         return os.path.join(cls._get_project_dir(project_id), 'project.json')
-    
+
     @classmethod
     def _get_project_files_dir(cls, project_id: str) -> str:
-        """获取项目文件存储目录"""
+        """Get a project's file storage directory"""
         return os.path.join(cls._get_project_dir(project_id), 'files')
-    
+
     @classmethod
     def _get_project_text_path(cls, project_id: str) -> str:
-        """获取项目提取文本存储路径"""
+        """Get the storage path of a project's extracted text"""
         return os.path.join(cls._get_project_dir(project_id), 'extracted_text.txt')
-    
+
     @classmethod
     def create_project(cls, name: str = "Unnamed Project") -> Project:
         """
-        创建新项目
-        
+        Create a new project.
+
         Args:
-            name: 项目名称
-            
+            name: project name
+
         Returns:
-            新创建的Project对象
+            The newly-created Project object
         """
         cls._ensure_projects_dir()
-        
+
         project_id = f"proj_{uuid.uuid4().hex[:12]}"
         now = datetime.now().isoformat()
-        
+
         project = Project(
             project_id=project_id,
             name=name,
@@ -152,154 +153,153 @@ class ProjectManager:
             created_at=now,
             updated_at=now
         )
-        
-        # 创建项目目录结构
+
+        # Create the project directory structure
         project_dir = cls._get_project_dir(project_id)
         files_dir = cls._get_project_files_dir(project_id)
         os.makedirs(project_dir, exist_ok=True)
         os.makedirs(files_dir, exist_ok=True)
-        
-        # 保存项目元数据
+
+        # Save the project metadata
         cls.save_project(project)
-        
+
         return project
-    
+
     @classmethod
     def save_project(cls, project: Project) -> None:
-        """保存项目元数据"""
+        """Save the project metadata"""
         project.updated_at = datetime.now().isoformat()
         meta_path = cls._get_project_meta_path(project.project_id)
-        
+
         with open(meta_path, 'w', encoding='utf-8') as f:
             json.dump(project.to_dict(), f, ensure_ascii=False, indent=2)
-    
+
     @classmethod
     def get_project(cls, project_id: str) -> Optional[Project]:
         """
-        获取项目
-        
+        Get a project.
+
         Args:
-            project_id: 项目ID
-            
+            project_id: project ID
+
         Returns:
-            Project对象，如果不存在返回None
+            Project object, or None if it does not exist
         """
         meta_path = cls._get_project_meta_path(project_id)
-        
+
         if not os.path.exists(meta_path):
             return None
-        
+
         with open(meta_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
-        
+
         return Project.from_dict(data)
-    
+
     @classmethod
     def list_projects(cls, limit: int = 50) -> List[Project]:
         """
-        列出所有项目
-        
+        List all projects.
+
         Args:
-            limit: 返回数量限制
-            
+            limit: maximum number of items to return
+
         Returns:
-            项目列表，按创建时间倒序
+            List of projects, sorted by creation time descending
         """
         cls._ensure_projects_dir()
-        
+
         projects = []
         for project_id in os.listdir(cls.PROJECTS_DIR):
             project = cls.get_project(project_id)
             if project:
                 projects.append(project)
-        
-        # 按创建时间倒序排序
+
+        # Sort by creation time descending
         projects.sort(key=lambda p: p.created_at, reverse=True)
-        
+
         return projects[:limit]
-    
+
     @classmethod
     def delete_project(cls, project_id: str) -> bool:
         """
-        删除项目及其所有文件
-        
+        Delete a project and all its files.
+
         Args:
-            project_id: 项目ID
-            
+            project_id: project ID
+
         Returns:
-            是否删除成功
+            Whether the deletion succeeded
         """
         project_dir = cls._get_project_dir(project_id)
-        
+
         if not os.path.exists(project_dir):
             return False
-        
+
         shutil.rmtree(project_dir)
         return True
-    
+
     @classmethod
     def save_file_to_project(cls, project_id: str, file_storage, original_filename: str) -> Dict[str, str]:
         """
-        保存上传的文件到项目目录
-        
+        Save an uploaded file to the project directory.
+
         Args:
-            project_id: 项目ID
-            file_storage: Flask的FileStorage对象
-            original_filename: 原始文件名
-            
+            project_id: project ID
+            file_storage: Flask FileStorage object
+            original_filename: original filename
+
         Returns:
-            文件信息字典 {filename, path, size}
+            File-info dict {filename, path, size}
         """
         files_dir = cls._get_project_files_dir(project_id)
         os.makedirs(files_dir, exist_ok=True)
-        
-        # 生成安全的文件名
+
+        # Generate a safe filename
         ext = os.path.splitext(original_filename)[1].lower()
         safe_filename = f"{uuid.uuid4().hex[:8]}{ext}"
         file_path = os.path.join(files_dir, safe_filename)
-        
-        # 保存文件
+
+        # Save the file
         file_storage.save(file_path)
-        
-        # 获取文件大小
+
+        # Get the file size
         file_size = os.path.getsize(file_path)
-        
+
         return {
             "original_filename": original_filename,
             "saved_filename": safe_filename,
             "path": file_path,
             "size": file_size
         }
-    
+
     @classmethod
     def save_extracted_text(cls, project_id: str, text: str) -> None:
-        """保存提取的文本"""
+        """Save the extracted text"""
         text_path = cls._get_project_text_path(project_id)
         with open(text_path, 'w', encoding='utf-8') as f:
             f.write(text)
-    
+
     @classmethod
     def get_extracted_text(cls, project_id: str) -> Optional[str]:
-        """获取提取的文本"""
+        """Get the extracted text"""
         text_path = cls._get_project_text_path(project_id)
-        
+
         if not os.path.exists(text_path):
             return None
-        
+
         with open(text_path, 'r', encoding='utf-8') as f:
             return f.read()
-    
+
     @classmethod
     def get_project_files(cls, project_id: str) -> List[str]:
-        """获取项目的所有文件路径"""
+        """Get all file paths belonging to a project"""
         files_dir = cls._get_project_files_dir(project_id)
-        
+
         if not os.path.exists(files_dir):
             return []
-        
+
         return [
-            os.path.join(files_dir, f) 
-            for f in os.listdir(files_dir) 
+            os.path.join(files_dir, f)
+            for f in os.listdir(files_dir)
             if os.path.isfile(os.path.join(files_dir, f))
         ]
-

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -1,6 +1,6 @@
 """
-任务状态管理
-用于跟踪长时间运行的任务（如图谱构建）
+Task state management
+Used to track long-running tasks (e.g. graph construction).
 """
 
 import uuid
@@ -14,30 +14,30 @@ from ..utils.locale import t
 
 
 class TaskStatus(str, Enum):
-    """任务状态枚举"""
-    PENDING = "pending"          # 等待中
-    PROCESSING = "processing"    # 处理中
-    COMPLETED = "completed"      # 已完成
-    FAILED = "failed"            # 失败
+    """Task status enum"""
+    PENDING = "pending"          # waiting
+    PROCESSING = "processing"    # in progress
+    COMPLETED = "completed"      # completed
+    FAILED = "failed"            # failed
 
 
 @dataclass
 class Task:
-    """任务数据类"""
+    """Task data class"""
     task_id: str
     task_type: str
     status: TaskStatus
     created_at: datetime
     updated_at: datetime
-    progress: int = 0              # 总进度百分比 0-100
-    message: str = ""              # 状态消息
-    result: Optional[Dict] = None  # 任务结果
-    error: Optional[str] = None    # 错误信息
-    metadata: Dict = field(default_factory=dict)  # 额外元数据
-    progress_detail: Dict = field(default_factory=dict)  # 详细进度信息
-    
+    progress: int = 0              # overall progress percentage 0-100
+    message: str = ""              # status message
+    result: Optional[Dict] = None  # task result
+    error: Optional[str] = None    # error message
+    metadata: Dict = field(default_factory=dict)  # extra metadata
+    progress_detail: Dict = field(default_factory=dict)  # detailed progress info
+
     def to_dict(self) -> Dict[str, Any]:
-        """转换为字典"""
+        """Convert to a dict"""
         return {
             "task_id": self.task_id,
             "task_type": self.task_type,
@@ -55,15 +55,15 @@ class Task:
 
 class TaskManager:
     """
-    任务管理器
-    线程安全的任务状态管理
+    Task manager
+    Thread-safe task state management.
     """
-    
+
     _instance = None
     _lock = threading.Lock()
-    
+
     def __new__(cls):
-        """单例模式"""
+        """Singleton pattern"""
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
@@ -71,21 +71,21 @@ class TaskManager:
                     cls._instance._tasks: Dict[str, Task] = {}
                     cls._instance._task_lock = threading.Lock()
         return cls._instance
-    
+
     def create_task(self, task_type: str, metadata: Optional[Dict] = None) -> str:
         """
-        创建新任务
-        
+        Create a new task.
+
         Args:
-            task_type: 任务类型
-            metadata: 额外元数据
-            
+            task_type: task type
+            metadata: extra metadata
+
         Returns:
-            任务ID
+            Task ID
         """
         task_id = str(uuid.uuid4())
         now = datetime.now()
-        
+
         task = Task(
             task_id=task_id,
             task_type=task_type,
@@ -94,17 +94,17 @@ class TaskManager:
             updated_at=now,
             metadata=metadata or {}
         )
-        
+
         with self._task_lock:
             self._tasks[task_id] = task
-        
+
         return task_id
-    
+
     def get_task(self, task_id: str) -> Optional[Task]:
-        """获取任务"""
+        """Get a task"""
         with self._task_lock:
             return self._tasks.get(task_id)
-    
+
     def update_task(
         self,
         task_id: str,
@@ -116,16 +116,16 @@ class TaskManager:
         progress_detail: Optional[Dict] = None
     ):
         """
-        更新任务状态
-        
+        Update task state.
+
         Args:
-            task_id: 任务ID
-            status: 新状态
-            progress: 进度
-            message: 消息
-            result: 结果
-            error: 错误信息
-            progress_detail: 详细进度信息
+            task_id: task ID
+            status: new status
+            progress: progress
+            message: message
+            result: result
+            error: error message
+            progress_detail: detailed progress info
         """
         with self._task_lock:
             task = self._tasks.get(task_id)
@@ -143,9 +143,9 @@ class TaskManager:
                     task.error = error
                 if progress_detail is not None:
                     task.progress_detail = progress_detail
-    
+
     def complete_task(self, task_id: str, result: Dict):
-        """标记任务完成"""
+        """Mark a task as completed"""
         self.update_task(
             task_id,
             status=TaskStatus.COMPLETED,
@@ -153,29 +153,29 @@ class TaskManager:
             message=t('progress.taskComplete'),
             result=result
         )
-    
+
     def fail_task(self, task_id: str, error: str):
-        """标记任务失败"""
+        """Mark a task as failed"""
         self.update_task(
             task_id,
             status=TaskStatus.FAILED,
             message=t('progress.taskFailed'),
             error=error
         )
-    
+
     def list_tasks(self, task_type: Optional[str] = None) -> list:
-        """列出任务"""
+        """List tasks"""
         with self._task_lock:
             tasks = list(self._tasks.values())
             if task_type:
                 tasks = [t for t in tasks if t.task_type == task_type]
             return [t.to_dict() for t in sorted(tasks, key=lambda x: x.created_at, reverse=True)]
-    
+
     def cleanup_old_tasks(self, max_age_hours: int = 24):
-        """清理旧任务"""
+        """Clean up old tasks"""
         from datetime import timedelta
         cutoff = datetime.now() - timedelta(hours=max_age_hours)
-        
+
         with self._task_lock:
             old_ids = [
                 tid for tid, task in self._tasks.items()
@@ -183,4 +183,3 @@ class TaskManager:
             ]
             for tid in old_ids:
                 del self._tasks[tid]
-

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,5 +1,5 @@
 """
-业务服务模块
+Business services module
 """
 
 from .ontology_generator import OntologyGenerator
@@ -9,7 +9,7 @@ from .zep_entity_reader import ZepEntityReader, EntityNode, FilteredEntities
 from .oasis_profile_generator import OasisProfileGenerator, OasisAgentProfile
 from .simulation_manager import SimulationManager, SimulationState, SimulationStatus
 from .simulation_config_generator import (
-    SimulationConfigGenerator, 
+    SimulationConfigGenerator,
     SimulationParameters,
     AgentActivityConfig,
     TimeSimulationConfig,
@@ -38,8 +38,8 @@ from .simulation_ipc import (
 )
 
 __all__ = [
-    'OntologyGenerator', 
-    'GraphBuilderService', 
+    'OntologyGenerator',
+    'GraphBuilderService',
     'TextProcessor',
     'ZepEntityReader',
     'EntityNode',

--- a/backend/app/services/graph_builder.py
+++ b/backend/app/services/graph_builder.py
@@ -1,6 +1,6 @@
 """
-图谱构建服务
-接口2：使用Zep API构建Standalone Graph
+Graph building service
+Interface 2: Build a Standalone Graph using the Zep API
 """
 
 import os
@@ -22,7 +22,7 @@ from ..utils.locale import t, get_locale, set_locale
 
 @dataclass
 class GraphInfo:
-    """图谱信息"""
+    """Graph information"""
     graph_id: str
     node_count: int
     edge_count: int
@@ -39,14 +39,14 @@ class GraphInfo:
 
 class GraphBuilderService:
     """
-    图谱构建服务
-    负责调用Zep API构建知识图谱
+    Graph building service
+    Responsible for calling the Zep API to build the knowledge graph
     """
-    
+
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = api_key or Config.ZEP_API_KEY
         if not self.api_key:
-            raise ValueError("ZEP_API_KEY 未配置")
+            raise ValueError("ZEP_API_KEY is not configured")
         
         self.client = Zep(api_key=self.api_key)
         self.task_manager = TaskManager()
@@ -61,20 +61,20 @@ class GraphBuilderService:
         batch_size: int = 3
     ) -> str:
         """
-        异步构建图谱
-        
+        Build the graph asynchronously
+
         Args:
-            text: 输入文本
-            ontology: 本体定义（来自接口1的输出）
-            graph_name: 图谱名称
-            chunk_size: 文本块大小
-            chunk_overlap: 块重叠大小
-            batch_size: 每批发送的块数量
-            
+            text: Input text
+            ontology: Ontology definition (output of interface 1)
+            graph_name: Graph name
+            chunk_size: Text chunk size
+            chunk_overlap: Chunk overlap size
+            batch_size: Number of chunks sent per batch
+
         Returns:
-            任务ID
+            Task ID
         """
-        # 创建任务
+        # Create the task
         task_id = self.task_manager.create_task(
             task_type="graph_build",
             metadata={
@@ -87,7 +87,7 @@ class GraphBuilderService:
         # Capture locale before spawning background thread
         current_locale = get_locale()
 
-        # 在后台线程中执行构建
+        # Run the build in a background thread
         thread = threading.Thread(
             target=self._build_graph_worker,
             args=(task_id, text, ontology, graph_name, chunk_size, chunk_overlap, batch_size, current_locale)
@@ -108,7 +108,7 @@ class GraphBuilderService:
         batch_size: int,
         locale: str = 'zh'
     ):
-        """图谱构建工作线程"""
+        """Graph building worker thread"""
         set_locale(locale)
         try:
             self.task_manager.update_task(
@@ -118,7 +118,7 @@ class GraphBuilderService:
                 message=t('progress.startBuildingGraph')
             )
             
-            # 1. 创建图谱
+            # 1. Create the graph
             graph_id = self.create_graph(graph_name)
             self.task_manager.update_task(
                 task_id,
@@ -126,7 +126,7 @@ class GraphBuilderService:
                 message=t('progress.graphCreated', graphId=graph_id)
             )
             
-            # 2. 设置本体
+            # 2. Set the ontology
             self.set_ontology(graph_id, ontology)
             self.task_manager.update_task(
                 task_id,
@@ -134,7 +134,7 @@ class GraphBuilderService:
                 message=t('progress.ontologySet')
             )
             
-            # 3. 文本分块
+            # 3. Split text into chunks
             chunks = TextProcessor.split_text(text, chunk_size, chunk_overlap)
             total_chunks = len(chunks)
             self.task_manager.update_task(
@@ -143,7 +143,7 @@ class GraphBuilderService:
                 message=t('progress.textSplit', count=total_chunks)
             )
             
-            # 4. 分批发送数据
+            # 4. Send data in batches
             episode_uuids = self.add_text_batches(
                 graph_id, chunks, batch_size,
                 lambda msg, prog: self.task_manager.update_task(
@@ -153,7 +153,7 @@ class GraphBuilderService:
                 )
             )
             
-            # 5. 等待Zep处理完成
+            # 5. Wait for Zep processing to complete
             self.task_manager.update_task(
                 task_id,
                 progress=60,
@@ -169,7 +169,7 @@ class GraphBuilderService:
                 )
             )
             
-            # 6. 获取图谱信息
+            # 6. Fetch graph information
             self.task_manager.update_task(
                 task_id,
                 progress=90,
@@ -178,7 +178,7 @@ class GraphBuilderService:
             
             graph_info = self._get_graph_info(graph_id)
             
-            # 完成
+            # Done
             self.task_manager.complete_task(task_id, {
                 "graph_id": graph_id,
                 "graph_info": graph_info.to_dict(),
@@ -191,7 +191,7 @@ class GraphBuilderService:
             self.task_manager.fail_task(task_id, error_msg)
     
     def create_graph(self, name: str) -> str:
-        """创建Zep图谱（公开方法）"""
+        """Create a Zep graph (public method)"""
         graph_id = f"mirofish_{uuid.uuid4().hex[:16]}"
         
         self.client.graph.create(
@@ -203,74 +203,75 @@ class GraphBuilderService:
         return graph_id
     
     def set_ontology(self, graph_id: str, ontology: Dict[str, Any]):
-        """设置图谱本体（公开方法）"""
+        """Set the graph ontology (public method)"""
         import warnings
         from typing import Optional
         from pydantic import Field
         from zep_cloud.external_clients.ontology import EntityModel, EntityText, EdgeModel
         
-        # 抑制 Pydantic v2 关于 Field(default=None) 的警告
-        # 这是 Zep SDK 要求的用法，警告来自动态类创建，可以安全忽略
+        # Suppress Pydantic v2 warnings about Field(default=None).
+        # This usage is required by the Zep SDK; the warning comes from
+        # dynamic class creation and can safely be ignored.
         warnings.filterwarnings('ignore', category=UserWarning, module='pydantic')
-        
-        # Zep 保留名称，不能作为属性名
+
+        # Zep reserved names that cannot be used as attribute names
         RESERVED_NAMES = {'uuid', 'name', 'group_id', 'name_embedding', 'summary', 'created_at'}
-        
+
         def safe_attr_name(attr_name: str) -> str:
-            """将保留名称转换为安全名称"""
+            """Convert reserved names to safe names"""
             if attr_name.lower() in RESERVED_NAMES:
                 return f"entity_{attr_name}"
             return attr_name
-        
-        # 动态创建实体类型
+
+        # Dynamically create entity types
         entity_types = {}
         for entity_def in ontology.get("entity_types", []):
             name = entity_def["name"]
             description = entity_def.get("description", f"A {name} entity.")
-            
-            # 创建属性字典和类型注解（Pydantic v2 需要）
+
+            # Build attribute dict and type annotations (Pydantic v2 requires both)
             attrs = {"__doc__": description}
             annotations = {}
-            
+
             for attr_def in entity_def.get("attributes", []):
-                attr_name = safe_attr_name(attr_def["name"])  # 使用安全名称
+                attr_name = safe_attr_name(attr_def["name"])  # use safe name
                 attr_desc = attr_def.get("description", attr_name)
-                # Zep API 需要 Field 的 description，这是必需的
+                # Zep API requires Field description; it is mandatory
                 attrs[attr_name] = Field(description=attr_desc, default=None)
-                annotations[attr_name] = Optional[EntityText]  # 类型注解
-            
+                annotations[attr_name] = Optional[EntityText]  # type annotation
+
             attrs["__annotations__"] = annotations
-            
-            # 动态创建类
+
+            # Dynamically create the class
             entity_class = type(name, (EntityModel,), attrs)
             entity_class.__doc__ = description
             entity_types[name] = entity_class
-        
-        # 动态创建边类型
+
+        # Dynamically create edge types
         edge_definitions = {}
         for edge_def in ontology.get("edge_types", []):
             name = edge_def["name"]
             description = edge_def.get("description", f"A {name} relationship.")
-            
-            # 创建属性字典和类型注解
+
+            # Build attribute dict and type annotations
             attrs = {"__doc__": description}
             annotations = {}
-            
+
             for attr_def in edge_def.get("attributes", []):
-                attr_name = safe_attr_name(attr_def["name"])  # 使用安全名称
+                attr_name = safe_attr_name(attr_def["name"])  # use safe name
                 attr_desc = attr_def.get("description", attr_name)
-                # Zep API 需要 Field 的 description，这是必需的
+                # Zep API requires Field description; it is mandatory
                 attrs[attr_name] = Field(description=attr_desc, default=None)
-                annotations[attr_name] = Optional[str]  # 边属性用str类型
-            
+                annotations[attr_name] = Optional[str]  # edge attributes use str type
+
             attrs["__annotations__"] = annotations
-            
-            # 动态创建类
+
+            # Dynamically create the class
             class_name = ''.join(word.capitalize() for word in name.split('_'))
             edge_class = type(class_name, (EdgeModel,), attrs)
             edge_class.__doc__ = description
-            
-            # 构建source_targets
+
+            # Build source_targets
             source_targets = []
             for st in edge_def.get("source_targets", []):
                 source_targets.append(
@@ -283,7 +284,7 @@ class GraphBuilderService:
             if source_targets:
                 edge_definitions[name] = (edge_class, source_targets)
         
-        # 调用Zep API设置本体
+        # Call the Zep API to set the ontology
         if entity_types or edge_definitions:
             self.client.graph.set_ontology(
                 graph_ids=[graph_id],
@@ -298,7 +299,7 @@ class GraphBuilderService:
         batch_size: int = 3,
         progress_callback: Optional[Callable] = None
     ) -> List[str]:
-        """分批添加文本到图谱，返回所有 episode 的 uuid 列表"""
+        """Add text to the graph in batches; returns the list of all episode uuids"""
         episode_uuids = []
         total_chunks = len(chunks)
         
@@ -314,27 +315,27 @@ class GraphBuilderService:
                     progress
                 )
             
-            # 构建episode数据
+            # Build episode data
             episodes = [
                 EpisodeData(data=chunk, type="text")
                 for chunk in batch_chunks
             ]
-            
-            # 发送到Zep
+
+            # Send to Zep
             try:
                 batch_result = self.client.graph.add_batch(
                     graph_id=graph_id,
                     episodes=episodes
                 )
                 
-                # 收集返回的 episode uuid
+                # Collect returned episode uuids
                 if batch_result and isinstance(batch_result, list):
                     for ep in batch_result:
                         ep_uuid = getattr(ep, 'uuid_', None) or getattr(ep, 'uuid', None)
                         if ep_uuid:
                             episode_uuids.append(ep_uuid)
-                
-                # 避免请求过快
+
+                # Avoid sending requests too quickly
                 time.sleep(1)
                 
             except Exception as e:
@@ -350,7 +351,7 @@ class GraphBuilderService:
         progress_callback: Optional[Callable] = None,
         timeout: int = 600
     ):
-        """等待所有 episode 处理完成（通过查询每个 episode 的 processed 状态）"""
+        """Wait for all episodes to finish processing (by polling each episode's processed status)"""
         if not episode_uuids:
             if progress_callback:
                 progress_callback(t('progress.noEpisodesWait'), 1.0)
@@ -373,18 +374,18 @@ class GraphBuilderService:
                     )
                 break
             
-            # 检查每个 episode 的处理状态
+            # Check the processing status of each episode
             for ep_uuid in list(pending_episodes):
                 try:
                     episode = self.client.graph.episode.get(uuid_=ep_uuid)
                     is_processed = getattr(episode, 'processed', False)
-                    
+
                     if is_processed:
                         pending_episodes.remove(ep_uuid)
                         completed_count += 1
-                        
+
                 except Exception as e:
-                    # 忽略单个查询错误，继续
+                    # Ignore individual query errors and continue
                     pass
             
             elapsed = int(time.time() - start_time)
@@ -395,20 +396,20 @@ class GraphBuilderService:
                 )
             
             if pending_episodes:
-                time.sleep(3)  # 每3秒检查一次
+                time.sleep(3)  # check every 3 seconds
         
         if progress_callback:
             progress_callback(t('progress.processingComplete', completed=completed_count, total=total_episodes), 1.0)
     
     def _get_graph_info(self, graph_id: str) -> GraphInfo:
-        """获取图谱信息"""
-        # 获取节点（分页）
+        """Fetch graph information"""
+        # Fetch nodes (paginated)
         nodes = fetch_all_nodes(self.client, graph_id)
 
-        # 获取边（分页）
+        # Fetch edges (paginated)
         edges = fetch_all_edges(self.client, graph_id)
 
-        # 统计实体类型
+        # Tally entity types
         entity_types = set()
         for node in nodes:
             if node.labels:
@@ -425,25 +426,25 @@ class GraphBuilderService:
     
     def get_graph_data(self, graph_id: str) -> Dict[str, Any]:
         """
-        获取完整图谱数据（包含详细信息）
-        
+        Get the full graph data (with detailed information)
+
         Args:
-            graph_id: 图谱ID
-            
+            graph_id: Graph ID
+
         Returns:
-            包含nodes和edges的字典，包括时间信息、属性等详细数据
+            Dictionary containing nodes and edges, including temporal info, attributes, and other details
         """
         nodes = fetch_all_nodes(self.client, graph_id)
         edges = fetch_all_edges(self.client, graph_id)
 
-        # 创建节点映射用于获取节点名称
+        # Build a node map to look up node names
         node_map = {}
         for node in nodes:
             node_map[node.uuid_] = node.name or ""
-        
+
         nodes_data = []
         for node in nodes:
-            # 获取创建时间
+            # Get creation time
             created_at = getattr(node, 'created_at', None)
             if created_at:
                 created_at = str(created_at)
@@ -459,20 +460,20 @@ class GraphBuilderService:
         
         edges_data = []
         for edge in edges:
-            # 获取时间信息
+            # Get temporal info
             created_at = getattr(edge, 'created_at', None)
             valid_at = getattr(edge, 'valid_at', None)
             invalid_at = getattr(edge, 'invalid_at', None)
             expired_at = getattr(edge, 'expired_at', None)
-            
-            # 获取 episodes
+
+            # Get episodes
             episodes = getattr(edge, 'episodes', None) or getattr(edge, 'episode_ids', None)
             if episodes and not isinstance(episodes, list):
                 episodes = [str(episodes)]
             elif episodes:
                 episodes = [str(e) for e in episodes]
-            
-            # 获取 fact_type
+
+            # Get fact_type
             fact_type = getattr(edge, 'fact_type', None) or edge.name or ""
             
             edges_data.append({
@@ -501,6 +502,6 @@ class GraphBuilderService:
         }
     
     def delete_graph(self, graph_id: str):
-        """删除图谱"""
+        """Delete the graph"""
         self.client.graph.delete(graph_id=graph_id)
 

--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -1,11 +1,12 @@
 """
-OASIS Agent Profile生成器
-将Zep图谱中的实体转换为OASIS模拟平台所需的Agent Profile格式
+OASIS Agent Profile generator
+Converts entities from a Zep graph into the Agent Profile format required by the
+OASIS simulation platform.
 
-优化改进：
-1. 调用Zep检索功能二次丰富节点信息
-2. 优化提示词生成非常详细的人设
-3. 区分个人实体和抽象群体实体
+Optimizations:
+1. Calls Zep retrieval to further enrich node information
+2. Refines prompts to produce highly detailed personas
+3. Distinguishes individual entities from abstract group entities
 """
 
 import json
@@ -28,49 +29,49 @@ logger = get_logger('mirofish.oasis_profile')
 
 @dataclass
 class OasisAgentProfile:
-    """OASIS Agent Profile数据结构"""
-    # 通用字段
+    """OASIS Agent Profile data structure"""
+    # Common fields
     user_id: int
     user_name: str
     name: str
     bio: str
     persona: str
-    
-    # 可选字段 - Reddit风格
+
+    # Optional fields - Reddit-style
     karma: int = 1000
-    
-    # 可选字段 - Twitter风格
+
+    # Optional fields - Twitter-style
     friend_count: int = 100
     follower_count: int = 150
     statuses_count: int = 500
-    
-    # 额外人设信息
+
+    # Additional persona information
     age: Optional[int] = None
     gender: Optional[str] = None
     mbti: Optional[str] = None
     country: Optional[str] = None
     profession: Optional[str] = None
     interested_topics: List[str] = field(default_factory=list)
-    
-    # 来源实体信息
+
+    # Source entity information
     source_entity_uuid: Optional[str] = None
     source_entity_type: Optional[str] = None
-    
+
     created_at: str = field(default_factory=lambda: datetime.now().strftime("%Y-%m-%d"))
-    
+
     def to_reddit_format(self) -> Dict[str, Any]:
-        """转换为Reddit平台格式"""
+        """Convert to Reddit platform format"""
         profile = {
             "user_id": self.user_id,
-            "username": self.user_name,  # OASIS 库要求字段名为 username（无下划线）
+            "username": self.user_name,  # The OASIS library requires the field name to be 'username' (no underscore)
             "name": self.name,
             "bio": self.bio,
             "persona": self.persona,
             "karma": self.karma,
             "created_at": self.created_at,
         }
-        
-        # 添加额外人设信息（如果有）
+
+        # Include the additional persona information when available
         if self.age:
             profile["age"] = self.age
         if self.gender:
@@ -83,14 +84,14 @@ class OasisAgentProfile:
             profile["profession"] = self.profession
         if self.interested_topics:
             profile["interested_topics"] = self.interested_topics
-        
+
         return profile
-    
+
     def to_twitter_format(self) -> Dict[str, Any]:
-        """转换为Twitter平台格式"""
+        """Convert to Twitter platform format"""
         profile = {
             "user_id": self.user_id,
-            "username": self.user_name,  # OASIS 库要求字段名为 username（无下划线）
+            "username": self.user_name,  # The OASIS library requires the field name to be 'username' (no underscore)
             "name": self.name,
             "bio": self.bio,
             "persona": self.persona,
@@ -99,8 +100,8 @@ class OasisAgentProfile:
             "statuses_count": self.statuses_count,
             "created_at": self.created_at,
         }
-        
-        # 添加额外人设信息
+
+        # Include additional persona information
         if self.age:
             profile["age"] = self.age
         if self.gender:
@@ -113,11 +114,11 @@ class OasisAgentProfile:
             profile["profession"] = self.profession
         if self.interested_topics:
             profile["interested_topics"] = self.interested_topics
-        
+
         return profile
-    
+
     def to_dict(self) -> Dict[str, Any]:
-        """转换为完整字典格式"""
+        """Convert to a complete dict format"""
         return {
             "user_id": self.user_id,
             "user_name": self.user_name,
@@ -142,44 +143,44 @@ class OasisAgentProfile:
 
 class OasisProfileGenerator:
     """
-    OASIS Profile生成器
-    
-    将Zep图谱中的实体转换为OASIS模拟所需的Agent Profile
-    
-    优化特性：
-    1. 调用Zep图谱检索功能获取更丰富的上下文
-    2. 生成非常详细的人设（包括基本信息、职业经历、性格特征、社交媒体行为等）
-    3. 区分个人实体和抽象群体实体
+    OASIS Profile generator
+
+    Converts entities from a Zep graph into Agent Profiles required by the OASIS simulation.
+
+    Optimization features:
+    1. Calls the Zep graph retrieval API to obtain richer context
+    2. Generates very detailed personas (basic information, career history, personality traits, social-media behavior, etc.)
+    3. Distinguishes individual entities from abstract group entities
     """
-    
-    # MBTI类型列表
+
+    # MBTI type list
     MBTI_TYPES = [
         "INTJ", "INTP", "ENTJ", "ENTP",
         "INFJ", "INFP", "ENFJ", "ENFP",
         "ISTJ", "ISFJ", "ESTJ", "ESFJ",
         "ISTP", "ISFP", "ESTP", "ESFP"
     ]
-    
-    # 常见国家列表
+
+    # Common countries list
     COUNTRIES = [
-        "China", "US", "UK", "Japan", "Germany", "France", 
+        "China", "US", "UK", "Japan", "Germany", "France",
         "Canada", "Australia", "Brazil", "India", "South Korea"
     ]
-    
-    # 个人类型实体（需要生成具体人设）
+
+    # Individual-type entities (require a concrete persona)
     INDIVIDUAL_ENTITY_TYPES = [
-        "student", "alumni", "professor", "person", "publicfigure", 
+        "student", "alumni", "professor", "person", "publicfigure",
         "expert", "faculty", "official", "journalist", "activist"
     ]
-    
-    # 群体/机构类型实体（需要生成群体代表人设）
+
+    # Group/institution-type entities (require a representative-account persona)
     GROUP_ENTITY_TYPES = [
-        "university", "governmentagency", "organization", "ngo", 
+        "university", "governmentagency", "organization", "ngo",
         "mediaoutlet", "company", "institution", "group", "community"
     ]
-    
+
     def __init__(
-        self, 
+        self,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         model_name: Optional[str] = None,
@@ -189,54 +190,54 @@ class OasisProfileGenerator:
         self.api_key = api_key or Config.LLM_API_KEY
         self.base_url = base_url or Config.LLM_BASE_URL
         self.model_name = model_name or Config.LLM_MODEL_NAME
-        
+
         if not self.api_key:
-            raise ValueError("LLM_API_KEY 未配置")
-        
+            raise ValueError("LLM_API_KEY is not configured")
+
         self.client = OpenAI(
             api_key=self.api_key,
             base_url=self.base_url
         )
-        
-        # Zep客户端用于检索丰富上下文
+
+        # Zep client used to retrieve richer context
         self.zep_api_key = zep_api_key or Config.ZEP_API_KEY
         self.zep_client = None
         self.graph_id = graph_id
-        
+
         if self.zep_api_key:
             try:
                 self.zep_client = Zep(api_key=self.zep_api_key)
             except Exception as e:
-                logger.warning(f"Zep客户端初始化失败: {e}")
-    
+                logger.warning(f"Zep client initialization failed: {e}")
+
     def generate_profile_from_entity(
-        self, 
-        entity: EntityNode, 
+        self,
+        entity: EntityNode,
         user_id: int,
         use_llm: bool = True
     ) -> OasisAgentProfile:
         """
-        从Zep实体生成OASIS Agent Profile
-        
+        Generate an OASIS Agent Profile from a Zep entity.
+
         Args:
-            entity: Zep实体节点
-            user_id: 用户ID（用于OASIS）
-            use_llm: 是否使用LLM生成详细人设
-            
+            entity: Zep entity node
+            user_id: User ID (for OASIS)
+            use_llm: Whether to use the LLM to generate a detailed persona
+
         Returns:
             OasisAgentProfile
         """
         entity_type = entity.get_entity_type() or "Entity"
-        
-        # 基础信息
+
+        # Basic info
         name = entity.name
         user_name = self._generate_username(name)
-        
-        # 构建上下文信息
+
+        # Build the context information
         context = self._build_entity_context(entity)
-        
+
         if use_llm:
-            # 使用LLM生成详细人设
+            # Use the LLM to generate a detailed persona
             profile_data = self._generate_profile_with_llm(
                 entity_name=name,
                 entity_type=entity_type,
@@ -245,14 +246,14 @@ class OasisProfileGenerator:
                 context=context
             )
         else:
-            # 使用规则生成基础人设
+            # Use rules to generate a basic persona
             profile_data = self._generate_profile_rule_based(
                 entity_name=name,
                 entity_type=entity_type,
                 entity_summary=entity.summary,
                 entity_attributes=entity.attributes
             )
-        
+
         return OasisAgentProfile(
             user_id=user_id,
             user_name=user_name,
@@ -272,56 +273,57 @@ class OasisProfileGenerator:
             source_entity_uuid=entity.uuid,
             source_entity_type=entity_type,
         )
-    
+
     def _generate_username(self, name: str) -> str:
-        """生成用户名"""
-        # 移除特殊字符，转换为小写
+        """Generate a username"""
+        # Remove special characters and convert to lower case
         username = name.lower().replace(" ", "_")
         username = ''.join(c for c in username if c.isalnum() or c == '_')
-        
-        # 添加随机后缀避免重复
+
+        # Append a random suffix to avoid collisions
         suffix = random.randint(100, 999)
         return f"{username}_{suffix}"
-    
+
     def _search_zep_for_entity(self, entity: EntityNode) -> Dict[str, Any]:
         """
-        使用Zep图谱混合搜索功能获取实体相关的丰富信息
-        
-        Zep没有内置混合搜索接口，需要分别搜索edges和nodes然后合并结果。
-        使用并行请求同时搜索，提高效率。
-        
+        Use the Zep graph hybrid-search feature to obtain rich information related to an entity.
+
+        Zep does not provide a built-in hybrid-search endpoint, so edges and nodes are
+        searched separately and the results merged. The two searches run in parallel
+        for efficiency.
+
         Args:
-            entity: 实体节点对象
-            
+            entity: Entity node object
+
         Returns:
-            包含facts, node_summaries, context的字典
+            Dict containing facts, node_summaries, and context
         """
         import concurrent.futures
-        
+
         if not self.zep_client:
             return {"facts": [], "node_summaries": [], "context": ""}
-        
+
         entity_name = entity.name
-        
+
         results = {
             "facts": [],
             "node_summaries": [],
             "context": ""
         }
-        
-        # 必须有graph_id才能进行搜索
+
+        # Searching requires graph_id
         if not self.graph_id:
-            logger.debug(f"跳过Zep检索：未设置graph_id")
+            logger.debug(f"Skipping Zep retrieval: graph_id is not set")
             return results
-        
+
         comprehensive_query = t('progress.zepSearchQuery', name=entity_name)
-        
+
         def search_edges():
-            """搜索边（事实/关系）- 带重试机制"""
+            """Search edges (facts/relationships) - with retry logic"""
             max_retries = 3
             last_exception = None
             delay = 2.0
-            
+
             for attempt in range(max_retries):
                 try:
                     return self.zep_client.graph.search(
@@ -334,19 +336,19 @@ class OasisProfileGenerator:
                 except Exception as e:
                     last_exception = e
                     if attempt < max_retries - 1:
-                        logger.debug(f"Zep边搜索第 {attempt + 1} 次失败: {str(e)[:80]}, 重试中...")
+                        logger.debug(f"Zep edge search attempt {attempt + 1} failed: {str(e)[:80]}; retrying...")
                         time.sleep(delay)
                         delay *= 2
                     else:
-                        logger.debug(f"Zep边搜索在 {max_retries} 次尝试后仍失败: {e}")
+                        logger.debug(f"Zep edge search still failed after {max_retries} attempts: {e}")
             return None
-        
+
         def search_nodes():
-            """搜索节点（实体摘要）- 带重试机制"""
+            """Search nodes (entity summaries) - with retry logic"""
             max_retries = 3
             last_exception = None
             delay = 2.0
-            
+
             for attempt in range(max_retries):
                 try:
                     return self.zep_client.graph.search(
@@ -359,141 +361,141 @@ class OasisProfileGenerator:
                 except Exception as e:
                     last_exception = e
                     if attempt < max_retries - 1:
-                        logger.debug(f"Zep节点搜索第 {attempt + 1} 次失败: {str(e)[:80]}, 重试中...")
+                        logger.debug(f"Zep node search attempt {attempt + 1} failed: {str(e)[:80]}; retrying...")
                         time.sleep(delay)
                         delay *= 2
                     else:
-                        logger.debug(f"Zep节点搜索在 {max_retries} 次尝试后仍失败: {e}")
+                        logger.debug(f"Zep node search still failed after {max_retries} attempts: {e}")
             return None
-        
+
         try:
-            # 并行执行edges和nodes搜索
+            # Run edge and node searches in parallel
             with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                 edge_future = executor.submit(search_edges)
                 node_future = executor.submit(search_nodes)
-                
-                # 获取结果
+
+                # Collect the results
                 edge_result = edge_future.result(timeout=30)
                 node_result = node_future.result(timeout=30)
-            
-            # 处理边搜索结果
+
+            # Process the edge search results
             all_facts = set()
             if edge_result and hasattr(edge_result, 'edges') and edge_result.edges:
                 for edge in edge_result.edges:
                     if hasattr(edge, 'fact') and edge.fact:
                         all_facts.add(edge.fact)
             results["facts"] = list(all_facts)
-            
-            # 处理节点搜索结果
+
+            # Process the node search results
             all_summaries = set()
             if node_result and hasattr(node_result, 'nodes') and node_result.nodes:
                 for node in node_result.nodes:
                     if hasattr(node, 'summary') and node.summary:
                         all_summaries.add(node.summary)
                     if hasattr(node, 'name') and node.name and node.name != entity_name:
-                        all_summaries.add(f"相关实体: {node.name}")
+                        all_summaries.add(f"Related entity: {node.name}")
             results["node_summaries"] = list(all_summaries)
-            
-            # 构建综合上下文
+
+            # Build the combined context
             context_parts = []
             if results["facts"]:
-                context_parts.append("事实信息:\n" + "\n".join(f"- {f}" for f in results["facts"][:20]))
+                context_parts.append("Facts:\n" + "\n".join(f"- {f}" for f in results["facts"][:20]))
             if results["node_summaries"]:
-                context_parts.append("相关实体:\n" + "\n".join(f"- {s}" for s in results["node_summaries"][:10]))
+                context_parts.append("Related entities:\n" + "\n".join(f"- {s}" for s in results["node_summaries"][:10]))
             results["context"] = "\n\n".join(context_parts)
-            
-            logger.info(f"Zep混合检索完成: {entity_name}, 获取 {len(results['facts'])} 条事实, {len(results['node_summaries'])} 个相关节点")
-            
+
+            logger.info(f"Zep hybrid retrieval complete: {entity_name}, retrieved {len(results['facts'])} facts and {len(results['node_summaries'])} related nodes")
+
         except concurrent.futures.TimeoutError:
-            logger.warning(f"Zep检索超时 ({entity_name})")
+            logger.warning(f"Zep retrieval timed out ({entity_name})")
         except Exception as e:
-            logger.warning(f"Zep检索失败 ({entity_name}): {e}")
-        
+            logger.warning(f"Zep retrieval failed ({entity_name}): {e}")
+
         return results
-    
+
     def _build_entity_context(self, entity: EntityNode) -> str:
         """
-        构建实体的完整上下文信息
-        
-        包括：
-        1. 实体本身的边信息（事实）
-        2. 关联节点的详细信息
-        3. Zep混合检索到的丰富信息
+        Build the complete context information for an entity.
+
+        Includes:
+        1. The entity's own edge information (facts)
+        2. Detailed information about related nodes
+        3. Rich information retrieved via Zep hybrid search
         """
         context_parts = []
-        
-        # 1. 添加实体属性信息
+
+        # 1. Add entity attributes
         if entity.attributes:
             attrs = []
             for key, value in entity.attributes.items():
                 if value and str(value).strip():
                     attrs.append(f"- {key}: {value}")
             if attrs:
-                context_parts.append("### 实体属性\n" + "\n".join(attrs))
-        
-        # 2. 添加相关边信息（事实/关系）
+                context_parts.append("### Entity attributes\n" + "\n".join(attrs))
+
+        # 2. Add related-edge information (facts/relationships)
         existing_facts = set()
         if entity.related_edges:
             relationships = []
-            for edge in entity.related_edges:  # 不限制数量
+            for edge in entity.related_edges:  # No limit on the number
                 fact = edge.get("fact", "")
                 edge_name = edge.get("edge_name", "")
                 direction = edge.get("direction", "")
-                
+
                 if fact:
                     relationships.append(f"- {fact}")
                     existing_facts.add(fact)
                 elif edge_name:
                     if direction == "outgoing":
-                        relationships.append(f"- {entity.name} --[{edge_name}]--> (相关实体)")
+                        relationships.append(f"- {entity.name} --[{edge_name}]--> (related entity)")
                     else:
-                        relationships.append(f"- (相关实体) --[{edge_name}]--> {entity.name}")
-            
+                        relationships.append(f"- (related entity) --[{edge_name}]--> {entity.name}")
+
             if relationships:
-                context_parts.append("### 相关事实和关系\n" + "\n".join(relationships))
-        
-        # 3. 添加关联节点的详细信息
+                context_parts.append("### Related facts and relationships\n" + "\n".join(relationships))
+
+        # 3. Add detailed information about related nodes
         if entity.related_nodes:
             related_info = []
-            for node in entity.related_nodes:  # 不限制数量
+            for node in entity.related_nodes:  # No limit on the number
                 node_name = node.get("name", "")
                 node_labels = node.get("labels", [])
                 node_summary = node.get("summary", "")
-                
-                # 过滤掉默认标签
+
+                # Filter out the default labels
                 custom_labels = [l for l in node_labels if l not in ["Entity", "Node"]]
                 label_str = f" ({', '.join(custom_labels)})" if custom_labels else ""
-                
+
                 if node_summary:
                     related_info.append(f"- **{node_name}**{label_str}: {node_summary}")
                 else:
                     related_info.append(f"- **{node_name}**{label_str}")
-            
+
             if related_info:
-                context_parts.append("### 关联实体信息\n" + "\n".join(related_info))
-        
-        # 4. 使用Zep混合检索获取更丰富的信息
+                context_parts.append("### Related entity information\n" + "\n".join(related_info))
+
+        # 4. Use Zep hybrid retrieval for richer information
         zep_results = self._search_zep_for_entity(entity)
-        
+
         if zep_results.get("facts"):
-            # 去重：排除已存在的事实
+            # Deduplicate: exclude facts that already exist
             new_facts = [f for f in zep_results["facts"] if f not in existing_facts]
             if new_facts:
-                context_parts.append("### Zep检索到的事实信息\n" + "\n".join(f"- {f}" for f in new_facts[:15]))
-        
+                context_parts.append("### Facts retrieved from Zep\n" + "\n".join(f"- {f}" for f in new_facts[:15]))
+
         if zep_results.get("node_summaries"):
-            context_parts.append("### Zep检索到的相关节点\n" + "\n".join(f"- {s}" for s in zep_results["node_summaries"][:10]))
-        
+            context_parts.append("### Related nodes retrieved from Zep\n" + "\n".join(f"- {s}" for s in zep_results["node_summaries"][:10]))
+
         return "\n\n".join(context_parts)
-    
+
     def _is_individual_entity(self, entity_type: str) -> bool:
-        """判断是否是个人类型实体"""
+        """Determine whether the entity is an individual type"""
         return entity_type.lower() in self.INDIVIDUAL_ENTITY_TYPES
-    
+
     def _is_group_entity(self, entity_type: str) -> bool:
-        """判断是否是群体/机构类型实体"""
+        """Determine whether the entity is a group/institution type"""
         return entity_type.lower() in self.GROUP_ENTITY_TYPES
-    
+
     def _generate_profile_with_llm(
         self,
         entity_name: str,
@@ -503,15 +505,15 @@ class OasisProfileGenerator:
         context: str
     ) -> Dict[str, Any]:
         """
-        使用LLM生成非常详细的人设
-        
-        根据实体类型区分：
-        - 个人实体：生成具体的人物设定
-        - 群体/机构实体：生成代表性账号设定
+        Use the LLM to generate a very detailed persona.
+
+        Distinguishes by entity type:
+        - Individual entities: produce a concrete personal persona
+        - Group/institution entities: produce a representative-account persona
         """
-        
+
         is_individual = self._is_individual_entity(entity_type)
-        
+
         if is_individual:
             prompt = self._build_individual_persona_prompt(
                 entity_name, entity_type, entity_summary, entity_attributes, context
@@ -521,10 +523,10 @@ class OasisProfileGenerator:
                 entity_name, entity_type, entity_summary, entity_attributes, context
             )
 
-        # 尝试多次生成，直到成功或达到最大重试次数
+        # Try multiple times until success or the maximum retry count is reached
         max_attempts = 3
         last_error = None
-        
+
         for attempt in range(max_attempts):
             try:
                 response = self.client.chat.completions.create(
@@ -534,146 +536,146 @@ class OasisProfileGenerator:
                         {"role": "user", "content": prompt}
                     ],
                     response_format={"type": "json_object"},
-                    temperature=0.7 - (attempt * 0.1)  # 每次重试降低温度
-                    # 不设置max_tokens，让LLM自由发挥
+                    temperature=0.7 - (attempt * 0.1)  # Lower the temperature on each retry
+                    # Do not set max_tokens; let the LLM produce as much as needed
                 )
-                
+
                 content = response.choices[0].message.content
-                
-                # 检查是否被截断（finish_reason不是'stop'）
+
+                # Check whether the output was truncated (finish_reason is not 'stop')
                 finish_reason = response.choices[0].finish_reason
                 if finish_reason == 'length':
-                    logger.warning(f"LLM输出被截断 (attempt {attempt+1}), 尝试修复...")
+                    logger.warning(f"LLM output was truncated (attempt {attempt+1}); attempting to repair...")
                     content = self._fix_truncated_json(content)
-                
-                # 尝试解析JSON
+
+                # Try to parse the JSON
                 try:
                     result = json.loads(content)
-                    
-                    # 验证必需字段
+
+                    # Validate required fields
                     if "bio" not in result or not result["bio"]:
                         result["bio"] = entity_summary[:200] if entity_summary else f"{entity_type}: {entity_name}"
                     if "persona" not in result or not result["persona"]:
-                        result["persona"] = entity_summary or f"{entity_name}是一个{entity_type}。"
-                    
+                        result["persona"] = entity_summary or f"{entity_name} is a {entity_type}."
+
                     return result
-                    
+
                 except json.JSONDecodeError as je:
-                    logger.warning(f"JSON解析失败 (attempt {attempt+1}): {str(je)[:80]}")
-                    
-                    # 尝试修复JSON
+                    logger.warning(f"JSON parsing failed (attempt {attempt+1}): {str(je)[:80]}")
+
+                    # Try to repair the JSON
                     result = self._try_fix_json(content, entity_name, entity_type, entity_summary)
                     if result.get("_fixed"):
                         del result["_fixed"]
                         return result
-                    
+
                     last_error = je
-                    
+
             except Exception as e:
-                logger.warning(f"LLM调用失败 (attempt {attempt+1}): {str(e)[:80]}")
+                logger.warning(f"LLM call failed (attempt {attempt+1}): {str(e)[:80]}")
                 last_error = e
                 import time
-                time.sleep(1 * (attempt + 1))  # 指数退避
-        
-        logger.warning(f"LLM生成人设失败（{max_attempts}次尝试）: {last_error}, 使用规则生成")
+                time.sleep(1 * (attempt + 1))  # Exponential backoff
+
+        logger.warning(f"LLM persona generation failed ({max_attempts} attempts): {last_error}; falling back to rule-based generation")
         return self._generate_profile_rule_based(
             entity_name, entity_type, entity_summary, entity_attributes
         )
-    
+
     def _fix_truncated_json(self, content: str) -> str:
-        """修复被截断的JSON（输出被max_tokens限制截断）"""
+        """Repair truncated JSON (output was cut off by max_tokens)"""
         import re
-        
-        # 如果JSON被截断，尝试闭合它
+
+        # If the JSON is truncated, try to close it
         content = content.strip()
-        
-        # 计算未闭合的括号
+
+        # Count unclosed braces and brackets
         open_braces = content.count('{') - content.count('}')
         open_brackets = content.count('[') - content.count(']')
-        
-        # 检查是否有未闭合的字符串
-        # 简单检查：如果最后一个引号后没有逗号或闭合括号，可能是字符串被截断
+
+        # Check for an unclosed string
+        # Simple heuristic: if the last character is not followed by a comma or closing bracket, the string may be truncated
         if content and content[-1] not in '",}]':
-            # 尝试闭合字符串
+            # Try to close the string
             content += '"'
-        
-        # 闭合括号
+
+        # Close brackets and braces
         content += ']' * open_brackets
         content += '}' * open_braces
-        
+
         return content
-    
+
     def _try_fix_json(self, content: str, entity_name: str, entity_type: str, entity_summary: str = "") -> Dict[str, Any]:
-        """尝试修复损坏的JSON"""
+        """Try to repair broken JSON"""
         import re
-        
-        # 1. 首先尝试修复被截断的情况
+
+        # 1. First handle the truncation case
         content = self._fix_truncated_json(content)
-        
-        # 2. 尝试提取JSON部分
+
+        # 2. Try to extract the JSON portion
         json_match = re.search(r'\{[\s\S]*\}', content)
         if json_match:
             json_str = json_match.group()
-            
-            # 3. 处理字符串中的换行符问题
-            # 找到所有字符串值并替换其中的换行符
+
+            # 3. Handle newline characters inside strings
+            # Find every string value and replace newlines within it
             def fix_string_newlines(match):
                 s = match.group(0)
-                # 替换字符串内的实际换行符为空格
+                # Replace actual newlines inside the string with spaces
                 s = s.replace('\n', ' ').replace('\r', ' ')
-                # 替换多余空格
+                # Collapse extra whitespace
                 s = re.sub(r'\s+', ' ', s)
                 return s
-            
-            # 匹配JSON字符串值
+
+            # Match JSON string values
             json_str = re.sub(r'"[^"\\]*(?:\\.[^"\\]*)*"', fix_string_newlines, json_str)
-            
-            # 4. 尝试解析
+
+            # 4. Try to parse
             try:
                 result = json.loads(json_str)
                 result["_fixed"] = True
                 return result
             except json.JSONDecodeError as e:
-                # 5. 如果还是失败，尝试更激进的修复
+                # 5. If it still fails, try a more aggressive repair
                 try:
-                    # 移除所有控制字符
+                    # Remove all control characters
                     json_str = re.sub(r'[\x00-\x1f\x7f-\x9f]', ' ', json_str)
-                    # 替换所有连续空白
+                    # Collapse all consecutive whitespace
                     json_str = re.sub(r'\s+', ' ', json_str)
                     result = json.loads(json_str)
                     result["_fixed"] = True
                     return result
                 except:
                     pass
-        
-        # 6. 尝试从内容中提取部分信息
+
+        # 6. Try to extract partial information from the content
         bio_match = re.search(r'"bio"\s*:\s*"([^"]*)"', content)
-        persona_match = re.search(r'"persona"\s*:\s*"([^"]*)', content)  # 可能被截断
-        
+        persona_match = re.search(r'"persona"\s*:\s*"([^"]*)', content)  # May be truncated
+
         bio = bio_match.group(1) if bio_match else (entity_summary[:200] if entity_summary else f"{entity_type}: {entity_name}")
-        persona = persona_match.group(1) if persona_match else (entity_summary or f"{entity_name}是一个{entity_type}。")
-        
-        # 如果提取到了有意义的内容，标记为已修复
+        persona = persona_match.group(1) if persona_match else (entity_summary or f"{entity_name} is a {entity_type}.")
+
+        # If we managed to extract meaningful content, mark it as repaired
         if bio_match or persona_match:
-            logger.info(f"从损坏的JSON中提取了部分信息")
+            logger.info(f"Extracted partial information from broken JSON")
             return {
                 "bio": bio,
                 "persona": persona,
                 "_fixed": True
             }
-        
-        # 7. 完全失败，返回基础结构
-        logger.warning(f"JSON修复失败，返回基础结构")
+
+        # 7. Total failure: return a basic structure
+        logger.warning(f"JSON repair failed; returning basic structure")
         return {
             "bio": entity_summary[:200] if entity_summary else f"{entity_type}: {entity_name}",
-            "persona": entity_summary or f"{entity_name}是一个{entity_type}。"
+            "persona": entity_summary or f"{entity_name} is a {entity_type}."
         }
-    
+
     def _get_system_prompt(self, is_individual: bool) -> str:
-        """获取系统提示词"""
-        base_prompt = "你是社交媒体用户画像生成专家。生成详细、真实的人设用于舆论模拟,最大程度还原已有现实情况。必须返回有效的JSON格式，所有字符串值不能包含未转义的换行符。"
+        """Get the system prompt"""
+        base_prompt = "You are an expert in generating social-media user profiles. Generate detailed, realistic personas for public-opinion simulation, staying as faithful as possible to the existing real-world facts. You must return valid JSON; no string value may contain unescaped newlines."
         return f"{base_prompt}\n\n{get_language_instruction()}"
-    
+
     def _build_individual_persona_prompt(
         self,
         entity_name: str,
@@ -682,45 +684,45 @@ class OasisProfileGenerator:
         entity_attributes: Dict[str, Any],
         context: str
     ) -> str:
-        """构建个人实体的详细人设提示词"""
-        
-        attrs_str = json.dumps(entity_attributes, ensure_ascii=False) if entity_attributes else "无"
-        context_str = context[:3000] if context else "无额外上下文"
-        
-        return f"""为实体生成详细的社交媒体用户人设,最大程度还原已有现实情况。
+        """Build the detailed-persona prompt for an individual entity"""
 
-实体名称: {entity_name}
-实体类型: {entity_type}
-实体摘要: {entity_summary}
-实体属性: {attrs_str}
+        attrs_str = json.dumps(entity_attributes, ensure_ascii=False) if entity_attributes else "None"
+        context_str = context[:3000] if context else "No additional context"
 
-上下文信息:
+        return f"""Generate a detailed social-media user persona for the entity, staying as faithful as possible to the existing real-world facts.
+
+Entity name: {entity_name}
+Entity type: {entity_type}
+Entity summary: {entity_summary}
+Entity attributes: {attrs_str}
+
+Context information:
 {context_str}
 
-请生成JSON，包含以下字段:
+Produce JSON containing the following fields:
 
-1. bio: 社交媒体简介，200字
-2. persona: 详细人设描述（2000字的纯文本），需包含:
-   - 基本信息（年龄、职业、教育背景、所在地）
-   - 人物背景（重要经历、与事件的关联、社会关系）
-   - 性格特征（MBTI类型、核心性格、情绪表达方式）
-   - 社交媒体行为（发帖频率、内容偏好、互动风格、语言特点）
-   - 立场观点（对话题的态度、可能被激怒/感动的内容）
-   - 独特特征（口头禅、特殊经历、个人爱好）
-   - 个人记忆（人设的重要部分，要介绍这个个体与事件的关联，以及这个个体在事件中的已有动作与反应）
-3. age: 年龄数字（必须是整数）
-4. gender: 性别，必须是英文: "male" 或 "female"
-5. mbti: MBTI类型（如INTJ、ENFP等）
-6. country: 国家（使用中文，如"中国"）
-7. profession: 职业
-8. interested_topics: 感兴趣话题数组
+1. bio: social-media bio, 200 characters
+2. persona: detailed persona description (2000 characters of plain text). Must include:
+   - Basic information (age, occupation, educational background, location)
+   - Background (significant experiences, connection to the event, social relationships)
+   - Personality traits (MBTI type, core personality, way of expressing emotion)
+   - Social-media behavior (posting frequency, content preferences, interaction style, language quirks)
+   - Stance and views (attitude toward the topic, content that may anger or move them)
+   - Distinctive features (catchphrases, special experiences, personal hobbies)
+   - Personal memory (an important part of the persona that describes the individual's connection to the event and their existing actions/reactions during it)
+3. age: numeric age (must be an integer)
+4. gender: gender; must be English: "male" or "female"
+5. mbti: MBTI type (e.g., INTJ, ENFP)
+6. country: country (use the localized name, e.g., "China")
+7. profession: occupation
+8. interested_topics: array of topics of interest
 
-重要:
-- 所有字段值必须是字符串或数字，不要使用换行符
-- persona必须是一段连贯的文字描述
-- {get_language_instruction()} (gender字段必须用英文male/female)
-- 内容要与实体信息保持一致
-- age必须是有效的整数，gender必须是"male"或"female"
+Important:
+- Every field value must be a string or number; do not use newline characters
+- persona must be a single coherent block of text
+- {get_language_instruction()} (the gender field must use the English values male/female)
+- Content must be consistent with the entity information
+- age must be a valid integer; gender must be "male" or "female"
 """
 
     def _build_group_persona_prompt(
@@ -731,46 +733,46 @@ class OasisProfileGenerator:
         entity_attributes: Dict[str, Any],
         context: str
     ) -> str:
-        """构建群体/机构实体的详细人设提示词"""
-        
-        attrs_str = json.dumps(entity_attributes, ensure_ascii=False) if entity_attributes else "无"
-        context_str = context[:3000] if context else "无额外上下文"
-        
-        return f"""为机构/群体实体生成详细的社交媒体账号设定,最大程度还原已有现实情况。
+        """Build the detailed-persona prompt for a group/institution entity"""
 
-实体名称: {entity_name}
-实体类型: {entity_type}
-实体摘要: {entity_summary}
-实体属性: {attrs_str}
+        attrs_str = json.dumps(entity_attributes, ensure_ascii=False) if entity_attributes else "None"
+        context_str = context[:3000] if context else "No additional context"
 
-上下文信息:
+        return f"""Generate a detailed social-media account persona for the institution/group entity, staying as faithful as possible to the existing real-world facts.
+
+Entity name: {entity_name}
+Entity type: {entity_type}
+Entity summary: {entity_summary}
+Entity attributes: {attrs_str}
+
+Context information:
 {context_str}
 
-请生成JSON，包含以下字段:
+Produce JSON containing the following fields:
 
-1. bio: 官方账号简介，200字，专业得体
-2. persona: 详细账号设定描述（2000字的纯文本），需包含:
-   - 机构基本信息（正式名称、机构性质、成立背景、主要职能）
-   - 账号定位（账号类型、目标受众、核心功能）
-   - 发言风格（语言特点、常用表达、禁忌话题）
-   - 发布内容特点（内容类型、发布频率、活跃时间段）
-   - 立场态度（对核心话题的官方立场、面对争议的处理方式）
-   - 特殊说明（代表的群体画像、运营习惯）
-   - 机构记忆（机构人设的重要部分，要介绍这个机构与事件的关联，以及这个机构在事件中的已有动作与反应）
-3. age: 固定填30（机构账号的虚拟年龄）
-4. gender: 固定填"other"（机构账号使用other表示非个人）
-5. mbti: MBTI类型，用于描述账号风格，如ISTJ代表严谨保守
-6. country: 国家（使用中文，如"中国"）
-7. profession: 机构职能描述
-8. interested_topics: 关注领域数组
+1. bio: official-account bio, 200 characters, professional and appropriate
+2. persona: detailed account-persona description (2000 characters of plain text). Must include:
+   - Institutional basic information (formal name, organizational nature, founding background, primary functions)
+   - Account positioning (account type, target audience, core function)
+   - Communication style (language traits, common expressions, taboo topics)
+   - Posting characteristics (content types, posting frequency, active time windows)
+   - Stance and attitude (official position on core topics, approach to handling controversy)
+   - Special notes (representative audience profile, operational habits)
+   - Institutional memory (an important part of the account persona that describes the institution's connection to the event and its existing actions/reactions during it)
+3. age: fixed value of 30 (the institutional account's virtual age)
+4. gender: fixed value "other" (institutional accounts use "other" to indicate non-personal)
+5. mbti: MBTI type used to characterize the account style; e.g., ISTJ for rigorous and conservative
+6. country: country (use the localized name, e.g., "China")
+7. profession: description of the institution's function
+8. interested_topics: array of focus areas
 
-重要:
-- 所有字段值必须是字符串或数字，不允许null值
-- persona必须是一段连贯的文字描述，不要使用换行符
-- {get_language_instruction()} (gender字段必须用英文"other")
-- age必须是整数30，gender必须是字符串"other"
-- 机构账号发言要符合其身份定位"""
-    
+Important:
+- Every field value must be a string or number; null values are not allowed
+- persona must be a single coherent block of text and must not contain newline characters
+- {get_language_instruction()} (the gender field must use the English value "other")
+- age must be the integer 30; gender must be the string "other"
+- The institutional account's communication must match its identity"""
+
     def _generate_profile_rule_based(
         self,
         entity_name: str,
@@ -778,11 +780,11 @@ class OasisProfileGenerator:
         entity_summary: str,
         entity_attributes: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """使用规则生成基础人设"""
-        
-        # 根据实体类型生成不同的人设
+        """Use rules to generate a basic persona"""
+
+        # Generate different personas depending on entity type
         entity_type_lower = entity_type.lower()
-        
+
         if entity_type_lower in ["student", "alumni"]:
             return {
                 "bio": f"{entity_type} with interests in academics and social issues.",
@@ -794,7 +796,7 @@ class OasisProfileGenerator:
                 "profession": "Student",
                 "interested_topics": ["Education", "Social Issues", "Technology"],
             }
-        
+
         elif entity_type_lower in ["publicfigure", "expert", "faculty"]:
             return {
                 "bio": f"Expert and thought leader in their field.",
@@ -806,33 +808,33 @@ class OasisProfileGenerator:
                 "profession": entity_attributes.get("occupation", "Expert"),
                 "interested_topics": ["Politics", "Economics", "Culture & Society"],
             }
-        
+
         elif entity_type_lower in ["mediaoutlet", "socialmediaplatform"]:
             return {
                 "bio": f"Official account for {entity_name}. News and updates.",
                 "persona": f"{entity_name} is a media entity that reports news and facilitates public discourse. The account shares timely updates and engages with the audience on current events.",
-                "age": 30,  # 机构虚拟年龄
-                "gender": "other",  # 机构使用other
-                "mbti": "ISTJ",  # 机构风格：严谨保守
-                "country": "中国",
+                "age": 30,  # Institutional virtual age
+                "gender": "other",  # Institutions use "other"
+                "mbti": "ISTJ",  # Institutional style: rigorous and conservative
+                "country": "China",
                 "profession": "Media",
                 "interested_topics": ["General News", "Current Events", "Public Affairs"],
             }
-        
+
         elif entity_type_lower in ["university", "governmentagency", "ngo", "organization"]:
             return {
                 "bio": f"Official account of {entity_name}.",
                 "persona": f"{entity_name} is an institutional entity that communicates official positions, announcements, and engages with stakeholders on relevant matters.",
-                "age": 30,  # 机构虚拟年龄
-                "gender": "other",  # 机构使用other
-                "mbti": "ISTJ",  # 机构风格：严谨保守
-                "country": "中国",
+                "age": 30,  # Institutional virtual age
+                "gender": "other",  # Institutions use "other"
+                "mbti": "ISTJ",  # Institutional style: rigorous and conservative
+                "country": "China",
                 "profession": entity_type,
                 "interested_topics": ["Public Policy", "Community", "Official Announcements"],
             }
-        
+
         else:
-            # 默认人设
+            # Default persona
             return {
                 "bio": entity_summary[:150] if entity_summary else f"{entity_type}: {entity_name}",
                 "persona": entity_summary or f"{entity_name} is a {entity_type.lower()} participating in social discussions.",
@@ -843,11 +845,11 @@ class OasisProfileGenerator:
                 "profession": entity_type,
                 "interested_topics": ["General", "Social Issues"],
             }
-    
+
     def set_graph_id(self, graph_id: str):
-        """设置图谱ID用于Zep检索"""
+        """Set the graph ID used for Zep retrieval"""
         self.graph_id = graph_id
-    
+
     def generate_profiles_from_entities(
         self,
         entities: List[EntityNode],
@@ -859,52 +861,52 @@ class OasisProfileGenerator:
         output_platform: str = "reddit"
     ) -> List[OasisAgentProfile]:
         """
-        批量从实体生成Agent Profile（支持并行生成）
-        
+        Batch-generate Agent Profiles from entities (supports parallel generation).
+
         Args:
-            entities: 实体列表
-            use_llm: 是否使用LLM生成详细人设
-            progress_callback: 进度回调函数 (current, total, message)
-            graph_id: 图谱ID，用于Zep检索获取更丰富上下文
-            parallel_count: 并行生成数量，默认5
-            realtime_output_path: 实时写入的文件路径（如果提供，每生成一个就写入一次）
-            output_platform: 输出平台格式 ("reddit" 或 "twitter")
-            
+            entities: List of entities
+            use_llm: Whether to use the LLM to generate detailed personas
+            progress_callback: Progress callback function (current, total, message)
+            graph_id: Graph ID, used by Zep retrieval to obtain richer context
+            parallel_count: Number of profiles to generate in parallel; defaults to 5
+            realtime_output_path: File path for real-time writes (when provided, the file is rewritten after each profile is generated)
+            output_platform: Output platform format ("reddit" or "twitter")
+
         Returns:
-            Agent Profile列表
+            List of Agent Profiles
         """
         import concurrent.futures
         from threading import Lock
-        
-        # 设置graph_id用于Zep检索
+
+        # Set graph_id for Zep retrieval
         if graph_id:
             self.graph_id = graph_id
-        
+
         total = len(entities)
-        profiles = [None] * total  # 预分配列表保持顺序
-        completed_count = [0]  # 使用列表以便在闭包中修改
+        profiles = [None] * total  # Pre-allocate the list to preserve order
+        completed_count = [0]  # Use a list so the closure can mutate it
         lock = Lock()
-        
-        # 实时写入文件的辅助函数
+
+        # Helper that writes the profiles to disk in real time
         def save_profiles_realtime():
-            """实时保存已生成的 profiles 到文件"""
+            """Save the profiles generated so far to the file"""
             if not realtime_output_path:
                 return
-            
+
             with lock:
-                # 过滤出已生成的 profiles
+                # Filter to the profiles that have been generated
                 existing_profiles = [p for p in profiles if p is not None]
                 if not existing_profiles:
                     return
-                
+
                 try:
                     if output_platform == "reddit":
-                        # Reddit JSON 格式
+                        # Reddit JSON format
                         profiles_data = [p.to_reddit_format() for p in existing_profiles]
                         with open(realtime_output_path, 'w', encoding='utf-8') as f:
                             json.dump(profiles_data, f, ensure_ascii=False, indent=2)
                     else:
-                        # Twitter CSV 格式
+                        # Twitter CSV format
                         import csv
                         profiles_data = [p.to_twitter_format() for p in existing_profiles]
                         if profiles_data:
@@ -914,31 +916,31 @@ class OasisProfileGenerator:
                                 writer.writeheader()
                                 writer.writerows(profiles_data)
                 except Exception as e:
-                    logger.warning(f"实时保存 profiles 失败: {e}")
-        
+                    logger.warning(f"Real-time save of profiles failed: {e}")
+
         # Capture locale before spawning thread pool workers
         current_locale = get_locale()
 
         def generate_single_profile(idx: int, entity: EntityNode) -> tuple:
-            """生成单个profile的工作函数"""
+            """Worker function that generates a single profile"""
             set_locale(current_locale)
             entity_type = entity.get_entity_type() or "Entity"
-            
+
             try:
                 profile = self.generate_profile_from_entity(
                     entity=entity,
                     user_id=idx,
                     use_llm=use_llm
                 )
-                
-                # 实时输出生成的人设到控制台和日志
+
+                # Output the generated persona to console and log in real time
                 self._print_generated_profile(entity.name, entity_type, profile)
-                
+
                 return idx, profile, None
-                
+
             except Exception as e:
-                logger.error(f"生成实体 {entity.name} 的人设失败: {str(e)}")
-                # 创建一个基础profile
+                logger.error(f"Failed to generate persona for entity {entity.name}: {str(e)}")
+                # Create a basic fallback profile
                 fallback_profile = OasisAgentProfile(
                     user_id=idx,
                     user_name=self._generate_username(entity.name),
@@ -949,50 +951,50 @@ class OasisProfileGenerator:
                     source_entity_type=entity_type,
                 )
                 return idx, fallback_profile, str(e)
-        
-        logger.info(f"开始并行生成 {total} 个Agent人设（并行数: {parallel_count}）...")
+
+        logger.info(f"Starting parallel generation of {total} agent personas (parallelism: {parallel_count})...")
         print(f"\n{'='*60}")
-        print(f"开始生成Agent人设 - 共 {total} 个实体，并行数: {parallel_count}")
+        print(f"Starting agent persona generation - {total} entities, parallelism: {parallel_count}")
         print(f"{'='*60}\n")
-        
-        # 使用线程池并行执行
+
+        # Use a thread pool for parallel execution
         with concurrent.futures.ThreadPoolExecutor(max_workers=parallel_count) as executor:
-            # 提交所有任务
+            # Submit all tasks
             future_to_entity = {
                 executor.submit(generate_single_profile, idx, entity): (idx, entity)
                 for idx, entity in enumerate(entities)
             }
-            
-            # 收集结果
+
+            # Collect results
             for future in concurrent.futures.as_completed(future_to_entity):
                 idx, entity = future_to_entity[future]
                 entity_type = entity.get_entity_type() or "Entity"
-                
+
                 try:
                     result_idx, profile, error = future.result()
                     profiles[result_idx] = profile
-                    
+
                     with lock:
                         completed_count[0] += 1
                         current = completed_count[0]
-                    
-                    # 实时写入文件
+
+                    # Persist the file in real time
                     save_profiles_realtime()
-                    
+
                     if progress_callback:
                         progress_callback(
-                            current, 
-                            total, 
-                            f"已完成 {current}/{total}: {entity.name}（{entity_type}）"
+                            current,
+                            total,
+                            f"Completed {current}/{total}: {entity.name} ({entity_type})"
                         )
-                    
+
                     if error:
-                        logger.warning(f"[{current}/{total}] {entity.name} 使用备用人设: {error}")
+                        logger.warning(f"[{current}/{total}] {entity.name} using fallback persona: {error}")
                     else:
-                        logger.info(f"[{current}/{total}] 成功生成人设: {entity.name} ({entity_type})")
-                        
+                        logger.info(f"[{current}/{total}] Successfully generated persona: {entity.name} ({entity_type})")
+
                 except Exception as e:
-                    logger.error(f"处理实体 {entity.name} 时发生异常: {str(e)}")
+                    logger.error(f"Exception while processing entity {entity.name}: {str(e)}")
                     with lock:
                         completed_count[0] += 1
                     profiles[idx] = OasisAgentProfile(
@@ -1004,46 +1006,46 @@ class OasisProfileGenerator:
                         source_entity_uuid=entity.uuid,
                         source_entity_type=entity_type,
                     )
-                    # 实时写入文件（即使是备用人设）
+                    # Persist the file in real time (even for fallback personas)
                     save_profiles_realtime()
-        
+
         print(f"\n{'='*60}")
-        print(f"人设生成完成！共生成 {len([p for p in profiles if p])} 个Agent")
+        print(f"Persona generation complete! Generated {len([p for p in profiles if p])} agents")
         print(f"{'='*60}\n")
-        
+
         return profiles
-    
+
     def _print_generated_profile(self, entity_name: str, entity_type: str, profile: OasisAgentProfile):
-        """实时输出生成的人设到控制台（完整内容，不截断）"""
+        """Output the generated persona to the console in real time (full content, no truncation)"""
         separator = "-" * 70
-        
-        # 构建完整输出内容（不截断）
-        topics_str = ', '.join(profile.interested_topics) if profile.interested_topics else '无'
-        
+
+        # Build the full output content (no truncation)
+        topics_str = ', '.join(profile.interested_topics) if profile.interested_topics else 'None'
+
         output_lines = [
             f"\n{separator}",
             t('progress.profileGenerated', name=entity_name, type=entity_type),
             f"{separator}",
-            f"用户名: {profile.user_name}",
+            f"Username: {profile.user_name}",
             f"",
-            f"【简介】",
+            f"[Bio]",
             f"{profile.bio}",
             f"",
-            f"【详细人设】",
+            f"[Detailed persona]",
             f"{profile.persona}",
             f"",
-            f"【基本属性】",
-            f"年龄: {profile.age} | 性别: {profile.gender} | MBTI: {profile.mbti}",
-            f"职业: {profile.profession} | 国家: {profile.country}",
-            f"兴趣话题: {topics_str}",
+            f"[Basic attributes]",
+            f"Age: {profile.age} | Gender: {profile.gender} | MBTI: {profile.mbti}",
+            f"Profession: {profile.profession} | Country: {profile.country}",
+            f"Interested topics: {topics_str}",
             separator
         ]
-        
+
         output = "\n".join(output_lines)
-        
-        # 只输出到控制台（避免重复，logger不再输出完整内容）
+
+        # Only print to console (avoids duplication; logger no longer emits the full content)
         print(output)
-    
+
     def save_profiles(
         self,
         profiles: List[OasisAgentProfile],
@@ -1051,155 +1053,154 @@ class OasisProfileGenerator:
         platform: str = "reddit"
     ):
         """
-        保存Profile到文件（根据平台选择正确格式）
-        
-        OASIS平台格式要求：
-        - Twitter: CSV格式
-        - Reddit: JSON格式
-        
+        Save profiles to a file (selecting the correct format for the platform).
+
+        OASIS platform format requirements:
+        - Twitter: CSV format
+        - Reddit: JSON format
+
         Args:
-            profiles: Profile列表
-            file_path: 文件路径
-            platform: 平台类型 ("reddit" 或 "twitter")
+            profiles: Profile list
+            file_path: File path
+            platform: Platform type ("reddit" or "twitter")
         """
         if platform == "twitter":
             self._save_twitter_csv(profiles, file_path)
         else:
             self._save_reddit_json(profiles, file_path)
-    
+
     def _save_twitter_csv(self, profiles: List[OasisAgentProfile], file_path: str):
         """
-        保存Twitter Profile为CSV格式（符合OASIS官方要求）
-        
-        OASIS Twitter要求的CSV字段：
-        - user_id: 用户ID（根据CSV顺序从0开始）
-        - name: 用户真实姓名
-        - username: 系统中的用户名
-        - user_char: 详细人设描述（注入到LLM系统提示中，指导Agent行为）
-        - description: 简短的公开简介（显示在用户资料页面）
-        
-        user_char vs description 区别：
-        - user_char: 内部使用，LLM系统提示，决定Agent如何思考和行动
-        - description: 外部显示，其他用户可见的简介
+        Save Twitter profiles in CSV format (matching the OASIS official requirements).
+
+        OASIS Twitter required CSV fields:
+        - user_id: user ID (zero-based, following CSV order)
+        - name: real name
+        - username: in-system username
+        - user_char: detailed persona description (injected into the LLM system prompt to guide the agent's behavior)
+        - description: short public bio (shown on the user's profile page)
+
+        Difference between user_char and description:
+        - user_char: internal use, the LLM system prompt that determines how the agent thinks and acts
+        - description: external display, the bio visible to other users
         """
         import csv
-        
-        # 确保文件扩展名是.csv
+
+        # Ensure the file extension is .csv
         if not file_path.endswith('.csv'):
             file_path = file_path.replace('.json', '.csv')
-        
+
         with open(file_path, 'w', newline='', encoding='utf-8') as f:
             writer = csv.writer(f)
-            
-            # 写入OASIS要求的表头
+
+            # Write the headers required by OASIS
             headers = ['user_id', 'name', 'username', 'user_char', 'description']
             writer.writerow(headers)
-            
-            # 写入数据行
+
+            # Write data rows
             for idx, profile in enumerate(profiles):
-                # user_char: 完整人设（bio + persona），用于LLM系统提示
+                # user_char: full persona (bio + persona) used in the LLM system prompt
                 user_char = profile.bio
                 if profile.persona and profile.persona != profile.bio:
                     user_char = f"{profile.bio} {profile.persona}"
-                # 处理换行符（CSV中用空格替代）
+                # Strip newlines (replace with spaces in CSV)
                 user_char = user_char.replace('\n', ' ').replace('\r', ' ')
-                
-                # description: 简短简介，用于外部显示
+
+                # description: short bio for external display
                 description = profile.bio.replace('\n', ' ').replace('\r', ' ')
-                
+
                 row = [
-                    idx,                    # user_id: 从0开始的顺序ID
-                    profile.name,           # name: 真实姓名
-                    profile.user_name,      # username: 用户名
-                    user_char,              # user_char: 完整人设（内部LLM使用）
-                    description             # description: 简短简介（外部显示）
+                    idx,                    # user_id: zero-based sequential ID
+                    profile.name,           # name: real name
+                    profile.user_name,      # username: username
+                    user_char,              # user_char: full persona (used internally by the LLM)
+                    description             # description: short bio (external display)
                 ]
                 writer.writerow(row)
-        
-        logger.info(f"已保存 {len(profiles)} 个Twitter Profile到 {file_path} (OASIS CSV格式)")
-    
+
+        logger.info(f"Saved {len(profiles)} Twitter profiles to {file_path} (OASIS CSV format)")
+
     def _normalize_gender(self, gender: Optional[str]) -> str:
         """
-        标准化gender字段为OASIS要求的英文格式
-        
-        OASIS要求: male, female, other
+        Normalize the gender field to the English format required by OASIS.
+
+        OASIS requires: male, female, other.
         """
         if not gender:
             return "other"
-        
+
         gender_lower = gender.lower().strip()
-        
-        # 中文映射
+
+        # Localized mappings (covers values that may come in from non-English LLM output)
         gender_map = {
             "男": "male",
             "女": "female",
             "机构": "other",
             "其他": "other",
-            # 英文已有
+            # English values already
             "male": "male",
             "female": "female",
             "other": "other",
         }
-        
+
         return gender_map.get(gender_lower, "other")
-    
+
     def _save_reddit_json(self, profiles: List[OasisAgentProfile], file_path: str):
         """
-        保存Reddit Profile为JSON格式
-        
-        使用与 to_reddit_format() 一致的格式，确保 OASIS 能正确读取。
-        必须包含 user_id 字段，这是 OASIS agent_graph.get_agent() 匹配的关键！
-        
-        必需字段：
-        - user_id: 用户ID（整数，用于匹配 initial_posts 中的 poster_agent_id）
-        - username: 用户名
-        - name: 显示名称
-        - bio: 简介
-        - persona: 详细人设
-        - age: 年龄（整数）
-        - gender: "male", "female", 或 "other"
-        - mbti: MBTI类型
-        - country: 国家
+        Save Reddit profiles in JSON format.
+
+        Uses the same shape as to_reddit_format() to ensure OASIS reads them correctly.
+        The user_id field is mandatory; OASIS agent_graph.get_agent() relies on it for matching.
+
+        Required fields:
+        - user_id: user ID (integer, used to match poster_agent_id in initial_posts)
+        - username: username
+        - name: display name
+        - bio: short bio
+        - persona: detailed persona
+        - age: age (integer)
+        - gender: "male", "female", or "other"
+        - mbti: MBTI type
+        - country: country
         """
         data = []
         for idx, profile in enumerate(profiles):
-            # 使用与 to_reddit_format() 一致的格式
+            # Use the same shape as to_reddit_format()
             item = {
-                "user_id": profile.user_id if profile.user_id is not None else idx,  # 关键：必须包含 user_id
+                "user_id": profile.user_id if profile.user_id is not None else idx,  # Critical: must include user_id
                 "username": profile.user_name,
                 "name": profile.name,
                 "bio": profile.bio[:150] if profile.bio else f"{profile.name}",
                 "persona": profile.persona or f"{profile.name} is a participant in social discussions.",
                 "karma": profile.karma if profile.karma else 1000,
                 "created_at": profile.created_at,
-                # OASIS必需字段 - 确保都有默认值
+                # OASIS required fields - ensure each has a default
                 "age": profile.age if profile.age else 30,
                 "gender": self._normalize_gender(profile.gender),
                 "mbti": profile.mbti if profile.mbti else "ISTJ",
-                "country": profile.country if profile.country else "中国",
+                "country": profile.country if profile.country else "China",
             }
-            
-            # 可选字段
+
+            # Optional fields
             if profile.profession:
                 item["profession"] = profile.profession
             if profile.interested_topics:
                 item["interested_topics"] = profile.interested_topics
-            
+
             data.append(item)
-        
+
         with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
-        
-        logger.info(f"已保存 {len(profiles)} 个Reddit Profile到 {file_path} (JSON格式，包含user_id字段)")
-    
-    # 保留旧方法名作为别名，保持向后兼容
+
+        logger.info(f"Saved {len(profiles)} Reddit profiles to {file_path} (JSON format, including user_id field)")
+
+    # Keep the old method name as an alias for backwards compatibility
     def save_profiles_to_json(
         self,
         profiles: List[OasisAgentProfile],
         file_path: str,
         platform: str = "reddit"
     ):
-        """[已废弃] 请使用 save_profiles() 方法"""
-        logger.warning("save_profiles_to_json已废弃，请使用save_profiles方法")
+        """[Deprecated] Use the save_profiles() method instead"""
+        logger.warning("save_profiles_to_json is deprecated; use save_profiles instead")
         self.save_profiles(profiles, file_path, platform)
-

--- a/backend/app/services/ontology_generator.py
+++ b/backend/app/services/ontology_generator.py
@@ -1,6 +1,7 @@
 """
-本体生成服务
-接口1：分析文本内容，生成适合社会模拟的实体和关系类型定义
+Ontology generation service
+Interface 1: Analyze the text content and produce entity/relationship type
+definitions suitable for social simulation.
 """
 
 import json
@@ -14,174 +15,174 @@ logger = logging.getLogger(__name__)
 
 
 def _to_pascal_case(name: str) -> str:
-    """将任意格式的名称转换为 PascalCase（如 'works_for' -> 'WorksFor', 'person' -> 'Person'）"""
-    # 按非字母数字字符分割
+    """Convert any-format name to PascalCase (e.g. 'works_for' -> 'WorksFor', 'person' -> 'Person')."""
+    # Split by non-alphanumeric characters
     parts = re.split(r'[^a-zA-Z0-9]+', name)
-    # 再按 camelCase 边界分割（如 'camelCase' -> ['camel', 'Case']）
+    # Then split on camelCase boundaries (e.g. 'camelCase' -> ['camel', 'Case'])
     words = []
     for part in parts:
         words.extend(re.sub(r'([a-z])([A-Z])', r'\1_\2', part).split('_'))
-    # 每个词首字母大写，过滤空串
+    # Capitalize each word and drop empty pieces
     result = ''.join(word.capitalize() for word in words if word)
     return result if result else 'Unknown'
 
 
-# 本体生成的系统提示词
-ONTOLOGY_SYSTEM_PROMPT = """你是一个专业的知识图谱本体设计专家。你的任务是分析给定的文本内容和模拟需求，设计适合**社交媒体舆论模拟**的实体类型和关系类型。
+# System prompt for ontology generation
+ONTOLOGY_SYSTEM_PROMPT = """You are a professional knowledge-graph ontology design expert. Your task is to analyze the provided text content and simulation requirements, and design entity types and relationship types suitable for a **social-media public-opinion simulation**.
 
-**重要：你必须输出有效的JSON格式数据，不要输出任何其他内容。**
+**IMPORTANT: You MUST output valid JSON-formatted data and nothing else.**
 
-## 核心任务背景
+## Core Task Background
 
-我们正在构建一个**社交媒体舆论模拟系统**。在这个系统中：
-- 每个实体都是一个可以在社交媒体上发声、互动、传播信息的"账号"或"主体"
-- 实体之间会相互影响、转发、评论、回应
-- 我们需要模拟舆论事件中各方的反应和信息传播路径
+We are building a **social-media public-opinion simulation system**. In this system:
+- Each entity is an "account" or "actor" that can speak, interact, and propagate information on social media
+- Entities influence each other, repost, comment on, and respond to one another
+- We need to simulate how the various sides react in a public-opinion event and how information spreads
 
-因此，**实体必须是现实中真实存在的、可以在社媒上发声和互动的主体**：
+Therefore, **entities must be real-world subjects that can speak and interact on social media**:
 
-**可以是**：
-- 具体的个人（公众人物、当事人、意见领袖、专家学者、普通人）
-- 公司、企业（包括其官方账号）
-- 组织机构（大学、协会、NGO、工会等）
-- 政府部门、监管机构
-- 媒体机构（报纸、电视台、自媒体、网站）
-- 社交媒体平台本身
-- 特定群体代表（如校友会、粉丝团、维权群体等）
+**Allowed**:
+- Specific individuals (public figures, persons involved, opinion leaders, scholars/experts, ordinary people)
+- Companies and businesses (including their official accounts)
+- Organizations and institutions (universities, associations, NGOs, unions, etc.)
+- Government departments and regulators
+- Media outlets (newspapers, TV stations, self-media, websites)
+- The social-media platforms themselves
+- Representatives of specific groups (e.g., alumni associations, fan clubs, advocacy groups)
 
-**不可以是**：
-- 抽象概念（如"舆论"、"情绪"、"趋势"）
-- 主题/话题（如"学术诚信"、"教育改革"）
-- 观点/态度（如"支持方"、"反对方"）
+**Not allowed**:
+- Abstract concepts (e.g., "public opinion", "sentiment", "trends")
+- Topics/subjects (e.g., "academic integrity", "education reform")
+- Stances/attitudes (e.g., "the supporting side", "the opposing side")
 
-## 输出格式
+## Output Format
 
-请输出JSON格式，包含以下结构：
+Output JSON with the following structure:
 
 ```json
 {
     "entity_types": [
         {
-            "name": "实体类型名称（英文，PascalCase）",
-            "description": "简短描述（英文，不超过100字符）",
+            "name": "Entity type name (English, PascalCase)",
+            "description": "Short description (English, no more than 100 characters)",
             "attributes": [
                 {
-                    "name": "属性名（英文，snake_case）",
+                    "name": "Attribute name (English, snake_case)",
                     "type": "text",
-                    "description": "属性描述"
+                    "description": "Attribute description"
                 }
             ],
-            "examples": ["示例实体1", "示例实体2"]
+            "examples": ["example entity 1", "example entity 2"]
         }
     ],
     "edge_types": [
         {
-            "name": "关系类型名称（英文，UPPER_SNAKE_CASE）",
-            "description": "简短描述（英文，不超过100字符）",
+            "name": "Relationship type name (English, UPPER_SNAKE_CASE)",
+            "description": "Short description (English, no more than 100 characters)",
             "source_targets": [
-                {"source": "源实体类型", "target": "目标实体类型"}
+                {"source": "source entity type", "target": "target entity type"}
             ],
             "attributes": []
         }
     ],
-    "analysis_summary": "对文本内容的简要分析说明"
+    "analysis_summary": "A brief analytical summary of the text content"
 }
 ```
 
-## 设计指南（极其重要！）
+## Design Guide (Extremely Important!)
 
-### 1. 实体类型设计 - 必须严格遵守
+### 1. Entity-Type Design — must be strictly followed
 
-**数量要求：必须正好10个实体类型**
+**Quantity requirement: exactly 10 entity types**
 
-**层次结构要求（必须同时包含具体类型和兜底类型）**：
+**Hierarchy requirement (must include both specific types and fallback types)**:
 
-你的10个实体类型必须包含以下层次：
+Your 10 entity types must cover the following hierarchy:
 
-A. **兜底类型（必须包含，放在列表最后2个）**：
-   - `Person`: 任何自然人个体的兜底类型。当一个人不属于其他更具体的人物类型时，归入此类。
-   - `Organization`: 任何组织机构的兜底类型。当一个组织不属于其他更具体的组织类型时，归入此类。
+A. **Fallback types (must include; place at the end of the list, last 2)**:
+   - `Person`: fallback type for any natural person. When a person does not fit any more specific person type, classify as Person.
+   - `Organization`: fallback type for any organization/institution. When an organization does not fit any more specific organization type, classify as Organization.
 
-B. **具体类型（8个，根据文本内容设计）**：
-   - 针对文本中出现的主要角色，设计更具体的类型
-   - 例如：如果文本涉及学术事件，可以有 `Student`, `Professor`, `University`
-   - 例如：如果文本涉及商业事件，可以有 `Company`, `CEO`, `Employee`
+B. **Specific types (8 of them, designed based on the text content)**:
+   - For the main roles that appear in the text, design more specific types
+   - Example: if the text concerns an academic event, you may have `Student`, `Professor`, `University`
+   - Example: if the text concerns a business event, you may have `Company`, `CEO`, `Employee`
 
-**为什么需要兜底类型**：
-- 文本中会出现各种人物，如"中小学教师"、"路人甲"、"某位网友"
-- 如果没有专门的类型匹配，他们应该被归入 `Person`
-- 同理，小型组织、临时团体等应该归入 `Organization`
+**Why fallback types are needed**:
+- The text may mention various people such as "K-12 teachers", "a passerby", "some netizen"
+- If no dedicated type matches, they should be classified as `Person`
+- Likewise, small organizations and ad-hoc groups should be classified as `Organization`
 
-**具体类型的设计原则**：
-- 从文本中识别出高频出现或关键的角色类型
-- 每个具体类型应该有明确的边界，避免重叠
-- description 必须清晰说明这个类型和兜底类型的区别
+**Design principles for specific types**:
+- Identify the high-frequency or key role types from the text
+- Each specific type should have clear boundaries — avoid overlap
+- The description must clearly state the difference between this type and the fallback type
 
-### 2. 关系类型设计
+### 2. Relationship-Type Design
 
-- 数量：6-10个
-- 关系应该反映社媒互动中的真实联系
-- 确保关系的 source_targets 涵盖你定义的实体类型
+- Quantity: 6-10
+- Relationships should reflect actual connections in social-media interactions
+- Make sure the source_targets of each relationship cover the entity types you defined
 
-### 3. 属性设计
+### 3. Attribute Design
 
-- 每个实体类型1-3个关键属性
-- **注意**：属性名不能使用 `name`、`uuid`、`group_id`、`created_at`、`summary`（这些是系统保留字）
-- 推荐使用：`full_name`, `title`, `role`, `position`, `location`, `description` 等
+- 1-3 key attributes per entity type
+- **Note**: attribute names cannot use `name`, `uuid`, `group_id`, `created_at`, `summary` (these are system reserved words)
+- Recommended: `full_name`, `title`, `role`, `position`, `location`, `description`, etc.
 
-## 实体类型参考
+## Entity Type References
 
-**个人类（具体）**：
-- Student: 学生
-- Professor: 教授/学者
-- Journalist: 记者
-- Celebrity: 明星/网红
-- Executive: 高管
-- Official: 政府官员
-- Lawyer: 律师
-- Doctor: 医生
+**Person types (specific)**:
+- Student: a student
+- Professor: a professor / academic
+- Journalist: a journalist
+- Celebrity: a celebrity / influencer
+- Executive: an executive
+- Official: a government official
+- Lawyer: a lawyer
+- Doctor: a doctor
 
-**个人类（兜底）**：
-- Person: 任何自然人（不属于上述具体类型时使用）
+**Person types (fallback)**:
+- Person: any natural person (use when none of the specific person types fit)
 
-**组织类（具体）**：
-- University: 高校
-- Company: 公司企业
-- GovernmentAgency: 政府机构
-- MediaOutlet: 媒体机构
-- Hospital: 医院
-- School: 中小学
-- NGO: 非政府组织
+**Organization types (specific)**:
+- University: a university / college
+- Company: a company / business
+- GovernmentAgency: a government agency
+- MediaOutlet: a media outlet
+- Hospital: a hospital
+- School: a primary or secondary school
+- NGO: a non-governmental organization
 
-**组织类（兜底）**：
-- Organization: 任何组织机构（不属于上述具体类型时使用）
+**Organization types (fallback)**:
+- Organization: any organization (use when none of the specific organization types fit)
 
-## 关系类型参考
+## Relationship Type References
 
-- WORKS_FOR: 工作于
-- STUDIES_AT: 就读于
-- AFFILIATED_WITH: 隶属于
-- REPRESENTS: 代表
-- REGULATES: 监管
-- REPORTS_ON: 报道
-- COMMENTS_ON: 评论
-- RESPONDS_TO: 回应
-- SUPPORTS: 支持
-- OPPOSES: 反对
-- COLLABORATES_WITH: 合作
-- COMPETES_WITH: 竞争
+- WORKS_FOR: works for
+- STUDIES_AT: studies at
+- AFFILIATED_WITH: affiliated with
+- REPRESENTS: represents
+- REGULATES: regulates
+- REPORTS_ON: reports on
+- COMMENTS_ON: comments on
+- RESPONDS_TO: responds to
+- SUPPORTS: supports
+- OPPOSES: opposes
+- COLLABORATES_WITH: collaborates with
+- COMPETES_WITH: competes with
 """
 
 
 class OntologyGenerator:
     """
-    本体生成器
-    分析文本内容，生成实体和关系类型定义
+    Ontology generator
+    Analyzes text content and produces entity- and relationship-type definitions.
     """
-    
+
     def __init__(self, llm_client: Optional[LLMClient] = None):
         self.llm_client = llm_client or LLMClient()
-    
+
     def generate(
         self,
         document_texts: List[str],
@@ -189,107 +190,108 @@ class OntologyGenerator:
         additional_context: Optional[str] = None
     ) -> Dict[str, Any]:
         """
-        生成本体定义
-        
+        Generate ontology definitions
+
         Args:
-            document_texts: 文档文本列表
-            simulation_requirement: 模拟需求描述
-            additional_context: 额外上下文
-            
+            document_texts: List of document texts
+            simulation_requirement: Simulation requirement description
+            additional_context: Extra context
+
         Returns:
-            本体定义（entity_types, edge_types等）
+            Ontology definition (entity_types, edge_types, etc.)
         """
-        # 构建用户消息
+        # Build the user message
         user_message = self._build_user_message(
-            document_texts, 
+            document_texts,
             simulation_requirement,
             additional_context
         )
-        
+
         lang_instruction = get_language_instruction()
-        system_prompt = f"{ONTOLOGY_SYSTEM_PROMPT}\n\n{lang_instruction}\nIMPORTANT: Entity type names MUST be in English PascalCase (e.g., 'PersonEntity', 'MediaOrganization'). Relationship type names MUST be in English UPPER_SNAKE_CASE (e.g., 'WORKS_FOR'). Attribute names MUST be in English snake_case. Only description fields and analysis_summary should use the specified language above."
+        system_prompt = f"{ONTOLOGY_SYSTEM_PROMPT}\n\n{lang_instruction}\nIMPORTANT: Entity names MUST be in English. Entity type names MUST be in English PascalCase (e.g., 'PersonEntity', 'MediaOrganization'). Relationship type names MUST be in English UPPER_SNAKE_CASE (e.g., 'WORKS_FOR'). Attribute names MUST be in English snake_case. All entity node names extracted from the text MUST also be in English (translate any non-English names into English). Only description fields and analysis_summary should use the specified language above."
         messages = [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message}
         ]
-        
-        # 调用LLM
+
+        # Call the LLM
         result = self.llm_client.chat_json(
             messages=messages,
             temperature=0.3,
             max_tokens=4096
         )
-        
-        # 验证和后处理
+
+        # Validate and post-process
         result = self._validate_and_process(result)
-        
+
         return result
-    
-    # 传给 LLM 的文本最大长度（5万字）
+
+    # Maximum length of text passed to the LLM (50,000 characters)
     MAX_TEXT_LENGTH_FOR_LLM = 50000
-    
+
     def _build_user_message(
         self,
         document_texts: List[str],
         simulation_requirement: str,
         additional_context: Optional[str]
     ) -> str:
-        """构建用户消息"""
-        
-        # 合并文本
+        """Build the user message"""
+
+        # Concatenate the text
         combined_text = "\n\n---\n\n".join(document_texts)
         original_length = len(combined_text)
-        
-        # 如果文本超过5万字，截断（仅影响传给LLM的内容，不影响图谱构建）
+
+        # If the text exceeds 50,000 characters, truncate it
+        # (only affects what is passed to the LLM, not graph construction)
         if len(combined_text) > self.MAX_TEXT_LENGTH_FOR_LLM:
             combined_text = combined_text[:self.MAX_TEXT_LENGTH_FOR_LLM]
-            combined_text += f"\n\n...(原文共{original_length}字，已截取前{self.MAX_TEXT_LENGTH_FOR_LLM}字用于本体分析)..."
-        
-        message = f"""## 模拟需求
+            combined_text += f"\n\n...(original text is {original_length} characters; first {self.MAX_TEXT_LENGTH_FOR_LLM} characters used for ontology analysis)..."
+
+        message = f"""## Simulation Requirement
 
 {simulation_requirement}
 
-## 文档内容
+## Document Content
 
 {combined_text}
 """
-        
+
         if additional_context:
             message += f"""
-## 额外说明
+## Additional Notes
 
 {additional_context}
 """
-        
-        message += """
-请根据以上内容，设计适合社会舆论模拟的实体类型和关系类型。
 
-**必须遵守的规则**：
-1. 必须正好输出10个实体类型
-2. 最后2个必须是兜底类型：Person（个人兜底）和 Organization（组织兜底）
-3. 前8个是根据文本内容设计的具体类型
-4. 所有实体类型必须是现实中可以发声的主体，不能是抽象概念
-5. 属性名不能使用 name、uuid、group_id 等保留字，用 full_name、org_name 等替代
+        message += """
+Based on the content above, design entity types and relationship types suitable for a public-opinion simulation.
+
+**Mandatory rules**:
+1. Output exactly 10 entity types
+2. The last 2 must be fallback types: Person (fallback for individuals) and Organization (fallback for organizations)
+3. The first 8 are specific types designed for the text content
+4. All entity types must be real-world subjects that can speak; they cannot be abstract concepts
+5. Attribute names cannot use reserved words such as name, uuid, group_id; use full_name, org_name, etc. instead
 """
-        
+
         return message
-    
+
     def _validate_and_process(self, result: Dict[str, Any]) -> Dict[str, Any]:
-        """验证和后处理结果"""
-        
-        # 确保必要字段存在
+        """Validate and post-process the result"""
+
+        # Make sure required fields exist
         if "entity_types" not in result:
             result["entity_types"] = []
         if "edge_types" not in result:
             result["edge_types"] = []
         if "analysis_summary" not in result:
             result["analysis_summary"] = ""
-        
-        # 验证实体类型
-        # 记录原始名称到 PascalCase 的映射，用于后续修正 edge 的 source_targets 引用
+
+        # Validate entity types
+        # Track original-name to PascalCase mapping so we can fix up edge source_targets later
         entity_name_map = {}
         for entity in result["entity_types"]:
-            # 强制将 entity name 转为 PascalCase（Zep API 要求）
+            # Force entity name to PascalCase (Zep API requirement)
             if "name" in entity:
                 original_name = entity["name"]
                 entity["name"] = _to_pascal_case(original_name)
@@ -300,19 +302,19 @@ class OntologyGenerator:
                 entity["attributes"] = []
             if "examples" not in entity:
                 entity["examples"] = []
-            # 确保description不超过100字符
+            # Make sure description is no longer than 100 characters
             if len(entity.get("description", "")) > 100:
                 entity["description"] = entity["description"][:97] + "..."
-        
-        # 验证关系类型
+
+        # Validate relationship types
         for edge in result["edge_types"]:
-            # 强制将 edge name 转为 SCREAMING_SNAKE_CASE（Zep API 要求）
+            # Force edge name to SCREAMING_SNAKE_CASE (Zep API requirement)
             if "name" in edge:
                 original_name = edge["name"]
                 edge["name"] = original_name.upper()
                 if edge["name"] != original_name:
                     logger.warning(f"Edge type name '{original_name}' auto-converted to '{edge['name']}'")
-            # 修正 source_targets 中的实体名称引用，与转换后的 PascalCase 保持一致
+            # Fix up entity-name references inside source_targets to match the converted PascalCase
             for st in edge.get("source_targets", []):
                 if st.get("source") in entity_name_map:
                     st["source"] = entity_name_map[st["source"]]
@@ -324,12 +326,12 @@ class OntologyGenerator:
                 edge["attributes"] = []
             if len(edge.get("description", "")) > 100:
                 edge["description"] = edge["description"][:97] + "..."
-        
-        # Zep API 限制：最多 10 个自定义实体类型，最多 10 个自定义边类型
+
+        # Zep API limits: at most 10 custom entity types and at most 10 custom edge types
         MAX_ENTITY_TYPES = 10
         MAX_EDGE_TYPES = 10
 
-        # 去重：按 name 去重，保留首次出现的
+        # Deduplicate by name; keep the first occurrence
         seen_names = set()
         deduped = []
         for entity in result["entity_types"]:
@@ -341,7 +343,7 @@ class OntologyGenerator:
                 logger.warning(f"Duplicate entity type '{name}' removed during validation")
         result["entity_types"] = deduped
 
-        # 兜底类型定义
+        # Fallback type definitions
         person_fallback = {
             "name": "Person",
             "description": "Any individual person not fitting other specific person types.",
@@ -351,7 +353,7 @@ class OntologyGenerator:
             ],
             "examples": ["ordinary citizen", "anonymous netizen"]
         }
-        
+
         organization_fallback = {
             "name": "Organization",
             "description": "Any organization not fitting other specific organization types.",
@@ -361,74 +363,74 @@ class OntologyGenerator:
             ],
             "examples": ["small business", "community group"]
         }
-        
-        # 检查是否已有兜底类型
+
+        # Check whether the fallback types are already present
         entity_names = {e["name"] for e in result["entity_types"]}
         has_person = "Person" in entity_names
         has_organization = "Organization" in entity_names
-        
-        # 需要添加的兜底类型
+
+        # Fallback types that need to be added
         fallbacks_to_add = []
         if not has_person:
             fallbacks_to_add.append(person_fallback)
         if not has_organization:
             fallbacks_to_add.append(organization_fallback)
-        
+
         if fallbacks_to_add:
             current_count = len(result["entity_types"])
             needed_slots = len(fallbacks_to_add)
-            
-            # 如果添加后会超过 10 个，需要移除一些现有类型
+
+            # If adding the fallbacks would exceed 10, remove some existing types
             if current_count + needed_slots > MAX_ENTITY_TYPES:
-                # 计算需要移除多少个
+                # Calculate how many to remove
                 to_remove = current_count + needed_slots - MAX_ENTITY_TYPES
-                # 从末尾移除（保留前面更重要的具体类型）
+                # Remove from the end (keeping the more important specific types at the front)
                 result["entity_types"] = result["entity_types"][:-to_remove]
-            
-            # 添加兜底类型
+
+            # Append the fallback types
             result["entity_types"].extend(fallbacks_to_add)
-        
-        # 最终确保不超过限制（防御性编程）
+
+        # Final guarantee that we don't exceed the limits (defensive programming)
         if len(result["entity_types"]) > MAX_ENTITY_TYPES:
             result["entity_types"] = result["entity_types"][:MAX_ENTITY_TYPES]
-        
+
         if len(result["edge_types"]) > MAX_EDGE_TYPES:
             result["edge_types"] = result["edge_types"][:MAX_EDGE_TYPES]
-        
+
         return result
-    
+
     def generate_python_code(self, ontology: Dict[str, Any]) -> str:
         """
-        将本体定义转换为Python代码（类似ontology.py）
-        
+        Convert the ontology definition into Python code (similar to ontology.py)
+
         Args:
-            ontology: 本体定义
-            
+            ontology: Ontology definition
+
         Returns:
-            Python代码字符串
+            Python source-code string
         """
         code_lines = [
             '"""',
-            '自定义实体类型定义',
-            '由MiroFish自动生成，用于社会舆论模拟',
+            'Custom entity-type definitions',
+            'Auto-generated by MiroFish, used for public-opinion simulation',
             '"""',
             '',
             'from pydantic import Field',
             'from zep_cloud.external_clients.ontology import EntityModel, EntityText, EdgeModel',
             '',
             '',
-            '# ============== 实体类型定义 ==============',
+            '# ============== Entity type definitions ==============',
             '',
         ]
-        
-        # 生成实体类型
+
+        # Generate entity types
         for entity in ontology.get("entity_types", []):
             name = entity["name"]
             desc = entity.get("description", f"A {name} entity.")
-            
+
             code_lines.append(f'class {name}(EntityModel):')
             code_lines.append(f'    """{desc}"""')
-            
+
             attrs = entity.get("attributes", [])
             if attrs:
                 for attr in attrs:
@@ -440,23 +442,23 @@ class OntologyGenerator:
                     code_lines.append(f'    )')
             else:
                 code_lines.append('    pass')
-            
+
             code_lines.append('')
             code_lines.append('')
-        
-        code_lines.append('# ============== 关系类型定义 ==============')
+
+        code_lines.append('# ============== Relationship type definitions ==============')
         code_lines.append('')
-        
-        # 生成关系类型
+
+        # Generate relationship types
         for edge in ontology.get("edge_types", []):
             name = edge["name"]
-            # 转换为PascalCase类名
+            # Convert to PascalCase class name
             class_name = ''.join(word.capitalize() for word in name.split('_'))
             desc = edge.get("description", f"A {name} relationship.")
-            
+
             code_lines.append(f'class {class_name}(EdgeModel):')
             code_lines.append(f'    """{desc}"""')
-            
+
             attrs = edge.get("attributes", [])
             if attrs:
                 for attr in attrs:
@@ -468,12 +470,12 @@ class OntologyGenerator:
                     code_lines.append(f'    )')
             else:
                 code_lines.append('    pass')
-            
+
             code_lines.append('')
             code_lines.append('')
-        
-        # 生成类型字典
-        code_lines.append('# ============== 类型配置 ==============')
+
+        # Generate type-config dictionaries
+        code_lines.append('# ============== Type configuration ==============')
         code_lines.append('')
         code_lines.append('ENTITY_TYPES = {')
         for entity in ontology.get("entity_types", []):
@@ -488,8 +490,8 @@ class OntologyGenerator:
             code_lines.append(f'    "{name}": {class_name},')
         code_lines.append('}')
         code_lines.append('')
-        
-        # 生成边的source_targets映射
+
+        # Generate edge source_targets map
         code_lines.append('EDGE_SOURCE_TARGETS = {')
         for edge in ontology.get("edge_types", []):
             name = edge["name"]
@@ -501,6 +503,6 @@ class OntologyGenerator:
                 ])
                 code_lines.append(f'    "{name}": [{st_list}],')
         code_lines.append('}')
-        
+
         return '\n'.join(code_lines)
 

--- a/backend/app/services/report_agent.py
+++ b/backend/app/services/report_agent.py
@@ -1,12 +1,12 @@
 """
-Report Agent服务
-使用LangChain + Zep实现ReACT模式的模拟报告生成
+Report Agent service
+Implements ReACT-pattern simulation report generation using LangChain + Zep
 
-功能：
-1. 根据模拟需求和Zep图谱信息生成报告
-2. 先规划目录结构，然后分段生成
-3. 每段采用ReACT多轮思考与反思模式
-4. 支持与用户对话，在对话中自主调用检索工具
+Features:
+1. Generates reports from simulation requirements and Zep graph information
+2. First plans the table of contents, then generates section by section
+3. Each section uses the ReACT multi-round reasoning and reflection pattern
+4. Supports conversation with the user, autonomously invoking retrieval tools during chat
 """
 
 import os
@@ -23,9 +23,9 @@ from ..utils.llm_client import LLMClient
 from ..utils.logger import get_logger
 from ..utils.locale import get_language_instruction, t
 from .zep_tools import (
-    ZepToolsService, 
-    SearchResult, 
-    InsightForgeResult, 
+    ZepToolsService,
+    SearchResult,
+    InsightForgeResult,
     PanoramaResult,
     InterviewResult
 )
@@ -35,18 +35,18 @@ logger = get_logger('mirofish.report_agent')
 
 class ReportLogger:
     """
-    Report Agent 详细日志记录器
-    
-    在报告文件夹中生成 agent_log.jsonl 文件，记录每一步详细动作。
-    每行是一个完整的 JSON 对象，包含时间戳、动作类型、详细内容等。
+    Report Agent detailed logger
+
+    Generates an agent_log.jsonl file in the report folder, recording every detailed action.
+    Each line is a complete JSON object containing a timestamp, action type, detailed content, etc.
     """
-    
+
     def __init__(self, report_id: str):
         """
-        初始化日志记录器
-        
+        Initialize the logger
+
         Args:
-            report_id: 报告ID，用于确定日志文件路径
+            report_id: Report ID, used to determine the log file path
         """
         self.report_id = report_id
         self.log_file_path = os.path.join(
@@ -54,33 +54,33 @@ class ReportLogger:
         )
         self.start_time = datetime.now()
         self._ensure_log_file()
-    
+
     def _ensure_log_file(self):
-        """确保日志文件所在目录存在"""
+        """Make sure the directory containing the log file exists"""
         log_dir = os.path.dirname(self.log_file_path)
         os.makedirs(log_dir, exist_ok=True)
-    
+
     def _get_elapsed_time(self) -> float:
-        """获取从开始到现在的耗时（秒）"""
+        """Return elapsed time from start to now (in seconds)"""
         return (datetime.now() - self.start_time).total_seconds()
-    
+
     def log(
-        self, 
-        action: str, 
+        self,
+        action: str,
         stage: str,
         details: Dict[str, Any],
         section_title: str = None,
         section_index: int = None
     ):
         """
-        记录一条日志
-        
+        Write a log entry
+
         Args:
-            action: 动作类型，如 'start', 'tool_call', 'llm_response', 'section_complete' 等
-            stage: 当前阶段，如 'planning', 'generating', 'completed'
-            details: 详细内容字典，不截断
-            section_title: 当前章节标题（可选）
-            section_index: 当前章节索引（可选）
+            action: Action type, e.g. 'start', 'tool_call', 'llm_response', 'section_complete', etc.
+            stage: Current stage, e.g. 'planning', 'generating', 'completed'
+            details: Detail dictionary, not truncated
+            section_title: Current section title (optional)
+            section_index: Current section index (optional)
         """
         log_entry = {
             "timestamp": datetime.now().isoformat(),
@@ -92,13 +92,13 @@ class ReportLogger:
             "section_index": section_index,
             "details": details
         }
-        
-        # 追加写入 JSONL 文件
+
+        # Append to the JSONL file
         with open(self.log_file_path, 'a', encoding='utf-8') as f:
             f.write(json.dumps(log_entry, ensure_ascii=False) + '\n')
-    
+
     def log_start(self, simulation_id: str, graph_id: str, simulation_requirement: str):
-        """记录报告生成开始"""
+        """Record the start of report generation"""
         self.log(
             action="report_start",
             stage="pending",
@@ -109,17 +109,17 @@ class ReportLogger:
                 "message": t('report.taskStarted')
             }
         )
-    
+
     def log_planning_start(self):
-        """记录大纲规划开始"""
+        """Record the start of outline planning"""
         self.log(
             action="planning_start",
             stage="planning",
             details={"message": t('report.planningStart')}
         )
-    
+
     def log_planning_context(self, context: Dict[str, Any]):
-        """记录规划时获取的上下文信息"""
+        """Record the context information fetched during planning"""
         self.log(
             action="planning_context",
             stage="planning",
@@ -128,9 +128,9 @@ class ReportLogger:
                 "context": context
             }
         )
-    
+
     def log_planning_complete(self, outline_dict: Dict[str, Any]):
-        """记录大纲规划完成"""
+        """Record completion of outline planning"""
         self.log(
             action="planning_complete",
             stage="planning",
@@ -139,9 +139,9 @@ class ReportLogger:
                 "outline": outline_dict
             }
         )
-    
+
     def log_section_start(self, section_title: str, section_index: int):
-        """记录章节生成开始"""
+        """Record the start of section generation"""
         self.log(
             action="section_start",
             stage="generating",
@@ -149,9 +149,9 @@ class ReportLogger:
             section_index=section_index,
             details={"message": t('report.sectionStart', title=section_title)}
         )
-    
+
     def log_react_thought(self, section_title: str, section_index: int, iteration: int, thought: str):
-        """记录 ReACT 思考过程"""
+        """Record a ReACT reasoning step"""
         self.log(
             action="react_thought",
             stage="generating",
@@ -163,16 +163,16 @@ class ReportLogger:
                 "message": t('report.reactThought', iteration=iteration)
             }
         )
-    
+
     def log_tool_call(
-        self, 
-        section_title: str, 
+        self,
+        section_title: str,
         section_index: int,
-        tool_name: str, 
+        tool_name: str,
         parameters: Dict[str, Any],
         iteration: int
     ):
-        """记录工具调用"""
+        """Record a tool invocation"""
         self.log(
             action="tool_call",
             stage="generating",
@@ -185,7 +185,7 @@ class ReportLogger:
                 "message": t('report.toolCall', toolName=tool_name)
             }
         )
-    
+
     def log_tool_result(
         self,
         section_title: str,
@@ -194,7 +194,7 @@ class ReportLogger:
         result: str,
         iteration: int
     ):
-        """记录工具调用结果（完整内容，不截断）"""
+        """Record the result of a tool invocation (full content, not truncated)"""
         self.log(
             action="tool_result",
             stage="generating",
@@ -203,12 +203,12 @@ class ReportLogger:
             details={
                 "iteration": iteration,
                 "tool_name": tool_name,
-                "result": result,  # 完整结果，不截断
+                "result": result,  # Full result, not truncated
                 "result_length": len(result),
                 "message": t('report.toolResult', toolName=tool_name)
             }
         )
-    
+
     def log_llm_response(
         self,
         section_title: str,
@@ -218,7 +218,7 @@ class ReportLogger:
         has_tool_calls: bool,
         has_final_answer: bool
     ):
-        """记录 LLM 响应（完整内容，不截断）"""
+        """Record an LLM response (full content, not truncated)"""
         self.log(
             action="llm_response",
             stage="generating",
@@ -226,14 +226,14 @@ class ReportLogger:
             section_index=section_index,
             details={
                 "iteration": iteration,
-                "response": response,  # 完整响应，不截断
+                "response": response,  # Full response, not truncated
                 "response_length": len(response),
                 "has_tool_calls": has_tool_calls,
                 "has_final_answer": has_final_answer,
                 "message": t('report.llmResponse', hasToolCalls=has_tool_calls, hasFinalAnswer=has_final_answer)
             }
         )
-    
+
     def log_section_content(
         self,
         section_title: str,
@@ -241,20 +241,20 @@ class ReportLogger:
         content: str,
         tool_calls_count: int
     ):
-        """记录章节内容生成完成（仅记录内容，不代表整个章节完成）"""
+        """Record completion of section content generation (only the content; does not mean the entire section is finished)"""
         self.log(
             action="section_content",
             stage="generating",
             section_title=section_title,
             section_index=section_index,
             details={
-                "content": content,  # 完整内容，不截断
+                "content": content,  # Full content, not truncated
                 "content_length": len(content),
                 "tool_calls_count": tool_calls_count,
                 "message": t('report.sectionContentDone', title=section_title)
             }
         )
-    
+
     def log_section_full_complete(
         self,
         section_title: str,
@@ -262,9 +262,9 @@ class ReportLogger:
         full_content: str
     ):
         """
-        记录章节生成完成
+        Record completion of section generation
 
-        前端应监听此日志来判断一个章节是否真正完成，并获取完整内容
+        The frontend should listen for this log entry to determine whether a section is truly finished and to obtain the full content.
         """
         self.log(
             action="section_complete",
@@ -277,9 +277,9 @@ class ReportLogger:
                 "message": t('report.sectionComplete', title=section_title)
             }
         )
-    
+
     def log_report_complete(self, total_sections: int, total_time_seconds: float):
-        """记录报告生成完成"""
+        """Record completion of the report"""
         self.log(
             action="report_complete",
             stage="completed",
@@ -289,9 +289,9 @@ class ReportLogger:
                 "message": t('report.reportComplete')
             }
         )
-    
+
     def log_error(self, error_message: str, stage: str, section_title: str = None):
-        """记录错误"""
+        """Record an error"""
         self.log(
             action="error",
             stage=stage,
@@ -306,18 +306,18 @@ class ReportLogger:
 
 class ReportConsoleLogger:
     """
-    Report Agent 控制台日志记录器
-    
-    将控制台风格的日志（INFO、WARNING等）写入报告文件夹中的 console_log.txt 文件。
-    这些日志与 agent_log.jsonl 不同，是纯文本格式的控制台输出。
+    Report Agent console logger
+
+    Writes console-style logs (INFO, WARNING, etc.) to a console_log.txt file in the report folder.
+    These logs differ from agent_log.jsonl: they are plain-text console output.
     """
-    
+
     def __init__(self, report_id: str):
         """
-        初始化控制台日志记录器
-        
+        Initialize the console logger
+
         Args:
-            report_id: 报告ID，用于确定日志文件路径
+            report_id: Report ID, used to determine the log file path
         """
         self.report_id = report_id
         self.log_file_path = os.path.join(
@@ -326,68 +326,68 @@ class ReportConsoleLogger:
         self._ensure_log_file()
         self._file_handler = None
         self._setup_file_handler()
-    
+
     def _ensure_log_file(self):
-        """确保日志文件所在目录存在"""
+        """Make sure the directory containing the log file exists"""
         log_dir = os.path.dirname(self.log_file_path)
         os.makedirs(log_dir, exist_ok=True)
-    
+
     def _setup_file_handler(self):
-        """设置文件处理器，将日志同时写入文件"""
+        """Set up a file handler so logs are also written to the file"""
         import logging
-        
-        # 创建文件处理器
+
+        # Create the file handler
         self._file_handler = logging.FileHandler(
             self.log_file_path,
             mode='a',
             encoding='utf-8'
         )
         self._file_handler.setLevel(logging.INFO)
-        
-        # 使用与控制台相同的简洁格式
+
+        # Use the same concise format as the console
         formatter = logging.Formatter(
             '[%(asctime)s] %(levelname)s: %(message)s',
             datefmt='%H:%M:%S'
         )
         self._file_handler.setFormatter(formatter)
-        
-        # 添加到 report_agent 相关的 logger
+
+        # Attach to the loggers related to report_agent
         loggers_to_attach = [
             'mirofish.report_agent',
             'mirofish.zep_tools',
         ]
-        
+
         for logger_name in loggers_to_attach:
             target_logger = logging.getLogger(logger_name)
-            # 避免重复添加
+            # Avoid adding the handler twice
             if self._file_handler not in target_logger.handlers:
                 target_logger.addHandler(self._file_handler)
-    
+
     def close(self):
-        """关闭文件处理器并从 logger 中移除"""
+        """Close the file handler and detach it from the loggers"""
         import logging
-        
+
         if self._file_handler:
             loggers_to_detach = [
                 'mirofish.report_agent',
                 'mirofish.zep_tools',
             ]
-            
+
             for logger_name in loggers_to_detach:
                 target_logger = logging.getLogger(logger_name)
                 if self._file_handler in target_logger.handlers:
                     target_logger.removeHandler(self._file_handler)
-            
+
             self._file_handler.close()
             self._file_handler = None
-    
+
     def __del__(self):
-        """析构时确保关闭文件处理器"""
+        """Make sure the file handler is closed on destruction"""
         self.close()
 
 
 class ReportStatus(str, Enum):
-    """报告状态"""
+    """Report status"""
     PENDING = "pending"
     PLANNING = "planning"
     GENERATING = "generating"
@@ -397,7 +397,7 @@ class ReportStatus(str, Enum):
 
 @dataclass
 class ReportSection:
-    """报告章节"""
+    """Report section"""
     title: str
     content: str = ""
 
@@ -408,7 +408,7 @@ class ReportSection:
         }
 
     def to_markdown(self, level: int = 2) -> str:
-        """转换为Markdown格式"""
+        """Convert to Markdown format"""
         md = f"{'#' * level} {self.title}\n\n"
         if self.content:
             md += f"{self.content}\n\n"
@@ -417,20 +417,20 @@ class ReportSection:
 
 @dataclass
 class ReportOutline:
-    """报告大纲"""
+    """Report outline"""
     title: str
     summary: str
     sections: List[ReportSection]
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "title": self.title,
             "summary": self.summary,
             "sections": [s.to_dict() for s in self.sections]
         }
-    
+
     def to_markdown(self) -> str:
-        """转换为Markdown格式"""
+        """Convert to Markdown format"""
         md = f"# {self.title}\n\n"
         md += f"> {self.summary}\n\n"
         for section in self.sections:
@@ -440,7 +440,7 @@ class ReportOutline:
 
 @dataclass
 class Report:
-    """完整报告"""
+    """Complete report"""
     report_id: str
     simulation_id: str
     graph_id: str
@@ -451,7 +451,7 @@ class Report:
     created_at: str = ""
     completed_at: str = ""
     error: Optional[str] = None
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "report_id": self.report_id,
@@ -468,421 +468,421 @@ class Report:
 
 
 # ═══════════════════════════════════════════════════════════════
-# Prompt 模板常量
+# Prompt template constants
 # ═══════════════════════════════════════════════════════════════
 
-# ── 工具描述 ──
+# -- Tool descriptions --
 
 TOOL_DESC_INSIGHT_FORGE = """\
-【深度洞察检索 - 强大的检索工具】
-这是我们强大的检索函数，专为深度分析设计。它会：
-1. 自动将你的问题分解为多个子问题
-2. 从多个维度检索模拟图谱中的信息
-3. 整合语义搜索、实体分析、关系链追踪的结果
-4. 返回最全面、最深度的检索内容
+[Deep Insight Retrieval - Powerful retrieval tool]
+This is our powerful retrieval function, designed for deep analysis. It will:
+1. Automatically decompose your question into multiple sub-questions
+2. Retrieve information from the simulation graph along multiple dimensions
+3. Combine the results of semantic search, entity analysis, and relationship-chain tracing
+4. Return the most comprehensive and deepest retrieval content
 
-【使用场景】
-- 需要深入分析某个话题
-- 需要了解事件的多个方面
-- 需要获取支撑报告章节的丰富素材
+[When to use]
+- When you need to deeply analyze a topic
+- When you need to understand multiple aspects of an event
+- When you need to obtain rich material to support a report section
 
-【返回内容】
-- 相关事实原文（可直接引用）
-- 核心实体洞察
-- 关系链分析"""
+[Returned content]
+- Original text of relevant facts (can be quoted directly)
+- Key entity insights
+- Relationship-chain analysis"""
 
 TOOL_DESC_PANORAMA_SEARCH = """\
-【广度搜索 - 获取全貌视图】
-这个工具用于获取模拟结果的完整全貌，特别适合了解事件演变过程。它会：
-1. 获取所有相关节点和关系
-2. 区分当前有效的事实和历史/过期的事实
-3. 帮助你了解舆情是如何演变的
+[Panorama Search - Get the full-picture view]
+This tool obtains the complete panorama of the simulation results, especially suited for understanding how an event evolves. It will:
+1. Fetch all relevant nodes and relationships
+2. Distinguish currently valid facts from historical/expired facts
+3. Help you understand how public opinion has evolved
 
-【使用场景】
-- 需要了解事件的完整发展脉络
-- 需要对比不同阶段的舆情变化
-- 需要获取全面的实体和关系信息
+[When to use]
+- When you need to understand the full development of an event
+- When you need to compare changes in public opinion across different stages
+- When you need comprehensive entity and relationship information
 
-【返回内容】
-- 当前有效事实（模拟最新结果）
-- 历史/过期事实（演变记录）
-- 所有涉及的实体"""
+[Returned content]
+- Currently valid facts (the latest simulation results)
+- Historical/expired facts (evolution record)
+- All entities involved"""
 
 TOOL_DESC_QUICK_SEARCH = """\
-【简单搜索 - 快速检索】
-轻量级的快速检索工具，适合简单、直接的信息查询。
+[Simple Search - Quick retrieval]
+A lightweight quick-retrieval tool, suitable for simple, direct information lookups.
 
-【使用场景】
-- 需要快速查找某个具体信息
-- 需要验证某个事实
-- 简单的信息检索
+[When to use]
+- When you need to quickly look up a specific piece of information
+- When you need to verify a fact
+- For simple information retrieval
 
-【返回内容】
-- 与查询最相关的事实列表"""
+[Returned content]
+- A list of facts most relevant to the query"""
 
 TOOL_DESC_INTERVIEW_AGENTS = """\
-【深度采访 - 真实Agent采访（双平台）】
-调用OASIS模拟环境的采访API，对正在运行的模拟Agent进行真实采访！
-这不是LLM模拟，而是调用真实的采访接口获取模拟Agent的原始回答。
-默认在Twitter和Reddit两个平台同时采访，获取更全面的观点。
+[Deep Interview - Real Agent interviews (dual-platform)]
+Calls the OASIS simulation environment's interview API to conduct real interviews with the running simulation Agents!
+This is not LLM mock-up — it calls the real interview API to obtain raw answers from the simulation Agents.
+By default it interviews on both Twitter and Reddit simultaneously to obtain a more comprehensive view.
 
-功能流程：
-1. 自动读取人设文件，了解所有模拟Agent
-2. 智能选择与采访主题最相关的Agent（如学生、媒体、官方等）
-3. 自动生成采访问题
-4. 调用 /api/simulation/interview/batch 接口在双平台进行真实采访
-5. 整合所有采访结果，提供多视角分析
+Workflow:
+1. Automatically reads the persona files to understand all simulation Agents
+2. Intelligently selects Agents most relevant to the interview topic (e.g. students, media, officials, etc.)
+3. Automatically generates interview questions
+4. Calls the /api/simulation/interview/batch endpoint to conduct real interviews on both platforms
+5. Combines all interview results, providing multi-perspective analysis
 
-【使用场景】
-- 需要从不同角色视角了解事件看法（学生怎么看？媒体怎么看？官方怎么说？）
-- 需要收集多方意见和立场
-- 需要获取模拟Agent的真实回答（来自OASIS模拟环境）
-- 想让报告更生动，包含"采访实录"
+[When to use]
+- When you need to understand an event from different role perspectives (What do students think? What does the media say? What do officials say?)
+- When you need to collect opinions and stances from multiple parties
+- When you need real answers from simulation Agents (from the OASIS simulation environment)
+- When you want the report to be more vivid and include "interview transcripts"
 
-【返回内容】
-- 被采访Agent的身份信息
-- 各Agent在Twitter和Reddit两个平台的采访回答
-- 关键引言（可直接引用）
-- 采访摘要和观点对比
+[Returned content]
+- Identity information of the interviewed Agents
+- Each Agent's interview answers on both Twitter and Reddit
+- Key quotes (can be quoted directly)
+- Interview summary and viewpoint comparison
 
-【重要】需要OASIS模拟环境正在运行才能使用此功能！"""
+[Important] The OASIS simulation environment must be running for this feature to work!"""
 
-# ── 大纲规划 prompt ──
+# -- Outline-planning prompt --
 
 PLAN_SYSTEM_PROMPT = """\
-你是一个「未来预测报告」的撰写专家，拥有对模拟世界的「上帝视角」——你可以洞察模拟中每一位Agent的行为、言论和互动。
+You are an expert author of "future-prediction reports" with a "god's-eye view" of the simulated world — you can observe every Agent's behavior, statements, and interactions in the simulation.
 
-【核心理念】
-我们构建了一个模拟世界，并向其中注入了特定的「模拟需求」作为变量。模拟世界的演化结果，就是对未来可能发生情况的预测。你正在观察的不是"实验数据"，而是"未来的预演"。
+[Core idea]
+We have built a simulated world and injected a specific "simulation requirement" into it as a variable. The evolved outcome of the simulated world is a prediction of what may happen in the future. What you are observing is not "experimental data" — it is a "rehearsal of the future".
 
-【你的任务】
-撰写一份「未来预测报告」，回答：
-1. 在我们设定的条件下，未来发生了什么？
-2. 各类Agent（人群）是如何反应和行动？
-3. 这个模拟揭示了哪些值得关注的未来趋势和风险？
+[Your task]
+Write a "future-prediction report" that answers:
+1. Under the conditions we set, what happened in the future?
+2. How did the various Agents (populations) react and act?
+3. What noteworthy future trends and risks does this simulation reveal?
 
-【报告定位】
-- ✅ 这是一份基于模拟的未来预测报告，揭示"如果这样，未来会怎样"
-- ✅ 聚焦于预测结果：事件走向、群体反应、涌现现象、潜在风险
-- ✅ 模拟世界中的Agent言行就是对未来人群行为的预测
-- ❌ 不是对现实世界现状的分析
-- ❌ 不是泛泛而谈的舆情综述
+[Report positioning]
+- Yes: This is a simulation-based future-prediction report, revealing "if this, then what the future looks like"
+- Yes: Focus on the predicted outcomes — event trajectories, group reactions, emergent phenomena, potential risks
+- Yes: The Agents' words and actions in the simulated world are predictions of how future populations will behave
+- No: It is not an analysis of the current state of the real world
+- No: It is not a generic public-opinion overview
 
-【章节数量限制】
-- 最少2个章节，最多5个章节
-- 不需要子章节，每个章节直接撰写完整内容
-- 内容要精炼，聚焦于核心预测发现
-- 章节结构由你根据预测结果自主设计
+[Section count limits]
+- Minimum 2 sections, maximum 5 sections
+- No subsections required; write the full content directly under each section
+- Content must be concise, focused on the core predictive findings
+- The section structure is up to you, designed around the predicted outcomes
 
-请输出JSON格式的报告大纲，格式如下：
+Please output the report outline as JSON in the following format:
 {
-    "title": "报告标题",
-    "summary": "报告摘要（一句话概括核心预测发现）",
+    "title": "Report title",
+    "summary": "Report summary (one sentence summarizing the core predictive finding)",
     "sections": [
         {
-            "title": "章节标题",
-            "description": "章节内容描述"
+            "title": "Section title",
+            "description": "Description of the section content"
         }
     ]
 }
 
-注意：sections数组最少2个，最多5个元素！"""
+Note: the sections array must have at least 2 and at most 5 elements!"""
 
 PLAN_USER_PROMPT_TEMPLATE = """\
-【预测场景设定】
-我们向模拟世界注入的变量（模拟需求）：{simulation_requirement}
+[Prediction scenario setup]
+The variable (simulation requirement) we injected into the simulated world: {simulation_requirement}
 
-【模拟世界规模】
-- 参与模拟的实体数量: {total_nodes}
-- 实体间产生的关系数量: {total_edges}
-- 实体类型分布: {entity_types}
-- 活跃Agent数量: {total_entities}
+[Scale of the simulated world]
+- Number of entities participating in the simulation: {total_nodes}
+- Number of relationships among entities: {total_edges}
+- Distribution of entity types: {entity_types}
+- Number of active Agents: {total_entities}
 
-【模拟预测到的部分未来事实样本】
+[Sample of some future facts predicted by the simulation]
 {related_facts_json}
 
-请以「上帝视角」审视这个未来预演：
-1. 在我们设定的条件下，未来呈现出了什么样的状态？
-2. 各类人群（Agent）是如何反应和行动的？
-3. 这个模拟揭示了哪些值得关注的未来趋势？
+Please review this future rehearsal from a "god's-eye view":
+1. Under the conditions we set, what state did the future take?
+2. How did the various populations (Agents) react and act?
+3. What noteworthy future trends does this simulation reveal?
 
-根据预测结果，设计最合适的报告章节结构。
+Based on the predicted outcomes, design the most appropriate report-section structure.
 
-【再次提醒】报告章节数量：最少2个，最多5个，内容要精炼聚焦于核心预测发现。"""
+[Reminder again] Number of report sections: minimum 2, maximum 5. Content must be concise and focused on core predictive findings."""
 
-# ── 章节生成 prompt ──
+# -- Section-generation prompt --
 
 SECTION_SYSTEM_PROMPT_TEMPLATE = """\
-你是一个「未来预测报告」的撰写专家，正在撰写报告的一个章节。
+You are an expert author of "future-prediction reports" and you are now writing one section of the report.
 
-报告标题: {report_title}
-报告摘要: {report_summary}
-预测场景（模拟需求）: {simulation_requirement}
+Report title: {report_title}
+Report summary: {report_summary}
+Prediction scenario (simulation requirement): {simulation_requirement}
 
-当前要撰写的章节: {section_title}
-
-═══════════════════════════════════════════════════════════════
-【核心理念】
-═══════════════════════════════════════════════════════════════
-
-模拟世界是对未来的预演。我们向模拟世界注入了特定条件（模拟需求），
-模拟中Agent的行为和互动，就是对未来人群行为的预测。
-
-你的任务是：
-- 揭示在设定条件下，未来发生了什么
-- 预测各类人群（Agent）是如何反应和行动的
-- 发现值得关注的未来趋势、风险和机会
-
-❌ 不要写成对现实世界现状的分析
-✅ 要聚焦于"未来会怎样"——模拟结果就是预测的未来
+Section currently being written: {section_title}
 
 ═══════════════════════════════════════════════════════════════
-【最重要的规则 - 必须遵守】
+[Core idea]
 ═══════════════════════════════════════════════════════════════
 
-1. 【必须调用工具观察模拟世界】
-   - 你正在以「上帝视角」观察未来的预演
-   - 所有内容必须来自模拟世界中发生的事件和Agent言行
-   - 禁止使用你自己的知识来编写报告内容
-   - 每个章节至少调用3次工具（最多5次）来观察模拟的世界，它代表了未来
+The simulated world is a rehearsal of the future. We injected specific conditions (the simulation requirement) into the simulated world,
+and the behavior and interactions of the Agents in the simulation are predictions of how future populations will behave.
 
-2. 【必须引用Agent的原始言行】
-   - Agent的发言和行为是对未来人群行为的预测
-   - 在报告中使用引用格式展示这些预测，例如：
-     > "某类人群会表示：原文内容..."
-   - 这些引用是模拟预测的核心证据
+Your task is to:
+- Reveal what happened in the future under the given conditions
+- Predict how various populations (Agents) react and act
+- Identify noteworthy future trends, risks, and opportunities
 
-3. 【语言一致性 - 引用内容必须翻译为报告语言】
-   - 工具返回的内容可能包含与报告语言不同的表述
-   - 报告必须全部使用与用户指定语言一致的语言撰写
-   - 当你引用工具返回的其他语言内容时，必须将其翻译为报告语言后再写入
-   - 翻译时保持原意不变，确保表述自然通顺
-   - 这一规则同时适用于正文和引用块（> 格式）中的内容
-
-4. 【忠实呈现预测结果】
-   - 报告内容必须反映模拟世界中的代表未来的模拟结果
-   - 不要添加模拟中不存在的信息
-   - 如果某方面信息不足，如实说明
+No: Do not write it as an analysis of the current state of the real world
+Yes: Focus on "what the future will look like" — the simulation result is the predicted future
 
 ═══════════════════════════════════════════════════════════════
-【⚠️ 格式规范 - 极其重要！】
+[Most important rules — must be followed]
 ═══════════════════════════════════════════════════════════════
 
-【一个章节 = 最小内容单位】
-- 每个章节是报告的最小分块单位
-- ❌ 禁止在章节内使用任何 Markdown 标题（#、##、###、#### 等）
-- ❌ 禁止在内容开头添加章节主标题
-- ✅ 章节标题由系统自动添加，你只需撰写纯正文内容
-- ✅ 使用**粗体**、段落分隔、引用、列表来组织内容，但不要用标题
+1. [You must invoke tools to observe the simulated world]
+   - You are observing the future rehearsal from a "god's-eye view"
+   - All content must come from events and Agent statements/actions in the simulated world
+   - It is forbidden to use your own knowledge to write the report content
+   - Each section must invoke tools at least 3 times (at most 5 times) to observe the simulated world, which represents the future
 
-【正确示例】
+2. [You must quote Agents' original statements and actions]
+   - Agents' statements and behaviors are predictions of how future populations will behave
+   - Use quotation formatting in the report to present these predictions, for example:
+     > "A certain population would say: original content..."
+   - These quotations are the core evidence of the simulation predictions
+
+3. [Language consistency — quoted content must be translated into the report language]
+   - The content returned by the tools may contain expressions in a language different from the report
+   - The report must be written entirely in the language specified by the user
+   - When you cite content returned by tools that is in another language, you must translate it into the report language before writing it
+   - When translating, preserve the original meaning and ensure the wording is natural and fluent
+   - This rule applies to both body text and content inside quotation blocks (the > format)
+
+4. [Faithfully present the predicted results]
+   - Report content must reflect the simulation results in the simulated world that represent the future
+   - Do not add information that does not exist in the simulation
+   - If information about some aspect is insufficient, state that honestly
+
+═══════════════════════════════════════════════════════════════
+[Format conventions — extremely important!]
+═══════════════════════════════════════════════════════════════
+
+[One section = the smallest content unit]
+- Each section is the smallest block unit of the report
+- No: Do not use any Markdown headings inside a section (#, ##, ###, ####, etc.)
+- No: Do not add a section main title at the beginning of the content
+- Yes: The section title is added by the system automatically; you only need to write the body content
+- Yes: Use **bold**, paragraph breaks, quotations, and lists to organize the content, but do not use headings
+
+[Correct example]
 ```
-本章节分析了事件的舆论传播态势。通过对模拟数据的深入分析，我们发现...
+This section analyzes the public-opinion propagation of the event. Through in-depth analysis of the simulation data, we found...
 
-**首发引爆阶段**
+**Initial-ignition phase**
 
-微博作为舆情的第一现场，承担了信息首发的核心功能：
+Weibo, as the first scene of public opinion, took on the core function of information first-publication:
 
-> "微博贡献了68%的首发声量..."
+> "Weibo contributed 68% of the first-publication volume..."
 
-**情绪放大阶段**
+**Emotional-amplification phase**
 
-抖音平台进一步放大了事件影响力：
+The Douyin platform further amplified the event's impact:
 
-- 视觉冲击力强
-- 情绪共鸣度高
-```
-
-【错误示例】
-```
-## 执行摘要          ← 错误！不要添加任何标题
-### 一、首发阶段     ← 错误！不要用###分小节
-#### 1.1 详细分析   ← 错误！不要用####细分
-
-本章节分析了...
+- Strong visual impact
+- High emotional resonance
 ```
 
+[Incorrect example]
+```
+## Executive Summary    <- Wrong! Do not add any heading
+### 1. Initial phase    <- Wrong! Do not use ### for subsections
+#### 1.1 Detailed analysis   <- Wrong! Do not use #### for further subdivisions
+
+This section analyzes...
+```
+
 ═══════════════════════════════════════════════════════════════
-【可用检索工具】（每章节调用3-5次）
+[Available retrieval tools] (invoke 3-5 times per section)
 ═══════════════════════════════════════════════════════════════
 
 {tools_description}
 
-【工具使用建议 - 请混合使用不同工具，不要只用一种】
-- insight_forge: 深度洞察分析，自动分解问题并多维度检索事实和关系
-- panorama_search: 广角全景搜索，了解事件全貌、时间线和演变过程
-- quick_search: 快速验证某个具体信息点
-- interview_agents: 采访模拟Agent，获取不同角色的第一人称观点和真实反应
+[Suggestions for tool usage — please mix different tools, do not use only one]
+- insight_forge: deep insight analysis, automatically decomposes the question and retrieves facts and relationships from multiple dimensions
+- panorama_search: wide-angle panorama search, to understand the full picture, timeline, and evolution of an event
+- quick_search: quickly verify a specific piece of information
+- interview_agents: interview simulation Agents to obtain first-person opinions and authentic reactions from different roles
 
 ═══════════════════════════════════════════════════════════════
-【工作流程】
+[Workflow]
 ═══════════════════════════════════════════════════════════════
 
-每次回复你只能做以下两件事之一（不可同时做）：
+In each reply you can do exactly one of the following two things (not both at the same time):
 
-选项A - 调用工具：
-输出你的思考，然后用以下格式调用一个工具：
+Option A — Invoke a tool:
+Output your reasoning, then invoke one tool using the following format:
 <tool_call>
-{{"name": "工具名称", "parameters": {{"参数名": "参数值"}}}}
+{{"name": "tool_name", "parameters": {{"param_name": "param_value"}}}}
 </tool_call>
-系统会执行工具并把结果返回给你。你不需要也不能自己编写工具返回结果。
+The system will execute the tool and return the result to you. You do not need to (and must not) write the tool's return value yourself.
 
-选项B - 输出最终内容：
-当你已通过工具获取了足够信息，以 "Final Answer:" 开头输出章节内容。
+Option B — Output the final content:
+Once you have obtained enough information through the tools, output the section content beginning with "Final Answer:".
 
-⚠️ 严格禁止：
-- 禁止在一次回复中同时包含工具调用和 Final Answer
-- 禁止自己编造工具返回结果（Observation），所有工具结果由系统注入
-- 每次回复最多调用一个工具
+Strictly forbidden:
+- Forbidden to include both a tool call and Final Answer in the same reply
+- Forbidden to fabricate tool return results (Observation) on your own; all tool results are injected by the system
+- At most one tool call per reply
 
 ═══════════════════════════════════════════════════════════════
-【章节内容要求】
+[Section content requirements]
 ═══════════════════════════════════════════════════════════════
 
-1. 内容必须基于工具检索到的模拟数据
-2. 大量引用原文来展示模拟效果
-3. 使用Markdown格式（但禁止使用标题）：
-   - 使用 **粗体文字** 标记重点（代替子标题）
-   - 使用列表（-或1.2.3.）组织要点
-   - 使用空行分隔不同段落
-   - ❌ 禁止使用 #、##、###、#### 等任何标题语法
-4. 【引用格式规范 - 必须单独成段】
-   引用必须独立成段，前后各有一个空行，不能混在段落中：
+1. The content must be based on simulation data retrieved by the tools
+2. Quote source text liberally to demonstrate the simulation results
+3. Use Markdown formatting (but no headings):
+   - Use **bold text** to highlight key points (in place of subsection titles)
+   - Use lists (- or 1./2./3.) to organize key points
+   - Use blank lines to separate paragraphs
+   - No: Do not use any heading syntax such as #, ##, ###, ####
+4. [Quotation format — must be its own paragraph]
+   A quotation must stand alone as its own paragraph, with one blank line before and after, and must not be mixed into a paragraph:
 
-   ✅ 正确格式：
+   Yes — correct format:
    ```
-   校方的回应被认为缺乏实质内容。
+   The school's response was considered to lack substance.
 
-   > "校方的应对模式在瞬息万变的社交媒体环境中显得僵化和迟缓。"
+   > "The school's response model appears rigid and slow in the rapidly changing social-media environment."
 
-   这一评价反映了公众的普遍不满。
+   This assessment reflects widespread public dissatisfaction.
    ```
 
-   ❌ 错误格式：
+   No — incorrect format:
    ```
-   校方的回应被认为缺乏实质内容。> "校方的应对模式..." 这一评价反映了...
+   The school's response was considered to lack substance. > "The school's response model..." This assessment reflects...
    ```
-5. 保持与其他章节的逻辑连贯性
-6. 【避免重复】仔细阅读下方已完成的章节内容，不要重复描述相同的信息
-7. 【再次强调】不要添加任何标题！用**粗体**代替小节标题"""
+5. Maintain logical coherence with the other sections
+6. [Avoid duplication] Carefully read the already-completed section content below and do not repeat the same information
+7. [Reminder again] Do not add any heading! Use **bold** in place of subsection titles"""
 
 SECTION_USER_PROMPT_TEMPLATE = """\
-已完成的章节内容（请仔细阅读，避免重复）：
+Already-completed section content (please read carefully to avoid duplication):
 {previous_content}
 
 ═══════════════════════════════════════════════════════════════
-【当前任务】撰写章节: {section_title}
+[Current task] Write the section: {section_title}
 ═══════════════════════════════════════════════════════════════
 
-【重要提醒】
-1. 仔细阅读上方已完成的章节，避免重复相同的内容！
-2. 开始前必须先调用工具获取模拟数据
-3. 请混合使用不同工具，不要只用一种
-4. 报告内容必须来自检索结果，不要使用自己的知识
+[Important reminders]
+1. Carefully read the completed sections above and avoid duplicating the same content!
+2. Before starting, you must invoke tools to obtain simulation data
+3. Please mix different tools, do not use only one
+4. Report content must come from retrieval results, do not use your own knowledge
 
-【⚠️ 格式警告 - 必须遵守】
-- ❌ 不要写任何标题（#、##、###、####都不行）
-- ❌ 不要写"{section_title}"作为开头
-- ✅ 章节标题由系统自动添加
-- ✅ 直接写正文，用**粗体**代替小节标题
+[Format warning — must be followed]
+- No: Do not write any headings (#, ##, ###, #### are all forbidden)
+- No: Do not write "{section_title}" as the opening
+- Yes: The section title is added automatically by the system
+- Yes: Write the body directly, using **bold** in place of subsection titles
 
-请开始：
-1. 首先思考（Thought）这个章节需要什么信息
-2. 然后调用工具（Action）获取模拟数据
-3. 收集足够信息后输出 Final Answer（纯正文，无任何标题）"""
+Please begin:
+1. First reason (Thought) about what information this section needs
+2. Then invoke a tool (Action) to obtain simulation data
+3. After collecting enough information, output Final Answer (pure body, no headings of any kind)"""
 
-# ── ReACT 循环内消息模板 ──
+# -- Templates for messages inside the ReACT loop --
 
 REACT_OBSERVATION_TEMPLATE = """\
-Observation（检索结果）:
+Observation (retrieval result):
 
-═══ 工具 {tool_name} 返回 ═══
+═══ Tool {tool_name} returned ═══
 {result}
 
 ═══════════════════════════════════════════════════════════════
-已调用工具 {tool_calls_count}/{max_tool_calls} 次（已用: {used_tools_str}）{unused_hint}
-- 如果信息充分：以 "Final Answer:" 开头输出章节内容（必须引用上述原文）
-- 如果需要更多信息：调用一个工具继续检索
+Tools called {tool_calls_count}/{max_tool_calls} times (used: {used_tools_str}){unused_hint}
+- If the information is sufficient: output the section content beginning with "Final Answer:" (must quote the source text above)
+- If you need more information: invoke one tool to continue retrieving
 ═══════════════════════════════════════════════════════════════"""
 
 REACT_INSUFFICIENT_TOOLS_MSG = (
-    "【注意】你只调用了{tool_calls_count}次工具，至少需要{min_tool_calls}次。"
-    "请再调用工具获取更多模拟数据，然后再输出 Final Answer。{unused_hint}"
+    "[Note] You have only invoked tools {tool_calls_count} times; at least {min_tool_calls} are required. "
+    "Please invoke more tools to obtain additional simulation data, then output Final Answer.{unused_hint}"
 )
 
 REACT_INSUFFICIENT_TOOLS_MSG_ALT = (
-    "当前只调用了 {tool_calls_count} 次工具，至少需要 {min_tool_calls} 次。"
-    "请调用工具获取模拟数据。{unused_hint}"
+    "Currently only {tool_calls_count} tool calls have been made; at least {min_tool_calls} are required. "
+    "Please invoke a tool to obtain simulation data.{unused_hint}"
 )
 
 REACT_TOOL_LIMIT_MSG = (
-    "工具调用次数已达上限（{tool_calls_count}/{max_tool_calls}），不能再调用工具。"
-    '请立即基于已获取的信息，以 "Final Answer:" 开头输出章节内容。'
+    "Tool-call quota has been reached ({tool_calls_count}/{max_tool_calls}); no more tool calls are allowed. "
+    'Please immediately, based on the information already obtained, output the section content beginning with "Final Answer:".'
 )
 
-REACT_UNUSED_TOOLS_HINT = "\n💡 你还没有使用过: {unused_list}，建议尝试不同工具获取多角度信息"
+REACT_UNUSED_TOOLS_HINT = "\nTip: You have not yet used: {unused_list} — consider trying different tools to gather information from multiple angles"
 
-REACT_FORCE_FINAL_MSG = "已达到工具调用限制，请直接输出 Final Answer: 并生成章节内容。"
+REACT_FORCE_FINAL_MSG = "The tool-call limit has been reached; please output Final Answer: directly and generate the section content."
 
-# ── Chat prompt ──
+# -- Chat prompt --
 
 CHAT_SYSTEM_PROMPT_TEMPLATE = """\
-你是一个简洁高效的模拟预测助手。
+You are a concise and efficient simulation-prediction assistant.
 
-【背景】
-预测条件: {simulation_requirement}
+[Background]
+Prediction conditions: {simulation_requirement}
 
-【已生成的分析报告】
+[Already-generated analysis report]
 {report_content}
 
-【规则】
-1. 优先基于上述报告内容回答问题
-2. 直接回答问题，避免冗长的思考论述
-3. 仅在报告内容不足以回答时，才调用工具检索更多数据
-4. 回答要简洁、清晰、有条理
+[Rules]
+1. Answer the question primarily based on the report content above
+2. Answer the question directly; avoid lengthy reasoning prose
+3. Only invoke tools to retrieve more data when the report content is insufficient
+4. Answers should be concise, clear, and well-organized
 
-【可用工具】（仅在需要时使用，最多调用1-2次）
+[Available tools] (use only when necessary; at most 1-2 calls)
 {tools_description}
 
-【工具调用格式】
+[Tool-call format]
 <tool_call>
-{{"name": "工具名称", "parameters": {{"参数名": "参数值"}}}}
+{{"name": "tool_name", "parameters": {{"param_name": "param_value"}}}}
 </tool_call>
 
-【回答风格】
-- 简洁直接，不要长篇大论
-- 使用 > 格式引用关键内容
-- 优先给出结论，再解释原因"""
+[Answer style]
+- Concise and direct, no long-winded prose
+- Use the > format to quote key content
+- Give the conclusion first, then explain the reasoning"""
 
-CHAT_OBSERVATION_SUFFIX = "\n\n请简洁回答问题。"
+CHAT_OBSERVATION_SUFFIX = "\n\nPlease answer the question concisely."
 
 
 # ═══════════════════════════════════════════════════════════════
-# ReportAgent 主类
+# ReportAgent main class
 # ═══════════════════════════════════════════════════════════════
 
 
 class ReportAgent:
     """
-    Report Agent - 模拟报告生成Agent
+    Report Agent - simulation report generation Agent
 
-    采用ReACT（Reasoning + Acting）模式：
-    1. 规划阶段：分析模拟需求，规划报告目录结构
-    2. 生成阶段：逐章节生成内容，每章节可多次调用工具获取信息
-    3. 反思阶段：检查内容完整性和准确性
+    Uses the ReACT (Reasoning + Acting) pattern:
+    1. Planning stage: analyze the simulation requirement and plan the report's table of contents
+    2. Generation stage: generate content section by section; each section may invoke tools multiple times to obtain information
+    3. Reflection stage: check completeness and accuracy of the content
     """
-    
-    # 最大工具调用次数（每个章节）
+
+    # Maximum number of tool calls (per section)
     MAX_TOOL_CALLS_PER_SECTION = 5
-    
-    # 最大反思轮数
+
+    # Maximum number of reflection rounds
     MAX_REFLECTION_ROUNDS = 3
-    
-    # 对话中的最大工具调用次数
+
+    # Maximum number of tool calls per chat turn
     MAX_TOOL_CALLS_PER_CHAT = 2
-    
+
     def __init__(
-        self, 
+        self,
         graph_id: str,
         simulation_id: str,
         simulation_requirement: str,
@@ -890,83 +890,83 @@ class ReportAgent:
         zep_tools: Optional[ZepToolsService] = None
     ):
         """
-        初始化Report Agent
-        
+        Initialize the Report Agent
+
         Args:
-            graph_id: 图谱ID
-            simulation_id: 模拟ID
-            simulation_requirement: 模拟需求描述
-            llm_client: LLM客户端（可选）
-            zep_tools: Zep工具服务（可选）
+            graph_id: Graph ID
+            simulation_id: Simulation ID
+            simulation_requirement: Description of the simulation requirement
+            llm_client: LLM client (optional)
+            zep_tools: Zep tools service (optional)
         """
         self.graph_id = graph_id
         self.simulation_id = simulation_id
         self.simulation_requirement = simulation_requirement
-        
+
         self.llm = llm_client or LLMClient()
         self.zep_tools = zep_tools or ZepToolsService()
-        
-        # 工具定义
+
+        # Tool definitions
         self.tools = self._define_tools()
-        
-        # 日志记录器（在 generate_report 中初始化）
+
+        # Logger (initialized in generate_report)
         self.report_logger: Optional[ReportLogger] = None
-        # 控制台日志记录器（在 generate_report 中初始化）
+        # Console logger (initialized in generate_report)
         self.console_logger: Optional[ReportConsoleLogger] = None
-        
+
         logger.info(t('report.agentInitDone', graphId=graph_id, simulationId=simulation_id))
-    
+
     def _define_tools(self) -> Dict[str, Dict[str, Any]]:
-        """定义可用工具"""
+        """Define the available tools"""
         return {
             "insight_forge": {
                 "name": "insight_forge",
                 "description": TOOL_DESC_INSIGHT_FORGE,
                 "parameters": {
-                    "query": "你想深入分析的问题或话题",
-                    "report_context": "当前报告章节的上下文（可选，有助于生成更精准的子问题）"
+                    "query": "The question or topic you want to analyze in depth",
+                    "report_context": "The context of the current report section (optional; helps generate more accurate sub-questions)"
                 }
             },
             "panorama_search": {
                 "name": "panorama_search",
                 "description": TOOL_DESC_PANORAMA_SEARCH,
                 "parameters": {
-                    "query": "搜索查询，用于相关性排序",
-                    "include_expired": "是否包含过期/历史内容（默认True）"
+                    "query": "Search query, used for relevance ranking",
+                    "include_expired": "Whether to include expired/historical content (default True)"
                 }
             },
             "quick_search": {
                 "name": "quick_search",
                 "description": TOOL_DESC_QUICK_SEARCH,
                 "parameters": {
-                    "query": "搜索查询字符串",
-                    "limit": "返回结果数量（可选，默认10）"
+                    "query": "Search query string",
+                    "limit": "Number of results to return (optional, default 10)"
                 }
             },
             "interview_agents": {
                 "name": "interview_agents",
                 "description": TOOL_DESC_INTERVIEW_AGENTS,
                 "parameters": {
-                    "interview_topic": "采访主题或需求描述（如：'了解学生对宿舍甲醛事件的看法'）",
-                    "max_agents": "最多采访的Agent数量（可选，默认5，最大10）"
+                    "interview_topic": "Interview topic or requirement description (e.g. 'understand students' views on the dorm formaldehyde incident')",
+                    "max_agents": "Maximum number of Agents to interview (optional, default 5, max 10)"
                 }
             }
         }
-    
+
     def _execute_tool(self, tool_name: str, parameters: Dict[str, Any], report_context: str = "") -> str:
         """
-        执行工具调用
-        
+        Execute a tool call
+
         Args:
-            tool_name: 工具名称
-            parameters: 工具参数
-            report_context: 报告上下文（用于InsightForge）
-            
+            tool_name: Tool name
+            parameters: Tool parameters
+            report_context: Report context (used by InsightForge)
+
         Returns:
-            工具执行结果（文本格式）
+            Tool execution result (text format)
         """
         logger.info(t('report.executingTool', toolName=tool_name, params=parameters))
-        
+
         try:
             if tool_name == "insight_forge":
                 query = parameters.get("query", "")
@@ -978,9 +978,9 @@ class ReportAgent:
                     report_context=ctx
                 )
                 return result.to_text()
-            
+
             elif tool_name == "panorama_search":
-                # 广度搜索 - 获取全貌
+                # Panorama search - obtain the full picture
                 query = parameters.get("query", "")
                 include_expired = parameters.get("include_expired", True)
                 if isinstance(include_expired, str):
@@ -991,9 +991,9 @@ class ReportAgent:
                     include_expired=include_expired
                 )
                 return result.to_text()
-            
+
             elif tool_name == "quick_search":
-                # 简单搜索 - 快速检索
+                # Simple search - quick retrieval
                 query = parameters.get("query", "")
                 limit = parameters.get("limit", 10)
                 if isinstance(limit, str):
@@ -1004,9 +1004,9 @@ class ReportAgent:
                     limit=limit
                 )
                 return result.to_text()
-            
+
             elif tool_name == "interview_agents":
-                # 深度采访 - 调用真实的OASIS采访API获取模拟Agent的回答（双平台）
+                # Deep interview - call the real OASIS interview API to obtain answers from simulation Agents (dual-platform)
                 interview_topic = parameters.get("interview_topic", parameters.get("query", ""))
                 max_agents = parameters.get("max_agents", 5)
                 if isinstance(max_agents, str):
@@ -1019,18 +1019,18 @@ class ReportAgent:
                     max_agents=max_agents
                 )
                 return result.to_text()
-            
-            # ========== 向后兼容的旧工具（内部重定向到新工具） ==========
-            
+
+            # ========== Backward-compatible legacy tools (internally redirected to new tools) ==========
+
             elif tool_name == "search_graph":
-                # 重定向到 quick_search
+                # Redirect to quick_search
                 logger.info(t('report.redirectToQuickSearch'))
                 return self._execute_tool("quick_search", parameters, report_context)
-            
+
             elif tool_name == "get_graph_statistics":
                 result = self.zep_tools.get_graph_statistics(self.graph_id)
                 return json.dumps(result, ensure_ascii=False, indent=2)
-            
+
             elif tool_name == "get_entity_summary":
                 entity_name = parameters.get("entity_name", "")
                 result = self.zep_tools.get_entity_summary(
@@ -1038,13 +1038,13 @@ class ReportAgent:
                     entity_name=entity_name
                 )
                 return json.dumps(result, ensure_ascii=False, indent=2)
-            
+
             elif tool_name == "get_simulation_context":
-                # 重定向到 insight_forge，因为它更强大
+                # Redirect to insight_forge because it is more powerful
                 logger.info(t('report.redirectToInsightForge'))
                 query = parameters.get("query", self.simulation_requirement)
                 return self._execute_tool("insight_forge", {"query": query}, report_context)
-            
+
             elif tool_name == "get_entities_by_type":
                 entity_type = parameters.get("entity_type", "")
                 nodes = self.zep_tools.get_entities_by_type(
@@ -1053,28 +1053,28 @@ class ReportAgent:
                 )
                 result = [n.to_dict() for n in nodes]
                 return json.dumps(result, ensure_ascii=False, indent=2)
-            
+
             else:
-                return f"未知工具: {tool_name}。请使用以下工具之一: insight_forge, panorama_search, quick_search"
-                
+                return f"Unknown tool: {tool_name}. Please use one of the following tools: insight_forge, panorama_search, quick_search"
+
         except Exception as e:
             logger.error(t('report.toolExecFailed', toolName=tool_name, error=str(e)))
-            return f"工具执行失败: {str(e)}"
-    
-    # 合法的工具名称集合，用于裸 JSON 兜底解析时校验
+            return f"Tool execution failed: {str(e)}"
+
+    # Set of valid tool names, used for validation in the bare-JSON fallback parser
     VALID_TOOL_NAMES = {"insight_forge", "panorama_search", "quick_search", "interview_agents"}
 
     def _parse_tool_calls(self, response: str) -> List[Dict[str, Any]]:
         """
-        从LLM响应中解析工具调用
+        Parse tool calls out of an LLM response
 
-        支持的格式（按优先级）：
+        Supported formats (in order of priority):
         1. <tool_call>{"name": "tool_name", "parameters": {...}}</tool_call>
-        2. 裸 JSON（响应整体或单行就是一个工具调用 JSON）
+        2. Bare JSON (the whole response, or a single line, is one tool-call JSON object)
         """
         tool_calls = []
 
-        # 格式1: XML风格（标准格式）
+        # Format 1: XML style (the standard format)
         xml_pattern = r'<tool_call>\s*(\{.*?\})\s*</tool_call>'
         for match in re.finditer(xml_pattern, response, re.DOTALL):
             try:
@@ -1086,8 +1086,8 @@ class ReportAgent:
         if tool_calls:
             return tool_calls
 
-        # 格式2: 兜底 - LLM 直接输出裸 JSON（没包 <tool_call> 标签）
-        # 只在格式1未匹配时尝试，避免误匹配正文中的 JSON
+        # Format 2: fallback - the LLM emitted bare JSON (without the <tool_call> wrapper)
+        # Only attempted when format 1 did not match, to avoid false matches against JSON in body text
         stripped = response.strip()
         if stripped.startswith('{') and stripped.endswith('}'):
             try:
@@ -1098,7 +1098,7 @@ class ReportAgent:
             except json.JSONDecodeError:
                 pass
 
-        # 响应可能包含思考文字 + 裸 JSON，尝试提取最后一个 JSON 对象
+        # The response may contain reasoning text + bare JSON; try to extract the last JSON object
         json_pattern = r'(\{"(?:name|tool)"\s*:.*?\})\s*$'
         match = re.search(json_pattern, stripped, re.DOTALL)
         if match:
@@ -1112,57 +1112,57 @@ class ReportAgent:
         return tool_calls
 
     def _is_valid_tool_call(self, data: dict) -> bool:
-        """校验解析出的 JSON 是否是合法的工具调用"""
-        # 支持 {"name": ..., "parameters": ...} 和 {"tool": ..., "params": ...} 两种键名
+        """Validate that the parsed JSON is a legitimate tool call"""
+        # Supports both {"name": ..., "parameters": ...} and {"tool": ..., "params": ...} key sets
         tool_name = data.get("name") or data.get("tool")
         if tool_name and tool_name in self.VALID_TOOL_NAMES:
-            # 统一键名为 name / parameters
+            # Normalize keys to name / parameters
             if "tool" in data:
                 data["name"] = data.pop("tool")
             if "params" in data and "parameters" not in data:
                 data["parameters"] = data.pop("params")
             return True
         return False
-    
+
     def _get_tools_description(self) -> str:
-        """生成工具描述文本"""
-        desc_parts = ["可用工具："]
+        """Generate the tools description text"""
+        desc_parts = ["Available tools:"]
         for name, tool in self.tools.items():
             params_desc = ", ".join([f"{k}: {v}" for k, v in tool["parameters"].items()])
             desc_parts.append(f"- {name}: {tool['description']}")
             if params_desc:
-                desc_parts.append(f"  参数: {params_desc}")
+                desc_parts.append(f"  Parameters: {params_desc}")
         return "\n".join(desc_parts)
-    
+
     def plan_outline(
-        self, 
+        self,
         progress_callback: Optional[Callable] = None
     ) -> ReportOutline:
         """
-        规划报告大纲
-        
-        使用LLM分析模拟需求，规划报告的目录结构
-        
+        Plan the report outline
+
+        Uses the LLM to analyze the simulation requirement and plan the report's table of contents
+
         Args:
-            progress_callback: 进度回调函数
-            
+            progress_callback: Progress callback function
+
         Returns:
-            ReportOutline: 报告大纲
+            ReportOutline: The report outline
         """
         logger.info(t('report.startPlanningOutline'))
-        
+
         if progress_callback:
             progress_callback("planning", 0, t('progress.analyzingRequirements'))
-        
-        # 首先获取模拟上下文
+
+        # First obtain the simulation context
         context = self.zep_tools.get_simulation_context(
             graph_id=self.graph_id,
             simulation_requirement=self.simulation_requirement
         )
-        
+
         if progress_callback:
             progress_callback("planning", 30, t('progress.generatingOutline'))
-        
+
         system_prompt = f"{PLAN_SYSTEM_PROMPT}\n\n{get_language_instruction()}"
         user_prompt = PLAN_USER_PROMPT_TEMPLATE.format(
             simulation_requirement=self.simulation_requirement,
@@ -1181,45 +1181,45 @@ class ReportAgent:
                 ],
                 temperature=0.3
             )
-            
+
             if progress_callback:
                 progress_callback("planning", 80, t('progress.parsingOutline'))
-            
-            # 解析大纲
+
+            # Parse the outline
             sections = []
             for section_data in response.get("sections", []):
                 sections.append(ReportSection(
                     title=section_data.get("title", ""),
                     content=""
                 ))
-            
+
             outline = ReportOutline(
-                title=response.get("title", "模拟分析报告"),
+                title=response.get("title", "Simulation Analysis Report"),
                 summary=response.get("summary", ""),
                 sections=sections
             )
-            
+
             if progress_callback:
                 progress_callback("planning", 100, t('progress.outlinePlanComplete'))
-            
+
             logger.info(t('report.outlinePlanDone', count=len(sections)))
             return outline
-            
+
         except Exception as e:
             logger.error(t('report.outlinePlanFailed', error=str(e)))
-            # 返回默认大纲（3个章节，作为fallback）
+            # Return a default outline (3 sections, as a fallback)
             return ReportOutline(
-                title="未来预测报告",
-                summary="基于模拟预测的未来趋势与风险分析",
+                title="Future Prediction Report",
+                summary="Future trends and risk analysis based on simulation predictions",
                 sections=[
-                    ReportSection(title="预测场景与核心发现"),
-                    ReportSection(title="人群行为预测分析"),
-                    ReportSection(title="趋势展望与风险提示")
+                    ReportSection(title="Prediction Scenario and Core Findings"),
+                    ReportSection(title="Population Behavior Prediction Analysis"),
+                    ReportSection(title="Trend Outlook and Risk Indications")
                 ]
             )
-    
+
     def _generate_section_react(
-        self, 
+        self,
         section: ReportSection,
         outline: ReportOutline,
         previous_sections: List[str],
@@ -1227,31 +1227,31 @@ class ReportAgent:
         section_index: int = 0
     ) -> str:
         """
-        使用ReACT模式生成单个章节内容
-        
-        ReACT循环：
-        1. Thought（思考）- 分析需要什么信息
-        2. Action（行动）- 调用工具获取信息
-        3. Observation（观察）- 分析工具返回结果
-        4. 重复直到信息足够或达到最大次数
-        5. Final Answer（最终回答）- 生成章节内容
-        
+        Generate a single section's content using the ReACT pattern
+
+        ReACT loop:
+        1. Thought - reason about what information is needed
+        2. Action - invoke tools to obtain information
+        3. Observation - analyze tool return results
+        4. Repeat until information is sufficient or max iterations reached
+        5. Final Answer - generate the section content
+
         Args:
-            section: 要生成的章节
-            outline: 完整大纲
-            previous_sections: 之前章节的内容（用于保持连贯性）
-            progress_callback: 进度回调
-            section_index: 章节索引（用于日志记录）
-            
+            section: The section to generate
+            outline: The full outline
+            previous_sections: Content of preceding sections (for coherence)
+            progress_callback: Progress callback
+            section_index: Section index (used for logging)
+
         Returns:
-            章节内容（Markdown格式）
+            Section content (Markdown format)
         """
         logger.info(t('report.reactGenerateSection', title=section.title))
-        
-        # 记录章节开始日志
+
+        # Log section start
         if self.report_logger:
             self.report_logger.log_section_start(section.title, section_index)
-        
+
         system_prompt = SECTION_SYSTEM_PROMPT_TEMPLATE.format(
             report_title=outline.title,
             report_summary=outline.summary,
@@ -1261,17 +1261,17 @@ class ReportAgent:
         )
         system_prompt = f"{system_prompt}\n\n{get_language_instruction()}"
 
-        # 构建用户prompt - 每个已完成章节各传入最大4000字
+        # Build the user prompt - up to 4000 characters of each completed section are included
         if previous_sections:
             previous_parts = []
             for sec in previous_sections:
-                # 每个章节最多4000字
+                # At most 4000 characters per section
                 truncated = sec[:4000] + "..." if len(sec) > 4000 else sec
                 previous_parts.append(truncated)
             previous_content = "\n\n---\n\n".join(previous_parts)
         else:
-            previous_content = "（这是第一个章节）"
-        
+            previous_content = "(This is the first section)"
+
         user_prompt = SECTION_USER_PROMPT_TEMPLATE.format(
             previous_content=previous_content,
             section_title=section.title,
@@ -1281,52 +1281,52 @@ class ReportAgent:
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt}
         ]
-        
-        # ReACT循环
+
+        # ReACT loop
         tool_calls_count = 0
-        max_iterations = 5  # 最大迭代轮数
-        min_tool_calls = 3  # 最少工具调用次数
-        conflict_retries = 0  # 工具调用与Final Answer同时出现的连续冲突次数
-        used_tools = set()  # 记录已调用过的工具名
+        max_iterations = 5  # Maximum iteration rounds
+        min_tool_calls = 3  # Minimum number of tool calls
+        conflict_retries = 0  # Consecutive conflicts where tool call and Final Answer appear together
+        used_tools = set()  # Names of tools already invoked
         all_tools = {"insight_forge", "panorama_search", "quick_search", "interview_agents"}
 
-        # 报告上下文，用于InsightForge的子问题生成
-        report_context = f"章节标题: {section.title}\n模拟需求: {self.simulation_requirement}"
-        
+        # Report context, used for InsightForge sub-question generation
+        report_context = f"Section title: {section.title}\nSimulation requirement: {self.simulation_requirement}"
+
         for iteration in range(max_iterations):
             if progress_callback:
                 progress_callback(
-                    "generating", 
+                    "generating",
                     int((iteration / max_iterations) * 100),
                     t('progress.deepSearchAndWrite', current=tool_calls_count, max=self.MAX_TOOL_CALLS_PER_SECTION)
                 )
-            
-            # 调用LLM
+
+            # Call the LLM
             response = self.llm.chat(
                 messages=messages,
                 temperature=0.5,
                 max_tokens=4096
             )
 
-            # 检查 LLM 返回是否为 None（API 异常或内容为空）
+            # Check whether the LLM returned None (API error or empty content)
             if response is None:
                 logger.warning(t('report.sectionIterNone', title=section.title, iteration=iteration + 1))
-                # 如果还有迭代次数，添加消息并重试
+                # If iterations remain, append messages and retry
                 if iteration < max_iterations - 1:
-                    messages.append({"role": "assistant", "content": "（响应为空）"})
-                    messages.append({"role": "user", "content": "请继续生成内容。"})
+                    messages.append({"role": "assistant", "content": "(Empty response)"})
+                    messages.append({"role": "user", "content": "Please continue generating content."})
                     continue
-                # 最后一次迭代也返回 None，跳出循环进入强制收尾
+                # The last iteration also returned None — break out and force closure
                 break
 
-            logger.debug(f"LLM响应: {response[:200]}...")
+            logger.debug(f"LLM response: {response[:200]}...")
 
-            # 解析一次，复用结果
+            # Parse once and reuse the result
             tool_calls = self._parse_tool_calls(response)
             has_tool_calls = bool(tool_calls)
             has_final_answer = "Final Answer:" in response
 
-            # ── 冲突处理：LLM 同时输出了工具调用和 Final Answer ──
+            # -- Conflict handling: the LLM emitted both a tool call and Final Answer --
             if has_tool_calls and has_final_answer:
                 conflict_retries += 1
                 logger.warning(
@@ -1334,21 +1334,21 @@ class ReportAgent:
                 )
 
                 if conflict_retries <= 2:
-                    # 前两次：丢弃本次响应，要求 LLM 重新回复
+                    # First two times: discard this response and ask the LLM to reply again
                     messages.append({"role": "assistant", "content": response})
                     messages.append({
                         "role": "user",
                         "content": (
-                            "【格式错误】你在一次回复中同时包含了工具调用和 Final Answer，这是不允许的。\n"
-                            "每次回复只能做以下两件事之一：\n"
-                            "- 调用一个工具（输出一个 <tool_call> 块，不要写 Final Answer）\n"
-                            "- 输出最终内容（以 'Final Answer:' 开头，不要包含 <tool_call>）\n"
-                            "请重新回复，只做其中一件事。"
+                            "[Format error] You included both a tool call and Final Answer in the same reply, which is not allowed.\n"
+                            "Each reply may do only one of the following two things:\n"
+                            "- Invoke one tool (output a single <tool_call> block, do not write Final Answer)\n"
+                            "- Output the final content (begin with 'Final Answer:', do not include <tool_call>)\n"
+                            "Please reply again, doing only one of these."
                         ),
                     })
                     continue
                 else:
-                    # 第三次：降级处理，截断到第一个工具调用，强制执行
+                    # On the third time: degrade by truncating to the first tool call and forcing it to execute
                     logger.warning(
                         t('report.sectionConflictDowngrade', title=section.title, conflictCount=conflict_retries)
                     )
@@ -1360,7 +1360,7 @@ class ReportAgent:
                     has_final_answer = False
                     conflict_retries = 0
 
-            # 记录 LLM 响应日志
+            # Log the LLM response
             if self.report_logger:
                 self.report_logger.log_llm_response(
                     section_title=section.title,
@@ -1371,13 +1371,13 @@ class ReportAgent:
                     has_final_answer=has_final_answer
                 )
 
-            # ── 情况1：LLM 输出了 Final Answer ──
+            # -- Case 1: the LLM emitted a Final Answer --
             if has_final_answer:
-                # 工具调用次数不足，拒绝并要求继续调工具
+                # Tool-call count is insufficient — reject and ask it to call more tools
                 if tool_calls_count < min_tool_calls:
                     messages.append({"role": "assistant", "content": response})
                     unused_tools = all_tools - used_tools
-                    unused_hint = f"（这些工具还未使用，推荐用一下他们: {', '.join(unused_tools)}）" if unused_tools else ""
+                    unused_hint = f" (These tools have not been used yet — recommend trying them: {', '.join(unused_tools)})" if unused_tools else ""
                     messages.append({
                         "role": "user",
                         "content": REACT_INSUFFICIENT_TOOLS_MSG.format(
@@ -1388,7 +1388,7 @@ class ReportAgent:
                     })
                     continue
 
-                # 正常结束
+                # Normal completion
                 final_answer = response.split("Final Answer:")[-1].strip()
                 logger.info(t('report.sectionGenDone', title=section.title, count=tool_calls_count))
 
@@ -1401,9 +1401,9 @@ class ReportAgent:
                     )
                 return final_answer
 
-            # ── 情况2：LLM 尝试调用工具 ──
+            # -- Case 2: the LLM tried to invoke a tool --
             if has_tool_calls:
-                # 工具额度已耗尽 → 明确告知，要求输出 Final Answer
+                # Tool-call quota exhausted -> tell the LLM clearly and require Final Answer
                 if tool_calls_count >= self.MAX_TOOL_CALLS_PER_SECTION:
                     messages.append({"role": "assistant", "content": response})
                     messages.append({
@@ -1415,7 +1415,7 @@ class ReportAgent:
                     })
                     continue
 
-                # 只执行第一个工具调用
+                # Execute only the first tool call
                 call = tool_calls[0]
                 if len(tool_calls) > 1:
                     logger.info(t('report.multiToolOnlyFirst', total=len(tool_calls), toolName=call['name']))
@@ -1447,11 +1447,11 @@ class ReportAgent:
                 tool_calls_count += 1
                 used_tools.add(call['name'])
 
-                # 构建未使用工具提示
+                # Build the unused-tools hint
                 unused_tools = all_tools - used_tools
                 unused_hint = ""
                 if unused_tools and tool_calls_count < self.MAX_TOOL_CALLS_PER_SECTION:
-                    unused_hint = REACT_UNUSED_TOOLS_HINT.format(unused_list="、".join(unused_tools))
+                    unused_hint = REACT_UNUSED_TOOLS_HINT.format(unused_list=", ".join(unused_tools))
 
                 messages.append({"role": "assistant", "content": response})
                 messages.append({
@@ -1467,13 +1467,13 @@ class ReportAgent:
                 })
                 continue
 
-            # ── 情况3：既没有工具调用，也没有 Final Answer ──
+            # -- Case 3: neither a tool call nor a Final Answer --
             messages.append({"role": "assistant", "content": response})
 
             if tool_calls_count < min_tool_calls:
-                # 工具调用次数不足，推荐未用过的工具
+                # Tool-call count insufficient — recommend the unused tools
                 unused_tools = all_tools - used_tools
-                unused_hint = f"（这些工具还未使用，推荐用一下他们: {', '.join(unused_tools)}）" if unused_tools else ""
+                unused_hint = f" (These tools have not been used yet — recommend trying them: {', '.join(unused_tools)})" if unused_tools else ""
 
                 messages.append({
                     "role": "user",
@@ -1485,8 +1485,8 @@ class ReportAgent:
                 })
                 continue
 
-            # 工具调用已足够，LLM 输出了内容但没带 "Final Answer:" 前缀
-            # 直接将这段内容作为最终答案，不再空转
+            # Tool-call count is sufficient; the LLM emitted content but without the "Final Answer:" prefix.
+            # Treat it directly as the final answer to avoid spinning.
             logger.info(t('report.sectionNoPrefix', title=section.title, count=tool_calls_count))
             final_answer = response.strip()
 
@@ -1498,18 +1498,18 @@ class ReportAgent:
                     tool_calls_count=tool_calls_count
                 )
             return final_answer
-        
-        # 达到最大迭代次数，强制生成内容
+
+        # Reached the maximum iterations — force content generation
         logger.warning(t('report.sectionMaxIter', title=section.title))
         messages.append({"role": "user", "content": REACT_FORCE_FINAL_MSG})
-        
+
         response = self.llm.chat(
             messages=messages,
             temperature=0.5,
             max_tokens=4096
         )
 
-        # 检查强制收尾时 LLM 返回是否为 None
+        # Check whether the LLM returned None during the forced closure
         if response is None:
             logger.error(t('report.sectionForceFailed', title=section.title))
             final_answer = t('report.sectionGenFailedContent')
@@ -1517,8 +1517,8 @@ class ReportAgent:
             final_answer = response.split("Final Answer:")[-1].strip()
         else:
             final_answer = response
-        
-        # 记录章节内容生成完成日志
+
+        # Log section content completion
         if self.report_logger:
             self.report_logger.log_section_content(
                 section_title=section.title,
@@ -1526,42 +1526,42 @@ class ReportAgent:
                 content=final_answer,
                 tool_calls_count=tool_calls_count
             )
-        
+
         return final_answer
-    
+
     def generate_report(
-        self, 
+        self,
         progress_callback: Optional[Callable[[str, int, str], None]] = None,
         report_id: Optional[str] = None
     ) -> Report:
         """
-        生成完整报告（分章节实时输出）
-        
-        每个章节生成完成后立即保存到文件夹，不需要等待整个报告完成。
-        文件结构：
+        Generate the complete report (with section-by-section streaming output)
+
+        Each section is saved to the folder immediately after generation, without waiting for the whole report to finish.
+        File structure:
         reports/{report_id}/
-            meta.json       - 报告元信息
-            outline.json    - 报告大纲
-            progress.json   - 生成进度
-            section_01.md   - 第1章节
-            section_02.md   - 第2章节
+            meta.json       - Report metadata
+            outline.json    - Report outline
+            progress.json   - Generation progress
+            section_01.md   - Section 1
+            section_02.md   - Section 2
             ...
-            full_report.md  - 完整报告
-        
+            full_report.md  - Complete report
+
         Args:
-            progress_callback: 进度回调函数 (stage, progress, message)
-            report_id: 报告ID（可选，如果不传则自动生成）
-            
+            progress_callback: Progress callback (stage, progress, message)
+            report_id: Report ID (optional; generated automatically if not provided)
+
         Returns:
-            Report: 完整报告
+            Report: The complete report
         """
         import uuid
-        
-        # 如果没有传入 report_id，则自动生成
+
+        # If report_id was not provided, generate one automatically
         if not report_id:
             report_id = f"report_{uuid.uuid4().hex[:12]}"
         start_time = datetime.now()
-        
+
         report = Report(
             report_id=report_id,
             simulation_id=self.simulation_id,
@@ -1570,74 +1570,74 @@ class ReportAgent:
             status=ReportStatus.PENDING,
             created_at=datetime.now().isoformat()
         )
-        
-        # 已完成的章节标题列表（用于进度追踪）
+
+        # List of titles of completed sections (used for progress tracking)
         completed_section_titles = []
-        
+
         try:
-            # 初始化：创建报告文件夹并保存初始状态
+            # Initialization: create the report folder and save the initial state
             ReportManager._ensure_report_folder(report_id)
-            
-            # 初始化日志记录器（结构化日志 agent_log.jsonl）
+
+            # Initialize the structured logger (agent_log.jsonl)
             self.report_logger = ReportLogger(report_id)
             self.report_logger.log_start(
                 simulation_id=self.simulation_id,
                 graph_id=self.graph_id,
                 simulation_requirement=self.simulation_requirement
             )
-            
-            # 初始化控制台日志记录器（console_log.txt）
+
+            # Initialize the console logger (console_log.txt)
             self.console_logger = ReportConsoleLogger(report_id)
-            
+
             ReportManager.update_progress(
                 report_id, "pending", 0, t('progress.initReport'),
                 completed_sections=[]
             )
             ReportManager.save_report(report)
-            
-            # 阶段1: 规划大纲
+
+            # Stage 1: plan the outline
             report.status = ReportStatus.PLANNING
             ReportManager.update_progress(
                 report_id, "planning", 5, t('progress.startPlanningOutline'),
                 completed_sections=[]
             )
-            
-            # 记录规划开始日志
+
+            # Log planning start
             self.report_logger.log_planning_start()
-            
+
             if progress_callback:
                 progress_callback("planning", 0, t('progress.startPlanningOutline'))
-            
+
             outline = self.plan_outline(
-                progress_callback=lambda stage, prog, msg: 
+                progress_callback=lambda stage, prog, msg:
                     progress_callback(stage, prog // 5, msg) if progress_callback else None
             )
             report.outline = outline
-            
-            # 记录规划完成日志
+
+            # Log planning completion
             self.report_logger.log_planning_complete(outline.to_dict())
-            
-            # 保存大纲到文件
+
+            # Save the outline to file
             ReportManager.save_outline(report_id, outline)
             ReportManager.update_progress(
                 report_id, "planning", 15, t('progress.outlineDone', count=len(outline.sections)),
                 completed_sections=[]
             )
             ReportManager.save_report(report)
-            
+
             logger.info(t('report.outlineSavedToFile', reportId=report_id))
-            
-            # 阶段2: 逐章节生成（分章节保存）
+
+            # Stage 2: generate sections one by one (saved per section)
             report.status = ReportStatus.GENERATING
-            
+
             total_sections = len(outline.sections)
-            generated_sections = []  # 保存内容用于上下文
-            
+            generated_sections = []  # Save content for context
+
             for i, section in enumerate(outline.sections):
                 section_num = i + 1
                 base_progress = 20 + int((i / total_sections) * 70)
-                
-                # 更新进度
+
+                # Update progress
                 ReportManager.update_progress(
                     report_id, "generating", base_progress,
                     t('progress.generatingSection', title=section.title, current=section_num, total=total_sections),
@@ -1651,29 +1651,29 @@ class ReportAgent:
                         base_progress,
                         t('progress.generatingSection', title=section.title, current=section_num, total=total_sections)
                     )
-                
-                # 生成主章节内容
+
+                # Generate the main section content
                 section_content = self._generate_section_react(
                     section=section,
                     outline=outline,
                     previous_sections=generated_sections,
                     progress_callback=lambda stage, prog, msg:
                         progress_callback(
-                            stage, 
+                            stage,
                             base_progress + int(prog * 0.7 / total_sections),
                             msg
                         ) if progress_callback else None,
                     section_index=section_num
                 )
-                
+
                 section.content = section_content
                 generated_sections.append(f"## {section.title}\n\n{section_content}")
 
-                # 保存章节
+                # Save the section
                 ReportManager.save_section(report_id, section_num, section)
                 completed_section_titles.append(section.title)
 
-                # 记录章节完成日志
+                # Log section completion
                 full_section_content = f"## {section.title}\n\n{section_content}"
 
                 if self.report_logger:
@@ -1684,69 +1684,69 @@ class ReportAgent:
                     )
 
                 logger.info(t('report.sectionSaved', reportId=report_id, sectionNum=f"{section_num:02d}"))
-                
-                # 更新进度
+
+                # Update progress
                 ReportManager.update_progress(
-                    report_id, "generating", 
+                    report_id, "generating",
                     base_progress + int(70 / total_sections),
                     t('progress.sectionDone', title=section.title),
                     current_section=None,
                     completed_sections=completed_section_titles
                 )
-            
-            # 阶段3: 组装完整报告
+
+            # Stage 3: assemble the complete report
             if progress_callback:
                 progress_callback("generating", 95, t('progress.assemblingReport'))
-            
+
             ReportManager.update_progress(
                 report_id, "generating", 95, t('progress.assemblingReport'),
                 completed_sections=completed_section_titles
             )
-            
-            # 使用ReportManager组装完整报告
+
+            # Use ReportManager to assemble the complete report
             report.markdown_content = ReportManager.assemble_full_report(report_id, outline)
             report.status = ReportStatus.COMPLETED
             report.completed_at = datetime.now().isoformat()
-            
-            # 计算总耗时
+
+            # Compute total elapsed time
             total_time_seconds = (datetime.now() - start_time).total_seconds()
-            
-            # 记录报告完成日志
+
+            # Log report completion
             if self.report_logger:
                 self.report_logger.log_report_complete(
                     total_sections=total_sections,
                     total_time_seconds=total_time_seconds
                 )
-            
-            # 保存最终报告
+
+            # Save the final report
             ReportManager.save_report(report)
             ReportManager.update_progress(
                 report_id, "completed", 100, t('progress.reportComplete'),
                 completed_sections=completed_section_titles
             )
-            
+
             if progress_callback:
                 progress_callback("completed", 100, t('progress.reportComplete'))
-            
+
             logger.info(t('report.reportGenDone', reportId=report_id))
-            
-            # 关闭控制台日志记录器
+
+            # Close the console logger
             if self.console_logger:
                 self.console_logger.close()
                 self.console_logger = None
-            
+
             return report
-            
+
         except Exception as e:
             logger.error(t('report.reportGenFailed', error=str(e)))
             report.status = ReportStatus.FAILED
             report.error = str(e)
-            
-            # 记录错误日志
+
+            # Log the error
             if self.report_logger:
                 self.report_logger.log_error(str(e), "failed")
-            
-            # 保存失败状态
+
+            # Save the failed state
             try:
                 ReportManager.save_report(report)
                 ReportManager.update_progress(
@@ -1754,126 +1754,126 @@ class ReportAgent:
                     completed_sections=completed_section_titles
                 )
             except Exception:
-                pass  # 忽略保存失败的错误
-            
-            # 关闭控制台日志记录器
+                pass  # Ignore errors from saving failure
+
+            # Close the console logger
             if self.console_logger:
                 self.console_logger.close()
                 self.console_logger = None
-            
+
             return report
-    
+
     def chat(
-        self, 
+        self,
         message: str,
         chat_history: List[Dict[str, str]] = None
     ) -> Dict[str, Any]:
         """
-        与Report Agent对话
-        
-        在对话中Agent可以自主调用检索工具来回答问题
-        
+        Chat with the Report Agent
+
+        During chat the Agent may autonomously invoke retrieval tools to answer questions
+
         Args:
-            message: 用户消息
-            chat_history: 对话历史
-            
+            message: User message
+            chat_history: Conversation history
+
         Returns:
             {
-                "response": "Agent回复",
-                "tool_calls": [调用的工具列表],
-                "sources": [信息来源]
+                "response": "Agent reply",
+                "tool_calls": [list of tool calls made],
+                "sources": [information sources]
             }
         """
         logger.info(t('report.agentChat', message=message[:50]))
-        
+
         chat_history = chat_history or []
-        
-        # 获取已生成的报告内容
+
+        # Fetch the already-generated report content
         report_content = ""
         try:
             report = ReportManager.get_report_by_simulation(self.simulation_id)
             if report and report.markdown_content:
-                # 限制报告长度，避免上下文过长
+                # Limit the report length to avoid an oversized context
                 report_content = report.markdown_content[:15000]
                 if len(report.markdown_content) > 15000:
-                    report_content += "\n\n... [报告内容已截断] ..."
+                    report_content += "\n\n... [Report content truncated] ..."
         except Exception as e:
             logger.warning(t('report.fetchReportFailed', error=e))
-        
+
         system_prompt = CHAT_SYSTEM_PROMPT_TEMPLATE.format(
             simulation_requirement=self.simulation_requirement,
-            report_content=report_content if report_content else "（暂无报告）",
+            report_content=report_content if report_content else "(No report yet)",
             tools_description=self._get_tools_description(),
         )
         system_prompt = f"{system_prompt}\n\n{get_language_instruction()}"
 
-        # 构建消息
+        # Build messages
         messages = [{"role": "system", "content": system_prompt}]
-        
-        # 添加历史对话
-        for h in chat_history[-10:]:  # 限制历史长度
+
+        # Add history
+        for h in chat_history[-10:]:  # Limit history length
             messages.append(h)
-        
-        # 添加用户消息
+
+        # Add the user message
         messages.append({
-            "role": "user", 
+            "role": "user",
             "content": message
         })
-        
-        # ReACT循环（简化版）
+
+        # ReACT loop (simplified version)
         tool_calls_made = []
-        max_iterations = 2  # 减少迭代轮数
-        
+        max_iterations = 2  # Reduced iteration count
+
         for iteration in range(max_iterations):
             response = self.llm.chat(
                 messages=messages,
                 temperature=0.5
             )
-            
-            # 解析工具调用
+
+            # Parse tool calls
             tool_calls = self._parse_tool_calls(response)
-            
+
             if not tool_calls:
-                # 没有工具调用，直接返回响应
+                # No tool call — return the response directly
                 clean_response = re.sub(r'<tool_call>.*?</tool_call>', '', response, flags=re.DOTALL)
                 clean_response = re.sub(r'\[TOOL_CALL\].*?\)', '', clean_response)
-                
+
                 return {
                     "response": clean_response.strip(),
                     "tool_calls": tool_calls_made,
                     "sources": [tc.get("parameters", {}).get("query", "") for tc in tool_calls_made]
                 }
-            
-            # 执行工具调用（限制数量）
+
+            # Execute tool calls (limit the number)
             tool_results = []
-            for call in tool_calls[:1]:  # 每轮最多执行1次工具调用
+            for call in tool_calls[:1]:  # At most one tool call per round
                 if len(tool_calls_made) >= self.MAX_TOOL_CALLS_PER_CHAT:
                     break
                 result = self._execute_tool(call["name"], call.get("parameters", {}))
                 tool_results.append({
                     "tool": call["name"],
-                    "result": result[:1500]  # 限制结果长度
+                    "result": result[:1500]  # Limit result length
                 })
                 tool_calls_made.append(call)
-            
-            # 将结果添加到消息
+
+            # Append the results to the messages
             messages.append({"role": "assistant", "content": response})
-            observation = "\n".join([f"[{r['tool']}结果]\n{r['result']}" for r in tool_results])
+            observation = "\n".join([f"[{r['tool']} result]\n{r['result']}" for r in tool_results])
             messages.append({
                 "role": "user",
                 "content": observation + CHAT_OBSERVATION_SUFFIX
             })
-        
-        # 达到最大迭代，获取最终响应
+
+        # Reached the maximum iterations — get the final response
         final_response = self.llm.chat(
             messages=messages,
             temperature=0.5
         )
-        
-        # 清理响应
+
+        # Clean the response
         clean_response = re.sub(r'<tool_call>.*?</tool_call>', '', final_response, flags=re.DOTALL)
         clean_response = re.sub(r'\[TOOL_CALL\].*?\)', '', clean_response)
-        
+
         return {
             "response": clean_response.strip(),
             "tool_calls": tool_calls_made,
@@ -1883,99 +1883,99 @@ class ReportAgent:
 
 class ReportManager:
     """
-    报告管理器
-    
-    负责报告的持久化存储和检索
-    
-    文件结构（分章节输出）：
+    Report manager
+
+    Responsible for persistence and retrieval of reports
+
+    File structure (per-section output):
     reports/
       {report_id}/
-        meta.json          - 报告元信息和状态
-        outline.json       - 报告大纲
-        progress.json      - 生成进度
-        section_01.md      - 第1章节
-        section_02.md      - 第2章节
+        meta.json          - Report metadata and status
+        outline.json       - Report outline
+        progress.json      - Generation progress
+        section_01.md      - Section 1
+        section_02.md      - Section 2
         ...
-        full_report.md     - 完整报告
+        full_report.md     - Complete report
     """
-    
-    # 报告存储目录
+
+    # Report storage directory
     REPORTS_DIR = os.path.join(Config.UPLOAD_FOLDER, 'reports')
-    
+
     @classmethod
     def _ensure_reports_dir(cls):
-        """确保报告根目录存在"""
+        """Make sure the reports root directory exists"""
         os.makedirs(cls.REPORTS_DIR, exist_ok=True)
-    
+
     @classmethod
     def _get_report_folder(cls, report_id: str) -> str:
-        """获取报告文件夹路径"""
+        """Return the report folder path"""
         return os.path.join(cls.REPORTS_DIR, report_id)
-    
+
     @classmethod
     def _ensure_report_folder(cls, report_id: str) -> str:
-        """确保报告文件夹存在并返回路径"""
+        """Make sure the report folder exists and return its path"""
         folder = cls._get_report_folder(report_id)
         os.makedirs(folder, exist_ok=True)
         return folder
-    
+
     @classmethod
     def _get_report_path(cls, report_id: str) -> str:
-        """获取报告元信息文件路径"""
+        """Return the path to the report metadata file"""
         return os.path.join(cls._get_report_folder(report_id), "meta.json")
-    
+
     @classmethod
     def _get_report_markdown_path(cls, report_id: str) -> str:
-        """获取完整报告Markdown文件路径"""
+        """Return the path to the complete report Markdown file"""
         return os.path.join(cls._get_report_folder(report_id), "full_report.md")
-    
+
     @classmethod
     def _get_outline_path(cls, report_id: str) -> str:
-        """获取大纲文件路径"""
+        """Return the path to the outline file"""
         return os.path.join(cls._get_report_folder(report_id), "outline.json")
-    
+
     @classmethod
     def _get_progress_path(cls, report_id: str) -> str:
-        """获取进度文件路径"""
+        """Return the path to the progress file"""
         return os.path.join(cls._get_report_folder(report_id), "progress.json")
-    
+
     @classmethod
     def _get_section_path(cls, report_id: str, section_index: int) -> str:
-        """获取章节Markdown文件路径"""
+        """Return the path to a section's Markdown file"""
         return os.path.join(cls._get_report_folder(report_id), f"section_{section_index:02d}.md")
-    
+
     @classmethod
     def _get_agent_log_path(cls, report_id: str) -> str:
-        """获取 Agent 日志文件路径"""
+        """Return the path to the Agent log file"""
         return os.path.join(cls._get_report_folder(report_id), "agent_log.jsonl")
-    
+
     @classmethod
     def _get_console_log_path(cls, report_id: str) -> str:
-        """获取控制台日志文件路径"""
+        """Return the path to the console log file"""
         return os.path.join(cls._get_report_folder(report_id), "console_log.txt")
-    
+
     @classmethod
     def get_console_log(cls, report_id: str, from_line: int = 0) -> Dict[str, Any]:
         """
-        获取控制台日志内容
-        
-        这是报告生成过程中的控制台输出日志（INFO、WARNING等），
-        与 agent_log.jsonl 的结构化日志不同。
-        
+        Get the console log content
+
+        This is the console output from report generation (INFO, WARNING, etc.),
+        and is different from the structured agent_log.jsonl.
+
         Args:
-            report_id: 报告ID
-            from_line: 从第几行开始读取（用于增量获取，0 表示从头开始）
-            
+            report_id: Report ID
+            from_line: Line number to start reading from (used for incremental retrieval; 0 means from the beginning)
+
         Returns:
             {
-                "logs": [日志行列表],
-                "total_lines": 总行数,
-                "from_line": 起始行号,
-                "has_more": 是否还有更多日志
+                "logs": [list of log lines],
+                "total_lines": Total number of lines,
+                "from_line": Starting line number,
+                "has_more": Whether there are more logs
             }
         """
         log_path = cls._get_console_log_path(report_id)
-        
+
         if not os.path.exists(log_path):
             return {
                 "logs": [],
@@ -1983,57 +1983,57 @@ class ReportManager:
                 "from_line": 0,
                 "has_more": False
             }
-        
+
         logs = []
         total_lines = 0
-        
+
         with open(log_path, 'r', encoding='utf-8') as f:
             for i, line in enumerate(f):
                 total_lines = i + 1
                 if i >= from_line:
-                    # 保留原始日志行，去掉末尾换行符
+                    # Keep the original log line, stripping the trailing newline
                     logs.append(line.rstrip('\n\r'))
-        
+
         return {
             "logs": logs,
             "total_lines": total_lines,
             "from_line": from_line,
-            "has_more": False  # 已读取到末尾
+            "has_more": False  # Already read to the end
         }
-    
+
     @classmethod
     def get_console_log_stream(cls, report_id: str) -> List[str]:
         """
-        获取完整的控制台日志（一次性获取全部）
-        
+        Get the entire console log at once
+
         Args:
-            report_id: 报告ID
-            
+            report_id: Report ID
+
         Returns:
-            日志行列表
+            List of log lines
         """
         result = cls.get_console_log(report_id, from_line=0)
         return result["logs"]
-    
+
     @classmethod
     def get_agent_log(cls, report_id: str, from_line: int = 0) -> Dict[str, Any]:
         """
-        获取 Agent 日志内容
-        
+        Get the Agent log content
+
         Args:
-            report_id: 报告ID
-            from_line: 从第几行开始读取（用于增量获取，0 表示从头开始）
-            
+            report_id: Report ID
+            from_line: Line number to start reading from (used for incremental retrieval; 0 means from the beginning)
+
         Returns:
             {
-                "logs": [日志条目列表],
-                "total_lines": 总行数,
-                "from_line": 起始行号,
-                "has_more": 是否还有更多日志
+                "logs": [list of log entries],
+                "total_lines": Total number of lines,
+                "from_line": Starting line number,
+                "has_more": Whether there are more logs
             }
         """
         log_path = cls._get_agent_log_path(report_id)
-        
+
         if not os.path.exists(log_path):
             return {
                 "logs": [],
@@ -2041,10 +2041,10 @@ class ReportManager:
                 "from_line": 0,
                 "has_more": False
             }
-        
+
         logs = []
         total_lines = 0
-        
+
         with open(log_path, 'r', encoding='utf-8') as f:
             for i, line in enumerate(f):
                 total_lines = i + 1
@@ -2053,44 +2053,44 @@ class ReportManager:
                         log_entry = json.loads(line.strip())
                         logs.append(log_entry)
                     except json.JSONDecodeError:
-                        # 跳过解析失败的行
+                        # Skip lines that fail to parse
                         continue
-        
+
         return {
             "logs": logs,
             "total_lines": total_lines,
             "from_line": from_line,
-            "has_more": False  # 已读取到末尾
+            "has_more": False  # Already read to the end
         }
-    
+
     @classmethod
     def get_agent_log_stream(cls, report_id: str) -> List[Dict[str, Any]]:
         """
-        获取完整的 Agent 日志（用于一次性获取全部）
-        
+        Get the entire Agent log at once
+
         Args:
-            report_id: 报告ID
-            
+            report_id: Report ID
+
         Returns:
-            日志条目列表
+            List of log entries
         """
         result = cls.get_agent_log(report_id, from_line=0)
         return result["logs"]
-    
+
     @classmethod
     def save_outline(cls, report_id: str, outline: ReportOutline) -> None:
         """
-        保存报告大纲
-        
-        在规划阶段完成后立即调用
+        Save the report outline
+
+        Called immediately after the planning stage completes
         """
         cls._ensure_report_folder(report_id)
-        
+
         with open(cls._get_outline_path(report_id), 'w', encoding='utf-8') as f:
             json.dump(outline.to_dict(), f, ensure_ascii=False, indent=2)
-        
+
         logger.info(t('report.outlineSaved', reportId=report_id))
-    
+
     @classmethod
     def save_section(
         cls,
@@ -2099,27 +2099,27 @@ class ReportManager:
         section: ReportSection
     ) -> str:
         """
-        保存单个章节
+        Save a single section
 
-        在每个章节生成完成后立即调用，实现分章节输出
+        Called immediately after each section finishes generating, enabling per-section streaming output
 
         Args:
-            report_id: 报告ID
-            section_index: 章节索引（从1开始）
-            section: 章节对象
+            report_id: Report ID
+            section_index: Section index (starts at 1)
+            section: Section object
 
         Returns:
-            保存的文件路径
+            Path to the saved file
         """
         cls._ensure_report_folder(report_id)
 
-        # 构建章节Markdown内容 - 清理可能存在的重复标题
+        # Build the section's Markdown content - clean any duplicated headings
         cleaned_content = cls._clean_section_content(section.content, section.title)
         md_content = f"## {section.title}\n\n"
         if cleaned_content:
             md_content += f"{cleaned_content}\n\n"
 
-        # 保存文件
+        # Save the file
         file_suffix = f"section_{section_index:02d}.md"
         file_path = os.path.join(cls._get_report_folder(report_id), file_suffix)
         with open(file_path, 'w', encoding='utf-8') as f:
@@ -2127,92 +2127,92 @@ class ReportManager:
 
         logger.info(t('report.sectionFileSaved', reportId=report_id, fileSuffix=file_suffix))
         return file_path
-    
+
     @classmethod
     def _clean_section_content(cls, content: str, section_title: str) -> str:
         """
-        清理章节内容
-        
-        1. 移除内容开头与章节标题重复的Markdown标题行
-        2. 将所有 ### 及以下级别的标题转换为粗体文本
-        
+        Clean up section content
+
+        1. Remove a Markdown heading line at the beginning that duplicates the section title
+        2. Convert all level-### or lower headings to bold text
+
         Args:
-            content: 原始内容
-            section_title: 章节标题
-            
+            content: Original content
+            section_title: Section title
+
         Returns:
-            清理后的内容
+            Cleaned content
         """
         import re
-        
+
         if not content:
             return content
-        
+
         content = content.strip()
         lines = content.split('\n')
         cleaned_lines = []
         skip_next_empty = False
-        
+
         for i, line in enumerate(lines):
             stripped = line.strip()
-            
-            # 检查是否是Markdown标题行
+
+            # Check whether this is a Markdown heading line
             heading_match = re.match(r'^(#{1,6})\s+(.+)$', stripped)
-            
+
             if heading_match:
                 level = len(heading_match.group(1))
                 title_text = heading_match.group(2).strip()
-                
-                # 检查是否是与章节标题重复的标题（跳过前5行内的重复）
+
+                # Check whether this is a heading duplicating the section title (only within the first 5 lines)
                 if i < 5:
                     if title_text == section_title or title_text.replace(' ', '') == section_title.replace(' ', ''):
                         skip_next_empty = True
                         continue
-                
-                # 将所有级别的标题（#, ##, ###, ####等）转换为粗体
-                # 因为章节标题由系统添加，内容中不应有任何标题
+
+                # Convert headings of any level (#, ##, ###, ####, etc.) to bold
+                # because the section title is added by the system; the content should not contain any heading
                 cleaned_lines.append(f"**{title_text}**")
-                cleaned_lines.append("")  # 添加空行
+                cleaned_lines.append("")  # Add a blank line
                 continue
-            
-            # 如果上一行是被跳过的标题，且当前行为空，也跳过
+
+            # If the previous line was a skipped heading and the current line is empty, skip it as well
             if skip_next_empty and stripped == '':
                 skip_next_empty = False
                 continue
-            
+
             skip_next_empty = False
             cleaned_lines.append(line)
-        
-        # 移除开头的空行
+
+        # Remove leading blank lines
         while cleaned_lines and cleaned_lines[0].strip() == '':
             cleaned_lines.pop(0)
-        
-        # 移除开头的分隔线
+
+        # Remove leading horizontal-rule lines
         while cleaned_lines and cleaned_lines[0].strip() in ['---', '***', '___']:
             cleaned_lines.pop(0)
-            # 同时移除分隔线后的空行
+            # Also remove blank lines that follow the horizontal rule
             while cleaned_lines and cleaned_lines[0].strip() == '':
                 cleaned_lines.pop(0)
-        
+
         return '\n'.join(cleaned_lines)
-    
+
     @classmethod
     def update_progress(
-        cls, 
-        report_id: str, 
-        status: str, 
-        progress: int, 
+        cls,
+        report_id: str,
+        status: str,
+        progress: int,
         message: str,
         current_section: str = None,
         completed_sections: List[str] = None
     ) -> None:
         """
-        更新报告生成进度
-        
-        前端可以通过读取progress.json获取实时进度
+        Update report generation progress
+
+        The frontend can read progress.json to obtain real-time progress
         """
         cls._ensure_report_folder(report_id)
-        
+
         progress_data = {
             "status": status,
             "progress": progress,
@@ -2221,33 +2221,33 @@ class ReportManager:
             "completed_sections": completed_sections or [],
             "updated_at": datetime.now().isoformat()
         }
-        
+
         with open(cls._get_progress_path(report_id), 'w', encoding='utf-8') as f:
             json.dump(progress_data, f, ensure_ascii=False, indent=2)
-    
+
     @classmethod
     def get_progress(cls, report_id: str) -> Optional[Dict[str, Any]]:
-        """获取报告生成进度"""
+        """Get report generation progress"""
         path = cls._get_progress_path(report_id)
-        
+
         if not os.path.exists(path):
             return None
-        
+
         with open(path, 'r', encoding='utf-8') as f:
             return json.load(f)
-    
+
     @classmethod
     def get_generated_sections(cls, report_id: str) -> List[Dict[str, Any]]:
         """
-        获取已生成的章节列表
-        
-        返回所有已保存的章节文件信息
+        Get the list of generated sections
+
+        Returns information for all already-saved section files
         """
         folder = cls._get_report_folder(report_id)
-        
+
         if not os.path.exists(folder):
             return []
-        
+
         sections = []
         for filename in sorted(os.listdir(folder)):
             if filename.startswith('section_') and filename.endswith('.md'):
@@ -2255,7 +2255,7 @@ class ReportManager:
                 with open(file_path, 'r', encoding='utf-8') as f:
                     content = f.read()
 
-                # 从文件名解析章节索引
+                # Parse the section index from the filename
                 parts = filename.replace('.md', '').split('_')
                 section_index = int(parts[1])
 
@@ -2266,77 +2266,77 @@ class ReportManager:
                 })
 
         return sections
-    
+
     @classmethod
     def assemble_full_report(cls, report_id: str, outline: ReportOutline) -> str:
         """
-        组装完整报告
-        
-        从已保存的章节文件组装完整报告，并进行标题清理
+        Assemble the complete report
+
+        Build the full report from already-saved section files and clean up headings
         """
         folder = cls._get_report_folder(report_id)
-        
-        # 构建报告头部
+
+        # Build the report header
         md_content = f"# {outline.title}\n\n"
         md_content += f"> {outline.summary}\n\n"
         md_content += f"---\n\n"
-        
-        # 按顺序读取所有章节文件
+
+        # Read all section files in order
         sections = cls.get_generated_sections(report_id)
         for section_info in sections:
             md_content += section_info["content"]
-        
-        # 后处理：清理整个报告的标题问题
+
+        # Post-processing: clean up heading issues across the whole report
         md_content = cls._post_process_report(md_content, outline)
-        
-        # 保存完整报告
+
+        # Save the complete report
         full_path = cls._get_report_markdown_path(report_id)
         with open(full_path, 'w', encoding='utf-8') as f:
             f.write(md_content)
-        
+
         logger.info(t('report.fullReportAssembled', reportId=report_id))
         return md_content
-    
+
     @classmethod
     def _post_process_report(cls, content: str, outline: ReportOutline) -> str:
         """
-        后处理报告内容
-        
-        1. 移除重复的标题
-        2. 保留报告主标题(#)和章节标题(##)，移除其他级别的标题(###, ####等)
-        3. 清理多余的空行和分隔线
-        
+        Post-process the report content
+
+        1. Remove duplicate headings
+        2. Keep the report main title (#) and section titles (##), remove other heading levels (###, ####, etc.)
+        3. Clean up extra blank lines and horizontal rules
+
         Args:
-            content: 原始报告内容
-            outline: 报告大纲
-            
+            content: Original report content
+            outline: Report outline
+
         Returns:
-            处理后的内容
+            Processed content
         """
         import re
-        
+
         lines = content.split('\n')
         processed_lines = []
         prev_was_heading = False
-        
-        # 收集大纲中的所有章节标题
+
+        # Collect all section titles from the outline
         section_titles = set()
         for section in outline.sections:
             section_titles.add(section.title)
-        
+
         i = 0
         while i < len(lines):
             line = lines[i]
             stripped = line.strip()
-            
-            # 检查是否是标题行
+
+            # Check whether this is a heading line
             heading_match = re.match(r'^(#{1,6})\s+(.+)$', stripped)
-            
+
             if heading_match:
                 level = len(heading_match.group(1))
                 title = heading_match.group(2).strip()
-                
-                # 检查是否是重复标题（在连续5行内出现相同内容的标题）
+
+                # Check whether it is a duplicate heading (the same heading text appearing in the previous 5 lines)
                 is_duplicate = False
                 for j in range(max(0, len(processed_lines) - 5), len(processed_lines)):
                     prev_line = processed_lines[j].strip()
@@ -2346,70 +2346,70 @@ class ReportManager:
                         if prev_title == title:
                             is_duplicate = True
                             break
-                
+
                 if is_duplicate:
-                    # 跳过重复标题及其后的空行
+                    # Skip the duplicate heading and any blank lines that follow
                     i += 1
                     while i < len(lines) and lines[i].strip() == '':
                         i += 1
                     continue
-                
-                # 标题层级处理：
-                # - # (level=1) 只保留报告主标题
-                # - ## (level=2) 保留章节标题
-                # - ### 及以下 (level>=3) 转换为粗体文本
-                
+
+                # Heading-level handling:
+                # - # (level=1) only the report main title is kept
+                # - ## (level=2) section titles are kept
+                # - ### and below (level>=3) are converted to bold text
+
                 if level == 1:
                     if title == outline.title:
-                        # 保留报告主标题
+                        # Keep the report main title
                         processed_lines.append(line)
                         prev_was_heading = True
                     elif title in section_titles:
-                        # 章节标题错误使用了#，修正为##
+                        # A section title incorrectly used #; correct it to ##
                         processed_lines.append(f"## {title}")
                         prev_was_heading = True
                     else:
-                        # 其他一级标题转为粗体
+                        # Other level-1 headings are converted to bold
                         processed_lines.append(f"**{title}**")
                         processed_lines.append("")
                         prev_was_heading = False
                 elif level == 2:
                     if title in section_titles or title == outline.title:
-                        # 保留章节标题
+                        # Keep the section title
                         processed_lines.append(line)
                         prev_was_heading = True
                     else:
-                        # 非章节的二级标题转为粗体
+                        # Non-section level-2 headings are converted to bold
                         processed_lines.append(f"**{title}**")
                         processed_lines.append("")
                         prev_was_heading = False
                 else:
-                    # ### 及以下级别的标题转换为粗体文本
+                    # Headings at level ### and below are converted to bold text
                     processed_lines.append(f"**{title}**")
                     processed_lines.append("")
                     prev_was_heading = False
-                
+
                 i += 1
                 continue
-            
+
             elif stripped == '---' and prev_was_heading:
-                # 跳过标题后紧跟的分隔线
+                # Skip a horizontal rule that immediately follows a heading
                 i += 1
                 continue
-            
+
             elif stripped == '' and prev_was_heading:
-                # 标题后只保留一个空行
+                # Keep only one blank line after a heading
                 if processed_lines and processed_lines[-1].strip() != '':
                     processed_lines.append(line)
                 prev_was_heading = False
-            
+
             else:
                 processed_lines.append(line)
                 prev_was_heading = False
-            
+
             i += 1
-        
-        # 清理连续的多个空行（保留最多2个）
+
+        # Collapse runs of multiple blank lines (keep at most 2)
         result_lines = []
         empty_count = 0
         for line in processed_lines:
@@ -2420,46 +2420,46 @@ class ReportManager:
             else:
                 empty_count = 0
                 result_lines.append(line)
-        
+
         return '\n'.join(result_lines)
-    
+
     @classmethod
     def save_report(cls, report: Report) -> None:
-        """保存报告元信息和完整报告"""
+        """Save report metadata and the complete report"""
         cls._ensure_report_folder(report.report_id)
-        
-        # 保存元信息JSON
+
+        # Save metadata JSON
         with open(cls._get_report_path(report.report_id), 'w', encoding='utf-8') as f:
             json.dump(report.to_dict(), f, ensure_ascii=False, indent=2)
-        
-        # 保存大纲
+
+        # Save the outline
         if report.outline:
             cls.save_outline(report.report_id, report.outline)
-        
-        # 保存完整Markdown报告
+
+        # Save the complete Markdown report
         if report.markdown_content:
             with open(cls._get_report_markdown_path(report.report_id), 'w', encoding='utf-8') as f:
                 f.write(report.markdown_content)
-        
+
         logger.info(t('report.reportSaved', reportId=report.report_id))
-    
+
     @classmethod
     def get_report(cls, report_id: str) -> Optional[Report]:
-        """获取报告"""
+        """Get a report"""
         path = cls._get_report_path(report_id)
-        
+
         if not os.path.exists(path):
-            # 兼容旧格式：检查直接存储在reports目录下的文件
+            # Backward compatibility: check for files stored directly under the reports directory
             old_path = os.path.join(cls.REPORTS_DIR, f"{report_id}.json")
             if os.path.exists(old_path):
                 path = old_path
             else:
                 return None
-        
+
         with open(path, 'r', encoding='utf-8') as f:
             data = json.load(f)
-        
-        # 重建Report对象
+
+        # Rebuild the Report object
         outline = None
         if data.get('outline'):
             outline_data = data['outline']
@@ -2474,15 +2474,15 @@ class ReportManager:
                 summary=outline_data['summary'],
                 sections=sections
             )
-        
-        # 如果markdown_content为空，尝试从full_report.md读取
+
+        # If markdown_content is empty, try to read it from full_report.md
         markdown_content = data.get('markdown_content', '')
         if not markdown_content:
             full_report_path = cls._get_report_markdown_path(report_id)
             if os.path.exists(full_report_path):
                 with open(full_report_path, 'r', encoding='utf-8') as f:
                     markdown_content = f.read()
-        
+
         return Report(
             report_id=data['report_id'],
             simulation_id=data['simulation_id'],
@@ -2495,78 +2495,78 @@ class ReportManager:
             completed_at=data.get('completed_at', ''),
             error=data.get('error')
         )
-    
+
     @classmethod
     def get_report_by_simulation(cls, simulation_id: str) -> Optional[Report]:
-        """根据模拟ID获取报告"""
+        """Get a report by simulation ID"""
         cls._ensure_reports_dir()
-        
+
         for item in os.listdir(cls.REPORTS_DIR):
             item_path = os.path.join(cls.REPORTS_DIR, item)
-            # 新格式：文件夹
+            # New format: a folder
             if os.path.isdir(item_path):
                 report = cls.get_report(item)
                 if report and report.simulation_id == simulation_id:
                     return report
-            # 兼容旧格式：JSON文件
+            # Backward compatibility: a JSON file
             elif item.endswith('.json'):
                 report_id = item[:-5]
                 report = cls.get_report(report_id)
                 if report and report.simulation_id == simulation_id:
                     return report
-        
+
         return None
-    
+
     @classmethod
     def list_reports(cls, simulation_id: Optional[str] = None, limit: int = 50) -> List[Report]:
-        """列出报告"""
+        """List reports"""
         cls._ensure_reports_dir()
-        
+
         reports = []
         for item in os.listdir(cls.REPORTS_DIR):
             item_path = os.path.join(cls.REPORTS_DIR, item)
-            # 新格式：文件夹
+            # New format: a folder
             if os.path.isdir(item_path):
                 report = cls.get_report(item)
                 if report:
                     if simulation_id is None or report.simulation_id == simulation_id:
                         reports.append(report)
-            # 兼容旧格式：JSON文件
+            # Backward compatibility: a JSON file
             elif item.endswith('.json'):
                 report_id = item[:-5]
                 report = cls.get_report(report_id)
                 if report:
                     if simulation_id is None or report.simulation_id == simulation_id:
                         reports.append(report)
-        
-        # 按创建时间倒序
+
+        # Sort in descending order by creation time
         reports.sort(key=lambda r: r.created_at, reverse=True)
-        
+
         return reports[:limit]
-    
+
     @classmethod
     def delete_report(cls, report_id: str) -> bool:
-        """删除报告（整个文件夹）"""
+        """Delete a report (the entire folder)"""
         import shutil
-        
+
         folder_path = cls._get_report_folder(report_id)
-        
-        # 新格式：删除整个文件夹
+
+        # New format: delete the entire folder
         if os.path.exists(folder_path) and os.path.isdir(folder_path):
             shutil.rmtree(folder_path)
             logger.info(t('report.reportFolderDeleted', reportId=report_id))
             return True
-        
-        # 兼容旧格式：删除单独的文件
+
+        # Backward compatibility: delete the standalone files
         deleted = False
         old_json_path = os.path.join(cls.REPORTS_DIR, f"{report_id}.json")
         old_md_path = os.path.join(cls.REPORTS_DIR, f"{report_id}.md")
-        
+
         if os.path.exists(old_json_path):
             os.remove(old_json_path)
             deleted = True
         if os.path.exists(old_md_path):
             os.remove(old_md_path)
             deleted = True
-        
+
         return deleted

--- a/backend/app/services/simulation_config_generator.py
+++ b/backend/app/services/simulation_config_generator.py
@@ -1,13 +1,15 @@
 """
-模拟配置智能生成器
-使用LLM根据模拟需求、文档内容、图谱信息自动生成细致的模拟参数
-实现全程自动化，无需人工设置参数
+Intelligent simulation configuration generator
+Uses an LLM to automatically produce a fine-grained simulation parameter set from the
+simulation requirement, document content, and graph information. The goal is full
+automation, with no manual parameter tweaking.
 
-采用分步生成策略，避免一次性生成过长内容导致失败：
-1. 生成时间配置
-2. 生成事件配置
-3. 分批生成Agent配置
-4. 生成平台配置
+A step-by-step generation strategy is used to avoid failures caused by producing too
+much content in a single call:
+1. Generate the time configuration
+2. Generate the event configuration
+3. Generate agent configurations in batches
+4. Generate the platform configurations
 """
 
 import json
@@ -25,156 +27,156 @@ from .zep_entity_reader import EntityNode, ZepEntityReader
 
 logger = get_logger('mirofish.simulation_config')
 
-# 中国作息时间配置（北京时间）
+# China daily-schedule configuration (Beijing time)
 CHINA_TIMEZONE_CONFIG = {
-    # 深夜时段（几乎无人活动）
+    # Late-night window (almost no activity)
     "dead_hours": [0, 1, 2, 3, 4, 5],
-    # 早间时段（逐渐醒来）
+    # Morning window (people gradually wake up)
     "morning_hours": [6, 7, 8],
-    # 工作时段
+    # Working hours
     "work_hours": [9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
-    # 晚间高峰（最活跃）
+    # Evening peak (most active)
     "peak_hours": [19, 20, 21, 22],
-    # 夜间时段（活跃度下降）
+    # Late-evening window (activity declines)
     "night_hours": [23],
-    # 活跃度系数
+    # Activity multipliers
     "activity_multipliers": {
-        "dead": 0.05,      # 凌晨几乎无人
-        "morning": 0.4,    # 早间逐渐活跃
-        "work": 0.7,       # 工作时段中等
-        "peak": 1.5,       # 晚间高峰
-        "night": 0.5       # 深夜下降
+        "dead": 0.05,      # Almost nobody around in the small hours
+        "morning": 0.4,    # Activity ramps up in the morning
+        "work": 0.7,       # Moderate during working hours
+        "peak": 1.5,       # Evening peak
+        "night": 0.5       # Declines late at night
     }
 }
 
 
 @dataclass
 class AgentActivityConfig:
-    """单个Agent的活动配置"""
+    """Activity configuration for a single agent"""
     agent_id: int
     entity_uuid: str
     entity_name: str
     entity_type: str
-    
-    # 活跃度配置 (0.0-1.0)
-    activity_level: float = 0.5  # 整体活跃度
-    
-    # 发言频率（每小时预期发言次数）
+
+    # Activity-level configuration (0.0-1.0)
+    activity_level: float = 0.5  # Overall activity level
+
+    # Posting frequency (expected posts per hour)
     posts_per_hour: float = 1.0
     comments_per_hour: float = 2.0
-    
-    # 活跃时间段（24小时制，0-23）
+
+    # Active hours (24-hour clock, 0-23)
     active_hours: List[int] = field(default_factory=lambda: list(range(8, 23)))
-    
-    # 响应速度（对热点事件的反应延迟，单位：模拟分钟）
+
+    # Response speed (delay reacting to hot events, in simulated minutes)
     response_delay_min: int = 5
     response_delay_max: int = 60
-    
-    # 情感倾向 (-1.0到1.0，负面到正面)
+
+    # Sentiment bias (-1.0 to 1.0, negative to positive)
     sentiment_bias: float = 0.0
-    
-    # 立场（对特定话题的态度）
+
+    # Stance (attitude toward a specific topic)
     stance: str = "neutral"  # supportive, opposing, neutral, observer
-    
-    # 影响力权重（决定其发言被其他Agent看到的概率）
+
+    # Influence weight (probability that this agent's posts are seen by other agents)
     influence_weight: float = 1.0
 
 
-@dataclass  
+@dataclass
 class TimeSimulationConfig:
-    """时间模拟配置（基于中国人作息习惯）"""
-    # 模拟总时长（模拟小时数）
-    total_simulation_hours: int = 72  # 默认模拟72小时（3天）
-    
-    # 每轮代表的时间（模拟分钟）- 默认60分钟（1小时），加快时间流速
+    """Time-simulation configuration (based on Chinese daily-schedule habits)"""
+    # Total simulated duration (in simulated hours)
+    total_simulation_hours: int = 72  # Defaults to 72 simulated hours (3 days)
+
+    # Time represented per round (simulated minutes) - default 60 minutes (1 hour) for faster time progression
     minutes_per_round: int = 60
-    
-    # 每小时激活的Agent数量范围
+
+    # Range of agents activated per hour
     agents_per_hour_min: int = 5
     agents_per_hour_max: int = 20
-    
-    # 高峰时段（晚间19-22点，中国人最活跃的时间）
+
+    # Peak hours (19:00-22:00 evening, the most active time for Chinese users)
     peak_hours: List[int] = field(default_factory=lambda: [19, 20, 21, 22])
     peak_activity_multiplier: float = 1.5
-    
-    # 低谷时段（凌晨0-5点，几乎无人活动）
+
+    # Off-peak hours (00:00-05:00, almost no activity)
     off_peak_hours: List[int] = field(default_factory=lambda: [0, 1, 2, 3, 4, 5])
-    off_peak_activity_multiplier: float = 0.05  # 凌晨活跃度极低
-    
-    # 早间时段
+    off_peak_activity_multiplier: float = 0.05  # Activity is extremely low overnight
+
+    # Morning window
     morning_hours: List[int] = field(default_factory=lambda: [6, 7, 8])
     morning_activity_multiplier: float = 0.4
-    
-    # 工作时段
+
+    # Working hours
     work_hours: List[int] = field(default_factory=lambda: [9, 10, 11, 12, 13, 14, 15, 16, 17, 18])
     work_activity_multiplier: float = 0.7
 
 
 @dataclass
 class EventConfig:
-    """事件配置"""
-    # 初始事件（模拟开始时的触发事件）
+    """Event configuration"""
+    # Initial events (triggers fired when the simulation starts)
     initial_posts: List[Dict[str, Any]] = field(default_factory=list)
-    
-    # 定时事件（在特定时间触发的事件）
+
+    # Scheduled events (events triggered at specific times)
     scheduled_events: List[Dict[str, Any]] = field(default_factory=list)
-    
-    # 热点话题关键词
+
+    # Hot-topic keywords
     hot_topics: List[str] = field(default_factory=list)
-    
-    # 舆论引导方向
+
+    # Narrative steering direction
     narrative_direction: str = ""
 
 
 @dataclass
 class PlatformConfig:
-    """平台特定配置"""
+    """Platform-specific configuration"""
     platform: str  # twitter or reddit
-    
-    # 推荐算法权重
-    recency_weight: float = 0.4  # 时间新鲜度
-    popularity_weight: float = 0.3  # 热度
-    relevance_weight: float = 0.3  # 相关性
-    
-    # 病毒传播阈值（达到多少互动后触发扩散）
+
+    # Recommendation algorithm weights
+    recency_weight: float = 0.4  # Time recency
+    popularity_weight: float = 0.3  # Popularity
+    relevance_weight: float = 0.3  # Relevance
+
+    # Viral spread threshold (number of interactions required to trigger diffusion)
     viral_threshold: int = 10
-    
-    # 回声室效应强度（相似观点聚集程度）
+
+    # Echo-chamber strength (how strongly similar opinions cluster)
     echo_chamber_strength: float = 0.5
 
 
 @dataclass
 class SimulationParameters:
-    """完整的模拟参数配置"""
-    # 基础信息
+    """Complete simulation parameter configuration"""
+    # Basic info
     simulation_id: str
     project_id: str
     graph_id: str
     simulation_requirement: str
-    
-    # 时间配置
+
+    # Time configuration
     time_config: TimeSimulationConfig = field(default_factory=TimeSimulationConfig)
-    
-    # Agent配置列表
+
+    # List of agent configurations
     agent_configs: List[AgentActivityConfig] = field(default_factory=list)
-    
-    # 事件配置
+
+    # Event configuration
     event_config: EventConfig = field(default_factory=EventConfig)
-    
-    # 平台配置
+
+    # Platform configurations
     twitter_config: Optional[PlatformConfig] = None
     reddit_config: Optional[PlatformConfig] = None
-    
-    # LLM配置
+
+    # LLM configuration
     llm_model: str = ""
     llm_base_url: str = ""
-    
-    # 生成元数据
+
+    # Generation metadata
     generated_at: str = field(default_factory=lambda: datetime.now().isoformat())
-    generation_reasoning: str = ""  # LLM的推理说明
-    
+    generation_reasoning: str = ""  # The LLM's reasoning notes
+
     def to_dict(self) -> Dict[str, Any]:
-        """转换为字典"""
+        """Convert to dict"""
         time_dict = asdict(self.time_config)
         return {
             "simulation_id": self.simulation_id,
@@ -191,37 +193,37 @@ class SimulationParameters:
             "generated_at": self.generated_at,
             "generation_reasoning": self.generation_reasoning,
         }
-    
+
     def to_json(self, indent: int = 2) -> str:
-        """转换为JSON字符串"""
+        """Convert to a JSON string"""
         return json.dumps(self.to_dict(), ensure_ascii=False, indent=indent)
 
 
 class SimulationConfigGenerator:
     """
-    模拟配置智能生成器
-    
-    使用LLM分析模拟需求、文档内容、图谱实体信息，
-    自动生成最佳的模拟参数配置
-    
-    采用分步生成策略：
-    1. 生成时间配置和事件配置（轻量级）
-    2. 分批生成Agent配置（每批10-20个）
-    3. 生成平台配置
+    Intelligent simulation configuration generator
+
+    Uses an LLM to analyze the simulation requirement, document content, and graph
+    entity information, and automatically produce an optimal simulation parameter set.
+
+    Step-by-step generation strategy:
+    1. Generate the time configuration and event configuration (lightweight)
+    2. Generate agent configurations in batches (10-20 per batch)
+    3. Generate the platform configurations
     """
-    
-    # 上下文最大字符数
+
+    # Maximum context character count
     MAX_CONTEXT_LENGTH = 50000
-    # 每批生成的Agent数量
+    # Number of agents generated per batch
     AGENTS_PER_BATCH = 15
-    
-    # 各步骤的上下文截断长度（字符数）
-    TIME_CONFIG_CONTEXT_LENGTH = 10000   # 时间配置
-    EVENT_CONFIG_CONTEXT_LENGTH = 8000   # 事件配置
-    ENTITY_SUMMARY_LENGTH = 300          # 实体摘要
-    AGENT_SUMMARY_LENGTH = 300           # Agent配置中的实体摘要
-    ENTITIES_PER_TYPE_DISPLAY = 20       # 每类实体显示数量
-    
+
+    # Per-step context truncation lengths (character counts)
+    TIME_CONFIG_CONTEXT_LENGTH = 10000   # Time configuration
+    EVENT_CONFIG_CONTEXT_LENGTH = 8000   # Event configuration
+    ENTITY_SUMMARY_LENGTH = 300          # Entity summary
+    AGENT_SUMMARY_LENGTH = 300           # Entity summary inside agent configuration
+    ENTITIES_PER_TYPE_DISPLAY = 20       # Number of entities displayed per type
+
     def __init__(
         self,
         api_key: Optional[str] = None,
@@ -231,15 +233,15 @@ class SimulationConfigGenerator:
         self.api_key = api_key or Config.LLM_API_KEY
         self.base_url = base_url or Config.LLM_BASE_URL
         self.model_name = model_name or Config.LLM_MODEL_NAME
-        
+
         if not self.api_key:
-            raise ValueError("LLM_API_KEY 未配置")
-        
+            raise ValueError("LLM_API_KEY is not configured")
+
         self.client = OpenAI(
             api_key=self.api_key,
             base_url=self.base_url
         )
-    
+
     def generate_config(
         self,
         simulation_id: str,
@@ -253,70 +255,70 @@ class SimulationConfigGenerator:
         progress_callback: Optional[Callable[[int, int, str], None]] = None,
     ) -> SimulationParameters:
         """
-        智能生成完整的模拟配置（分步生成）
-        
+        Intelligently generate the full simulation configuration (step by step).
+
         Args:
-            simulation_id: 模拟ID
-            project_id: 项目ID
-            graph_id: 图谱ID
-            simulation_requirement: 模拟需求描述
-            document_text: 原始文档内容
-            entities: 过滤后的实体列表
-            enable_twitter: 是否启用Twitter
-            enable_reddit: 是否启用Reddit
-            progress_callback: 进度回调函数(current_step, total_steps, message)
-            
+            simulation_id: Simulation ID
+            project_id: Project ID
+            graph_id: Graph ID
+            simulation_requirement: Simulation requirement description
+            document_text: Original document content
+            entities: Filtered entity list
+            enable_twitter: Whether to enable Twitter
+            enable_reddit: Whether to enable Reddit
+            progress_callback: Progress callback function (current_step, total_steps, message)
+
         Returns:
-            SimulationParameters: 完整的模拟参数
+            SimulationParameters: complete simulation parameters
         """
-        logger.info(f"开始智能生成模拟配置: simulation_id={simulation_id}, 实体数={len(entities)}")
-        
-        # 计算总步骤数
+        logger.info(f"Starting intelligent simulation configuration generation: simulation_id={simulation_id}, entity count={len(entities)}")
+
+        # Compute the total number of steps
         num_batches = math.ceil(len(entities) / self.AGENTS_PER_BATCH)
-        total_steps = 3 + num_batches  # 时间配置 + 事件配置 + N批Agent + 平台配置
+        total_steps = 3 + num_batches  # Time config + event config + N agent batches + platform config
         current_step = 0
-        
+
         def report_progress(step: int, message: str):
             nonlocal current_step
             current_step = step
             if progress_callback:
                 progress_callback(step, total_steps, message)
             logger.info(f"[{step}/{total_steps}] {message}")
-        
-        # 1. 构建基础上下文信息
+
+        # 1. Build the basic context
         context = self._build_context(
             simulation_requirement=simulation_requirement,
             document_text=document_text,
             entities=entities
         )
-        
+
         reasoning_parts = []
-        
-        # ========== 步骤1: 生成时间配置 ==========
+
+        # ========== Step 1: Generate time configuration ==========
         report_progress(1, t('progress.generatingTimeConfig'))
         num_entities = len(entities)
         time_config_result = self._generate_time_config(context, num_entities)
         time_config = self._parse_time_config(time_config_result, num_entities)
         reasoning_parts.append(f"{t('progress.timeConfigLabel')}: {time_config_result.get('reasoning', t('common.success'))}")
-        
-        # ========== 步骤2: 生成事件配置 ==========
+
+        # ========== Step 2: Generate event configuration ==========
         report_progress(2, t('progress.generatingEventConfig'))
         event_config_result = self._generate_event_config(context, simulation_requirement, entities)
         event_config = self._parse_event_config(event_config_result)
         reasoning_parts.append(f"{t('progress.eventConfigLabel')}: {event_config_result.get('reasoning', t('common.success'))}")
-        
-        # ========== 步骤3-N: 分批生成Agent配置 ==========
+
+        # ========== Steps 3-N: Generate agent configurations in batches ==========
         all_agent_configs = []
         for batch_idx in range(num_batches):
             start_idx = batch_idx * self.AGENTS_PER_BATCH
             end_idx = min(start_idx + self.AGENTS_PER_BATCH, len(entities))
             batch_entities = entities[start_idx:end_idx]
-            
+
             report_progress(
                 3 + batch_idx,
                 t('progress.generatingAgentConfig', start=start_idx + 1, end=end_idx, total=len(entities))
             )
-            
+
             batch_configs = self._generate_agent_configs_batch(
                 context=context,
                 entities=batch_entities,
@@ -324,20 +326,20 @@ class SimulationConfigGenerator:
                 simulation_requirement=simulation_requirement
             )
             all_agent_configs.extend(batch_configs)
-        
+
         reasoning_parts.append(t('progress.agentConfigResult', count=len(all_agent_configs)))
-        
-        # ========== 为初始帖子分配发布者 Agent ==========
-        logger.info("为初始帖子分配合适的发布者 Agent...")
+
+        # ========== Assign poster agents to initial posts ==========
+        logger.info("Assigning suitable poster agents to initial posts...")
         event_config = self._assign_initial_post_agents(event_config, all_agent_configs)
         assigned_count = len([p for p in event_config.initial_posts if p.get("poster_agent_id") is not None])
         reasoning_parts.append(t('progress.postAssignResult', count=assigned_count))
-        
-        # ========== 最后一步: 生成平台配置 ==========
+
+        # ========== Final step: Generate platform configurations ==========
         report_progress(total_steps, t('progress.generatingPlatformConfig'))
         twitter_config = None
         reddit_config = None
-        
+
         if enable_twitter:
             twitter_config = PlatformConfig(
                 platform="twitter",
@@ -347,7 +349,7 @@ class SimulationConfigGenerator:
                 viral_threshold=10,
                 echo_chamber_strength=0.5
             )
-        
+
         if enable_reddit:
             reddit_config = PlatformConfig(
                 platform="reddit",
@@ -357,8 +359,8 @@ class SimulationConfigGenerator:
                 viral_threshold=15,
                 echo_chamber_strength=0.6
             )
-        
-        # 构建最终参数
+
+        # Build the final parameters
         params = SimulationParameters(
             simulation_id=simulation_id,
             project_id=project_id,
@@ -373,71 +375,71 @@ class SimulationConfigGenerator:
             llm_base_url=self.base_url,
             generation_reasoning=" | ".join(reasoning_parts)
         )
-        
-        logger.info(f"模拟配置生成完成: {len(params.agent_configs)} 个Agent配置")
-        
+
+        logger.info(f"Simulation configuration generation complete: {len(params.agent_configs)} agent configurations")
+
         return params
-    
+
     def _build_context(
         self,
         simulation_requirement: str,
         document_text: str,
         entities: List[EntityNode]
     ) -> str:
-        """构建LLM上下文，截断到最大长度"""
-        
-        # 实体摘要
+        """Build the LLM context, truncating to the maximum length"""
+
+        # Entity summary
         entity_summary = self._summarize_entities(entities)
-        
-        # 构建上下文
+
+        # Build the context
         context_parts = [
-            f"## 模拟需求\n{simulation_requirement}",
-            f"\n## 实体信息 ({len(entities)}个)\n{entity_summary}",
+            f"## Simulation Requirement\n{simulation_requirement}",
+            f"\n## Entity Information ({len(entities)} entities)\n{entity_summary}",
         ]
-        
+
         current_length = sum(len(p) for p in context_parts)
-        remaining_length = self.MAX_CONTEXT_LENGTH - current_length - 500  # 留500字符余量
-        
+        remaining_length = self.MAX_CONTEXT_LENGTH - current_length - 500  # Leave a 500-character margin
+
         if remaining_length > 0 and document_text:
             doc_text = document_text[:remaining_length]
             if len(document_text) > remaining_length:
-                doc_text += "\n...(文档已截断)"
-            context_parts.append(f"\n## 原始文档内容\n{doc_text}")
-        
+                doc_text += "\n...(document truncated)"
+            context_parts.append(f"\n## Original Document Content\n{doc_text}")
+
         return "\n".join(context_parts)
-    
+
     def _summarize_entities(self, entities: List[EntityNode]) -> str:
-        """生成实体摘要"""
+        """Generate the entity summary"""
         lines = []
-        
-        # 按类型分组
+
+        # Group by type
         by_type: Dict[str, List[EntityNode]] = {}
         for e in entities:
             t = e.get_entity_type() or "Unknown"
             if t not in by_type:
                 by_type[t] = []
             by_type[t].append(e)
-        
+
         for entity_type, type_entities in by_type.items():
-            lines.append(f"\n### {entity_type} ({len(type_entities)}个)")
-            # 使用配置的显示数量和摘要长度
+            lines.append(f"\n### {entity_type} ({len(type_entities)} entities)")
+            # Use the configured display count and summary length
             display_count = self.ENTITIES_PER_TYPE_DISPLAY
             summary_len = self.ENTITY_SUMMARY_LENGTH
             for e in type_entities[:display_count]:
                 summary_preview = (e.summary[:summary_len] + "...") if len(e.summary) > summary_len else e.summary
                 lines.append(f"- {e.name}: {summary_preview}")
             if len(type_entities) > display_count:
-                lines.append(f"  ... 还有 {len(type_entities) - display_count} 个")
-        
+                lines.append(f"  ... and {len(type_entities) - display_count} more")
+
         return "\n".join(lines)
-    
+
     def _call_llm_with_retry(self, prompt: str, system_prompt: str) -> Dict[str, Any]:
-        """带重试的LLM调用，包含JSON修复逻辑"""
+        """LLM call with retry, including JSON-repair logic"""
         import re
-        
+
         max_attempts = 3
         last_error = None
-        
+
         for attempt in range(max_attempts):
             try:
                 response = self.client.chat.completions.create(
@@ -447,121 +449,121 @@ class SimulationConfigGenerator:
                         {"role": "user", "content": prompt}
                     ],
                     response_format={"type": "json_object"},
-                    temperature=0.7 - (attempt * 0.1)  # 每次重试降低温度
-                    # 不设置max_tokens，让LLM自由发挥
+                    temperature=0.7 - (attempt * 0.1)  # Lower the temperature on each retry
+                    # Do not set max_tokens; let the LLM produce as much as needed
                 )
-                
+
                 content = response.choices[0].message.content
                 finish_reason = response.choices[0].finish_reason
-                
-                # 检查是否被截断
+
+                # Check whether the output was truncated
                 if finish_reason == 'length':
-                    logger.warning(f"LLM输出被截断 (attempt {attempt+1})")
+                    logger.warning(f"LLM output was truncated (attempt {attempt+1})")
                     content = self._fix_truncated_json(content)
-                
-                # 尝试解析JSON
+
+                # Try to parse the JSON
                 try:
                     return json.loads(content)
                 except json.JSONDecodeError as e:
-                    logger.warning(f"JSON解析失败 (attempt {attempt+1}): {str(e)[:80]}")
-                    
-                    # 尝试修复JSON
+                    logger.warning(f"JSON parsing failed (attempt {attempt+1}): {str(e)[:80]}")
+
+                    # Try to repair the JSON
                     fixed = self._try_fix_config_json(content)
                     if fixed:
                         return fixed
-                    
+
                     last_error = e
-                    
+
             except Exception as e:
-                logger.warning(f"LLM调用失败 (attempt {attempt+1}): {str(e)[:80]}")
+                logger.warning(f"LLM call failed (attempt {attempt+1}): {str(e)[:80]}")
                 last_error = e
                 import time
                 time.sleep(2 * (attempt + 1))
-        
-        raise last_error or Exception("LLM调用失败")
-    
+
+        raise last_error or Exception("LLM call failed")
+
     def _fix_truncated_json(self, content: str) -> str:
-        """修复被截断的JSON"""
+        """Repair truncated JSON"""
         content = content.strip()
-        
-        # 计算未闭合的括号
+
+        # Count unclosed braces and brackets
         open_braces = content.count('{') - content.count('}')
         open_brackets = content.count('[') - content.count(']')
-        
-        # 检查是否有未闭合的字符串
+
+        # Check for an unclosed string
         if content and content[-1] not in '",}]':
             content += '"'
-        
-        # 闭合括号
+
+        # Close brackets and braces
         content += ']' * open_brackets
         content += '}' * open_braces
-        
+
         return content
-    
+
     def _try_fix_config_json(self, content: str) -> Optional[Dict[str, Any]]:
-        """尝试修复配置JSON"""
+        """Try to repair the configuration JSON"""
         import re
-        
-        # 修复被截断的情况
+
+        # Repair the truncation case first
         content = self._fix_truncated_json(content)
-        
-        # 提取JSON部分
+
+        # Extract the JSON portion
         json_match = re.search(r'\{[\s\S]*\}', content)
         if json_match:
             json_str = json_match.group()
-            
-            # 移除字符串中的换行符
+
+            # Remove newline characters inside strings
             def fix_string(match):
                 s = match.group(0)
                 s = s.replace('\n', ' ').replace('\r', ' ')
                 s = re.sub(r'\s+', ' ', s)
                 return s
-            
+
             json_str = re.sub(r'"[^"\\]*(?:\\.[^"\\]*)*"', fix_string, json_str)
-            
+
             try:
                 return json.loads(json_str)
             except:
-                # 尝试移除所有控制字符
+                # Try removing all control characters
                 json_str = re.sub(r'[\x00-\x1f\x7f-\x9f]', ' ', json_str)
                 json_str = re.sub(r'\s+', ' ', json_str)
                 try:
                     return json.loads(json_str)
                 except:
                     pass
-        
+
         return None
-    
+
     def _generate_time_config(self, context: str, num_entities: int) -> Dict[str, Any]:
-        """生成时间配置"""
-        # 使用配置的上下文截断长度
+        """Generate the time configuration"""
+        # Use the configured context truncation length
         context_truncated = context[:self.TIME_CONFIG_CONTEXT_LENGTH]
-        
-        # 计算最大允许值（80%的agent数）
+
+        # Compute the maximum allowed value (90% of the agent count)
         max_agents_allowed = max(1, int(num_entities * 0.9))
-        
-        prompt = f"""基于以下模拟需求，生成时间模拟配置。
+
+        prompt = f"""Based on the following simulation requirement, generate a time-simulation configuration.
 
 {context_truncated}
 
-## 任务
-请生成时间配置JSON。
+## Task
+Produce the time configuration as JSON.
 
-### 基本原则（仅供参考，需根据具体事件和参与群体灵活调整）：
-- 请根据模拟场景推断目标用户群体所在时区和作息习惯，以下为东八区(UTC+8)的参考示例
-- 凌晨0-5点几乎无人活动（活跃度系数0.05）
-- 早上6-8点逐渐活跃（活跃度系数0.4）
-- 工作时间9-18点中等活跃（活跃度系数0.7）
-- 晚间19-22点是高峰期（活跃度系数1.5）
-- 23点后活跃度下降（活跃度系数0.5）
-- 一般规律：凌晨低活跃、早间渐增、工作时段中等、晚间高峰
-- **重要**：以下示例值仅供参考，你需要根据事件性质、参与群体特点来调整具体时段
-  - 例如：学生群体高峰可能是21-23点；媒体全天活跃；官方机构只在工作时间
-  - 例如：突发热点可能导致深夜也有讨论，off_peak_hours 可适当缩短
+### Basic principles (for reference only; adjust flexibly based on the specific event and the participating audience):
+- Infer the target user group's timezone and daily schedule from the simulation scenario; the example below uses UTC+8 as a reference
+- Almost no activity between 00:00 and 05:00 (activity multiplier 0.05)
+- Activity gradually picks up between 06:00 and 08:00 (activity multiplier 0.4)
+- Moderate activity during working hours 09:00-18:00 (activity multiplier 0.7)
+- Evening peak between 19:00 and 22:00 (activity multiplier 1.5)
+- Activity declines after 23:00 (activity multiplier 0.5)
+- General pattern: low activity overnight, ramp-up in the morning, moderate during working hours, peak in the evening
+- **Important**: the example values below are references only; tailor each window to the nature of the event and the audience
+  - For example: a student audience may peak between 21:00 and 23:00; media accounts are active all day; official institutions are active only during working hours
+  - For example: a breaking news event may produce late-night discussion, so off_peak_hours can be shortened accordingly
 
-### 返回JSON格式（不要markdown）
+### Return JSON format (no markdown)
 
-示例：
+Example:
 {{
     "total_simulation_hours": 72,
     "minutes_per_round": 60,
@@ -571,92 +573,92 @@ class SimulationConfigGenerator:
     "off_peak_hours": [0, 1, 2, 3, 4, 5],
     "morning_hours": [6, 7, 8],
     "work_hours": [9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
-    "reasoning": "针对该事件的时间配置说明"
+    "reasoning": "Explanation of the time configuration for this event"
 }}
 
-字段说明：
-- total_simulation_hours (int): 模拟总时长，24-168小时，突发事件短、持续话题长
-- minutes_per_round (int): 每轮时长，30-120分钟，建议60分钟
-- agents_per_hour_min (int): 每小时最少激活Agent数（取值范围: 1-{max_agents_allowed}）
-- agents_per_hour_max (int): 每小时最多激活Agent数（取值范围: 1-{max_agents_allowed}）
-- peak_hours (int数组): 高峰时段，根据事件参与群体调整
-- off_peak_hours (int数组): 低谷时段，通常深夜凌晨
-- morning_hours (int数组): 早间时段
-- work_hours (int数组): 工作时段
-- reasoning (string): 简要说明为什么这样配置"""
+Field descriptions:
+- total_simulation_hours (int): total simulated duration, 24-168 hours; short for breaking events, long for ongoing topics
+- minutes_per_round (int): minutes per round, 30-120; 60 minutes is recommended
+- agents_per_hour_min (int): minimum number of agents activated per hour (range: 1-{max_agents_allowed})
+- agents_per_hour_max (int): maximum number of agents activated per hour (range: 1-{max_agents_allowed})
+- peak_hours (int array): peak hours, adjusted for the event's audience
+- off_peak_hours (int array): off-peak hours, typically late-night/early-morning
+- morning_hours (int array): morning hours
+- work_hours (int array): working hours
+- reasoning (string): brief explanation of why this configuration was chosen"""
 
-        system_prompt = "你是社交媒体模拟专家。返回纯JSON格式，时间配置需符合模拟场景中目标用户群体的作息习惯。"
+        system_prompt = "You are a social-media simulation expert. Return pure JSON; the time configuration must match the daily schedule of the target user group in the simulation scenario."
         system_prompt = f"{system_prompt}\n\n{get_language_instruction()}"
 
         try:
             return self._call_llm_with_retry(prompt, system_prompt)
         except Exception as e:
-            logger.warning(f"时间配置LLM生成失败: {e}, 使用默认配置")
+            logger.warning(f"LLM time-config generation failed: {e}; using default configuration")
             return self._get_default_time_config(num_entities)
-    
+
     def _get_default_time_config(self, num_entities: int) -> Dict[str, Any]:
-        """获取默认时间配置（中国人作息）"""
+        """Get the default time configuration (Chinese daily schedule)"""
         return {
             "total_simulation_hours": 72,
-            "minutes_per_round": 60,  # 每轮1小时，加快时间流速
+            "minutes_per_round": 60,  # One hour per round to speed up time progression
             "agents_per_hour_min": max(1, num_entities // 15),
             "agents_per_hour_max": max(5, num_entities // 5),
             "peak_hours": [19, 20, 21, 22],
             "off_peak_hours": [0, 1, 2, 3, 4, 5],
             "morning_hours": [6, 7, 8],
             "work_hours": [9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
-            "reasoning": "使用默认中国人作息配置（每轮1小时）"
+            "reasoning": "Using the default Chinese daily-schedule configuration (1 hour per round)"
         }
-    
+
     def _parse_time_config(self, result: Dict[str, Any], num_entities: int) -> TimeSimulationConfig:
-        """解析时间配置结果，并验证agents_per_hour值不超过总agent数"""
-        # 获取原始值
+        """Parse the time-config result and verify that agents_per_hour values do not exceed the total agent count"""
+        # Get the raw values
         agents_per_hour_min = result.get("agents_per_hour_min", max(1, num_entities // 15))
         agents_per_hour_max = result.get("agents_per_hour_max", max(5, num_entities // 5))
-        
-        # 验证并修正：确保不超过总agent数
+
+        # Validate and correct: ensure they do not exceed the total agent count
         if agents_per_hour_min > num_entities:
-            logger.warning(f"agents_per_hour_min ({agents_per_hour_min}) 超过总Agent数 ({num_entities})，已修正")
+            logger.warning(f"agents_per_hour_min ({agents_per_hour_min}) exceeds total agent count ({num_entities}); corrected")
             agents_per_hour_min = max(1, num_entities // 10)
-        
+
         if agents_per_hour_max > num_entities:
-            logger.warning(f"agents_per_hour_max ({agents_per_hour_max}) 超过总Agent数 ({num_entities})，已修正")
+            logger.warning(f"agents_per_hour_max ({agents_per_hour_max}) exceeds total agent count ({num_entities}); corrected")
             agents_per_hour_max = max(agents_per_hour_min + 1, num_entities // 2)
-        
-        # 确保 min < max
+
+        # Make sure min < max
         if agents_per_hour_min >= agents_per_hour_max:
             agents_per_hour_min = max(1, agents_per_hour_max // 2)
-            logger.warning(f"agents_per_hour_min >= max，已修正为 {agents_per_hour_min}")
-        
+            logger.warning(f"agents_per_hour_min >= max; corrected to {agents_per_hour_min}")
+
         return TimeSimulationConfig(
             total_simulation_hours=result.get("total_simulation_hours", 72),
-            minutes_per_round=result.get("minutes_per_round", 60),  # 默认每轮1小时
+            minutes_per_round=result.get("minutes_per_round", 60),  # Default to 1 hour per round
             agents_per_hour_min=agents_per_hour_min,
             agents_per_hour_max=agents_per_hour_max,
             peak_hours=result.get("peak_hours", [19, 20, 21, 22]),
             off_peak_hours=result.get("off_peak_hours", [0, 1, 2, 3, 4, 5]),
-            off_peak_activity_multiplier=0.05,  # 凌晨几乎无人
+            off_peak_activity_multiplier=0.05,  # Almost nobody around overnight
             morning_hours=result.get("morning_hours", [6, 7, 8]),
             morning_activity_multiplier=0.4,
             work_hours=result.get("work_hours", list(range(9, 19))),
             work_activity_multiplier=0.7,
             peak_activity_multiplier=1.5
         )
-    
+
     def _generate_event_config(
-        self, 
-        context: str, 
+        self,
+        context: str,
         simulation_requirement: str,
         entities: List[EntityNode]
     ) -> Dict[str, Any]:
-        """生成事件配置"""
-        
-        # 获取可用的实体类型列表，供 LLM 参考
+        """Generate the event configuration"""
+
+        # Get the list of available entity types for the LLM to reference
         entity_types_available = list(set(
             e.get_entity_type() or "Unknown" for e in entities
         ))
-        
-        # 为每种类型列出代表性实体名称
+
+        # List representative entity names for each type
         type_examples = {}
         for e in entities:
             etype = e.get_entity_type() or "Unknown"
@@ -664,89 +666,89 @@ class SimulationConfigGenerator:
                 type_examples[etype] = []
             if len(type_examples[etype]) < 3:
                 type_examples[etype].append(e.name)
-        
+
         type_info = "\n".join([
-            f"- {t}: {', '.join(examples)}" 
+            f"- {t}: {', '.join(examples)}"
             for t, examples in type_examples.items()
         ])
-        
-        # 使用配置的上下文截断长度
-        context_truncated = context[:self.EVENT_CONFIG_CONTEXT_LENGTH]
-        
-        prompt = f"""基于以下模拟需求，生成事件配置。
 
-模拟需求: {simulation_requirement}
+        # Use the configured context truncation length
+        context_truncated = context[:self.EVENT_CONFIG_CONTEXT_LENGTH]
+
+        prompt = f"""Based on the following simulation requirement, generate the event configuration.
+
+Simulation requirement: {simulation_requirement}
 
 {context_truncated}
 
-## 可用实体类型及示例
+## Available entity types and examples
 {type_info}
 
-## 任务
-请生成事件配置JSON：
-- 提取热点话题关键词
-- 描述舆论发展方向
-- 设计初始帖子内容，**每个帖子必须指定 poster_type（发布者类型）**
+## Task
+Produce the event configuration as JSON:
+- Extract hot-topic keywords
+- Describe the direction in which the discourse will develop
+- Design the initial posts; **each post must specify poster_type (the publisher's type)**
 
-**重要**: poster_type 必须从上面的"可用实体类型"中选择，这样初始帖子才能分配给合适的 Agent 发布。
-例如：官方声明应由 Official/University 类型发布，新闻由 MediaOutlet 发布，学生观点由 Student 发布。
+**Important**: poster_type MUST be chosen from the "available entity types" listed above so that initial posts can be assigned to a suitable agent.
+For example, official statements should be posted by Official/University types, news by MediaOutlet, and student opinions by Student.
 
-返回JSON格式（不要markdown）：
+Return JSON format (no markdown):
 {{
-    "hot_topics": ["关键词1", "关键词2", ...],
-    "narrative_direction": "<舆论发展方向描述>",
+    "hot_topics": ["keyword 1", "keyword 2", ...],
+    "narrative_direction": "<description of how the discourse will develop>",
     "initial_posts": [
-        {{"content": "帖子内容", "poster_type": "实体类型（必须从可用类型中选择）"}},
+        {{"content": "post content", "poster_type": "entity type (must come from the available types)"}},
         ...
     ],
-    "reasoning": "<简要说明>"
+    "reasoning": "<brief explanation>"
 }}"""
 
-        system_prompt = "你是舆论分析专家。返回纯JSON格式。注意 poster_type 必须精确匹配可用实体类型。"
+        system_prompt = "You are an expert in public-opinion analysis. Return pure JSON. Note that poster_type must precisely match an available entity type."
         system_prompt = f"{system_prompt}\n\n{get_language_instruction()}\nIMPORTANT: The 'poster_type' field value MUST be in English PascalCase exactly matching the available entity types. Only 'content', 'narrative_direction', 'hot_topics' and 'reasoning' fields should use the specified language."
 
         try:
             return self._call_llm_with_retry(prompt, system_prompt)
         except Exception as e:
-            logger.warning(f"事件配置LLM生成失败: {e}, 使用默认配置")
+            logger.warning(f"LLM event-config generation failed: {e}; using default configuration")
             return {
                 "hot_topics": [],
                 "narrative_direction": "",
                 "initial_posts": [],
-                "reasoning": "使用默认配置"
+                "reasoning": "Using the default configuration"
             }
-    
+
     def _parse_event_config(self, result: Dict[str, Any]) -> EventConfig:
-        """解析事件配置结果"""
+        """Parse the event-config result"""
         return EventConfig(
             initial_posts=result.get("initial_posts", []),
             scheduled_events=[],
             hot_topics=result.get("hot_topics", []),
             narrative_direction=result.get("narrative_direction", "")
         )
-    
+
     def _assign_initial_post_agents(
         self,
         event_config: EventConfig,
         agent_configs: List[AgentActivityConfig]
     ) -> EventConfig:
         """
-        为初始帖子分配合适的发布者 Agent
-        
-        根据每个帖子的 poster_type 匹配最合适的 agent_id
+        Assign suitable poster agents to initial posts.
+
+        Matches each post's poster_type against the most suitable agent_id.
         """
         if not event_config.initial_posts:
             return event_config
-        
-        # 按实体类型建立 agent 索引
+
+        # Build an agent index by entity type
         agents_by_type: Dict[str, List[AgentActivityConfig]] = {}
         for agent in agent_configs:
             etype = agent.entity_type.lower()
             if etype not in agents_by_type:
                 agents_by_type[etype] = []
             agents_by_type[etype].append(agent)
-        
-        # 类型映射表（处理 LLM 可能输出的不同格式）
+
+        # Type alias mapping (handles different formats the LLM may emit)
         type_aliases = {
             "official": ["official", "university", "governmentagency", "government"],
             "university": ["university", "official"],
@@ -757,26 +759,26 @@ class SimulationConfigGenerator:
             "organization": ["organization", "ngo", "company", "group"],
             "person": ["person", "student", "alumni"],
         }
-        
-        # 记录每种类型已使用的 agent 索引，避免重复使用同一个 agent
+
+        # Track the next-agent index used per type to avoid reusing the same agent
         used_indices: Dict[str, int] = {}
-        
+
         updated_posts = []
         for post in event_config.initial_posts:
             poster_type = post.get("poster_type", "").lower()
             content = post.get("content", "")
-            
-            # 尝试找到匹配的 agent
+
+            # Try to find a matching agent
             matched_agent_id = None
-            
-            # 1. 直接匹配
+
+            # 1. Direct match
             if poster_type in agents_by_type:
                 agents = agents_by_type[poster_type]
                 idx = used_indices.get(poster_type, 0) % len(agents)
                 matched_agent_id = agents[idx].agent_id
                 used_indices[poster_type] = idx + 1
             else:
-                # 2. 使用别名匹配
+                # 2. Match via aliases
                 for alias_key, aliases in type_aliases.items():
                     if poster_type in aliases or alias_key == poster_type:
                         for alias in aliases:
@@ -788,28 +790,28 @@ class SimulationConfigGenerator:
                                 break
                     if matched_agent_id is not None:
                         break
-            
-            # 3. 如果仍未找到，使用影响力最高的 agent
+
+            # 3. If no match was found, use the agent with the highest influence
             if matched_agent_id is None:
-                logger.warning(f"未找到类型 '{poster_type}' 的匹配 Agent，使用影响力最高的 Agent")
+                logger.warning(f"No matching agent found for type '{poster_type}'; using the highest-influence agent")
                 if agent_configs:
-                    # 按影响力排序，选择影响力最高的
+                    # Sort by influence and pick the highest
                     sorted_agents = sorted(agent_configs, key=lambda a: a.influence_weight, reverse=True)
                     matched_agent_id = sorted_agents[0].agent_id
                 else:
                     matched_agent_id = 0
-            
+
             updated_posts.append({
                 "content": content,
                 "poster_type": post.get("poster_type", "Unknown"),
                 "poster_agent_id": matched_agent_id
             })
-            
-            logger.info(f"初始帖子分配: poster_type='{poster_type}' -> agent_id={matched_agent_id}")
-        
+
+            logger.info(f"Initial post assigned: poster_type='{poster_type}' -> agent_id={matched_agent_id}")
+
         event_config.initial_posts = updated_posts
         return event_config
-    
+
     def _generate_agent_configs_batch(
         self,
         context: str,
@@ -817,9 +819,9 @@ class SimulationConfigGenerator:
         start_idx: int,
         simulation_requirement: str
     ) -> List[AgentActivityConfig]:
-        """分批生成Agent配置"""
-        
-        # 构建实体信息（使用配置的摘要长度）
+        """Generate agent configurations in batches"""
+
+        # Build the entity info (use the configured summary length)
         entity_list = []
         summary_len = self.AGENT_SUMMARY_LENGTH
         for i, e in enumerate(entities):
@@ -829,63 +831,63 @@ class SimulationConfigGenerator:
                 "entity_type": e.get_entity_type() or "Unknown",
                 "summary": e.summary[:summary_len] if e.summary else ""
             })
-        
-        prompt = f"""基于以下信息，为每个实体生成社交媒体活动配置。
 
-模拟需求: {simulation_requirement}
+        prompt = f"""Based on the following information, generate a social-media activity configuration for each entity.
 
-## 实体列表
+Simulation requirement: {simulation_requirement}
+
+## Entity list
 ```json
 {json.dumps(entity_list, ensure_ascii=False, indent=2)}
 ```
 
-## 任务
-为每个实体生成活动配置，注意：
-- **时间符合目标用户群体作息**：以下为参考（东八区），请根据模拟场景调整
-- **官方机构**（University/GovernmentAgency）：活跃度低(0.1-0.3)，工作时间(9-17)活动，响应慢(60-240分钟)，影响力高(2.5-3.0)
-- **媒体**（MediaOutlet）：活跃度中(0.4-0.6)，全天活动(8-23)，响应快(5-30分钟)，影响力高(2.0-2.5)
-- **个人**（Student/Person/Alumni）：活跃度高(0.6-0.9)，主要晚间活动(18-23)，响应快(1-15分钟)，影响力低(0.8-1.2)
-- **公众人物/专家**：活跃度中(0.4-0.6)，影响力中高(1.5-2.0)
+## Task
+Generate an activity configuration for each entity. Note the following:
+- **Times must match the target user group's daily schedule**: the example below uses UTC+8; adjust based on the simulation scenario
+- **Official institutions** (University/GovernmentAgency): low activity (0.1-0.3), active during working hours (9-17), slow response (60-240 minutes), high influence (2.5-3.0)
+- **Media** (MediaOutlet): moderate activity (0.4-0.6), active all day (8-23), fast response (5-30 minutes), high influence (2.0-2.5)
+- **Individuals** (Student/Person/Alumni): high activity (0.6-0.9), mostly active in the evening (18-23), fast response (1-15 minutes), low influence (0.8-1.2)
+- **Public figures/experts**: moderate activity (0.4-0.6), medium-to-high influence (1.5-2.0)
 
-返回JSON格式（不要markdown）：
+Return JSON format (no markdown):
 {{
     "agent_configs": [
         {{
-            "agent_id": <必须与输入一致>,
+            "agent_id": <must match the input>,
             "activity_level": <0.0-1.0>,
-            "posts_per_hour": <发帖频率>,
-            "comments_per_hour": <评论频率>,
-            "active_hours": [<活跃小时列表，考虑中国人作息>],
-            "response_delay_min": <最小响应延迟分钟>,
-            "response_delay_max": <最大响应延迟分钟>,
-            "sentiment_bias": <-1.0到1.0>,
+            "posts_per_hour": <posting frequency>,
+            "comments_per_hour": <commenting frequency>,
+            "active_hours": [<list of active hours, taking the target audience's daily schedule into account>],
+            "response_delay_min": <minimum response delay in minutes>,
+            "response_delay_max": <maximum response delay in minutes>,
+            "sentiment_bias": <-1.0 to 1.0>,
             "stance": "<supportive/opposing/neutral/observer>",
-            "influence_weight": <影响力权重>
+            "influence_weight": <influence weight>
         }},
         ...
     ]
 }}"""
 
-        system_prompt = "你是社交媒体行为分析专家。返回纯JSON，配置需符合模拟场景中目标用户群体的作息习惯。"
+        system_prompt = "You are an expert in social-media behavior analysis. Return pure JSON; configurations must match the daily schedule of the target user group in the simulation scenario."
         system_prompt = f"{system_prompt}\n\n{get_language_instruction()}\nIMPORTANT: The 'stance' field value MUST be one of the English strings: 'supportive', 'opposing', 'neutral', 'observer'. All JSON field names and numeric values must remain unchanged. Only natural language text fields should use the specified language."
 
         try:
             result = self._call_llm_with_retry(prompt, system_prompt)
             llm_configs = {cfg["agent_id"]: cfg for cfg in result.get("agent_configs", [])}
         except Exception as e:
-            logger.warning(f"Agent配置批次LLM生成失败: {e}, 使用规则生成")
+            logger.warning(f"LLM agent-config batch generation failed: {e}; falling back to rule-based generation")
             llm_configs = {}
-        
-        # 构建AgentActivityConfig对象
+
+        # Build AgentActivityConfig objects
         configs = []
         for i, entity in enumerate(entities):
             agent_id = start_idx + i
             cfg = llm_configs.get(agent_id, {})
-            
-            # 如果LLM没有生成，使用规则生成
+
+            # If the LLM did not produce a config, fall back to rule-based generation
             if not cfg:
                 cfg = self._generate_agent_config_by_rule(entity)
-            
+
             config = AgentActivityConfig(
                 agent_id=agent_id,
                 entity_uuid=entity.uuid,
@@ -902,15 +904,15 @@ class SimulationConfigGenerator:
                 influence_weight=cfg.get("influence_weight", 1.0)
             )
             configs.append(config)
-        
+
         return configs
-    
+
     def _generate_agent_config_by_rule(self, entity: EntityNode) -> Dict[str, Any]:
-        """基于规则生成单个Agent配置（中国人作息）"""
+        """Rule-based generation of a single agent configuration (Chinese daily schedule)"""
         entity_type = (entity.get_entity_type() or "Unknown").lower()
-        
+
         if entity_type in ["university", "governmentagency", "ngo"]:
-            # 官方机构：工作时间活动，低频率，高影响力
+            # Official institutions: active during working hours, low frequency, high influence
             return {
                 "activity_level": 0.2,
                 "posts_per_hour": 0.1,
@@ -923,7 +925,7 @@ class SimulationConfigGenerator:
                 "influence_weight": 3.0
             }
         elif entity_type in ["mediaoutlet"]:
-            # 媒体：全天活动，中等频率，高影响力
+            # Media: active all day, moderate frequency, high influence
             return {
                 "activity_level": 0.5,
                 "posts_per_hour": 0.8,
@@ -936,7 +938,7 @@ class SimulationConfigGenerator:
                 "influence_weight": 2.5
             }
         elif entity_type in ["professor", "expert", "official"]:
-            # 专家/教授：工作+晚间活动，中等频率
+            # Experts/professors: active during working hours and evenings, moderate frequency
             return {
                 "activity_level": 0.4,
                 "posts_per_hour": 0.3,
@@ -949,12 +951,12 @@ class SimulationConfigGenerator:
                 "influence_weight": 2.0
             }
         elif entity_type in ["student"]:
-            # 学生：晚间为主，高频率
+            # Students: mostly active in the evening, high frequency
             return {
                 "activity_level": 0.8,
                 "posts_per_hour": 0.6,
                 "comments_per_hour": 1.5,
-                "active_hours": [8, 9, 10, 11, 12, 13, 18, 19, 20, 21, 22, 23],  # 上午+晚间
+                "active_hours": [8, 9, 10, 11, 12, 13, 18, 19, 20, 21, 22, 23],  # Late morning + evening
                 "response_delay_min": 1,
                 "response_delay_max": 15,
                 "sentiment_bias": 0.0,
@@ -962,12 +964,12 @@ class SimulationConfigGenerator:
                 "influence_weight": 0.8
             }
         elif entity_type in ["alumni"]:
-            # 校友：晚间为主
+            # Alumni: mostly active in the evening
             return {
                 "activity_level": 0.6,
                 "posts_per_hour": 0.4,
                 "comments_per_hour": 0.8,
-                "active_hours": [12, 13, 19, 20, 21, 22, 23],  # 午休+晚间
+                "active_hours": [12, 13, 19, 20, 21, 22, 23],  # Lunch break + evening
                 "response_delay_min": 5,
                 "response_delay_max": 30,
                 "sentiment_bias": 0.0,
@@ -975,17 +977,16 @@ class SimulationConfigGenerator:
                 "influence_weight": 1.0
             }
         else:
-            # 普通人：晚间高峰
+            # Generic individual: evening peak
             return {
                 "activity_level": 0.7,
                 "posts_per_hour": 0.5,
                 "comments_per_hour": 1.2,
-                "active_hours": [9, 10, 11, 12, 13, 18, 19, 20, 21, 22, 23],  # 白天+晚间
+                "active_hours": [9, 10, 11, 12, 13, 18, 19, 20, 21, 22, 23],  # Daytime + evening
                 "response_delay_min": 2,
                 "response_delay_max": 20,
                 "sentiment_bias": 0.0,
                 "stance": "neutral",
                 "influence_weight": 1.0
             }
-    
 

--- a/backend/app/services/simulation_ipc.py
+++ b/backend/app/services/simulation_ipc.py
@@ -1,11 +1,11 @@
 """
-模拟IPC通信模块
-用于Flask后端和模拟脚本之间的进程间通信
+Simulation IPC module
+Used for inter-process communication between the Flask backend and simulation scripts.
 
-通过文件系统实现简单的命令/响应模式：
-1. Flask写入命令到 commands/ 目录
-2. 模拟脚本轮询命令目录，执行命令并写入响应到 responses/ 目录
-3. Flask轮询响应目录获取结果
+Implements a simple command/response pattern via the filesystem:
+1. Flask writes commands to the commands/ directory
+2. Simulation scripts poll the command directory, execute commands, and write responses to responses/
+3. Flask polls the responses directory to obtain results
 """
 
 import os
@@ -23,14 +23,14 @@ logger = get_logger('mirofish.simulation_ipc')
 
 
 class CommandType(str, Enum):
-    """命令类型"""
-    INTERVIEW = "interview"           # 单个Agent采访
-    BATCH_INTERVIEW = "batch_interview"  # 批量采访
-    CLOSE_ENV = "close_env"           # 关闭环境
+    """Command types"""
+    INTERVIEW = "interview"           # Interview a single agent
+    BATCH_INTERVIEW = "batch_interview"  # Batch interview
+    CLOSE_ENV = "close_env"           # Close the environment
 
 
 class CommandStatus(str, Enum):
-    """命令状态"""
+    """Command status"""
     PENDING = "pending"
     PROCESSING = "processing"
     COMPLETED = "completed"
@@ -39,12 +39,12 @@ class CommandStatus(str, Enum):
 
 @dataclass
 class IPCCommand:
-    """IPC命令"""
+    """IPC command"""
     command_id: str
     command_type: CommandType
     args: Dict[str, Any]
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "command_id": self.command_id,
@@ -52,7 +52,7 @@ class IPCCommand:
             "args": self.args,
             "timestamp": self.timestamp
         }
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'IPCCommand':
         return cls(
@@ -65,13 +65,13 @@ class IPCCommand:
 
 @dataclass
 class IPCResponse:
-    """IPC响应"""
+    """IPC response"""
     command_id: str
     status: CommandStatus
     result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "command_id": self.command_id,
@@ -80,7 +80,7 @@ class IPCResponse:
             "error": self.error,
             "timestamp": self.timestamp
         }
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'IPCResponse':
         return cls(
@@ -94,26 +94,26 @@ class IPCResponse:
 
 class SimulationIPCClient:
     """
-    模拟IPC客户端（Flask端使用）
-    
-    用于向模拟进程发送命令并等待响应
+    Simulation IPC client (used on the Flask side)
+
+    Used to send commands to the simulation process and wait for responses.
     """
-    
+
     def __init__(self, simulation_dir: str):
         """
-        初始化IPC客户端
-        
+        Initialize the IPC client.
+
         Args:
-            simulation_dir: 模拟数据目录
+            simulation_dir: Simulation data directory
         """
         self.simulation_dir = simulation_dir
         self.commands_dir = os.path.join(simulation_dir, "ipc_commands")
         self.responses_dir = os.path.join(simulation_dir, "ipc_responses")
-        
-        # 确保目录存在
+
+        # Ensure directories exist
         os.makedirs(self.commands_dir, exist_ok=True)
         os.makedirs(self.responses_dir, exist_ok=True)
-    
+
     def send_command(
         self,
         command_type: CommandType,
@@ -122,19 +122,19 @@ class SimulationIPCClient:
         poll_interval: float = 0.5
     ) -> IPCResponse:
         """
-        发送命令并等待响应
-        
+        Send a command and wait for the response.
+
         Args:
-            command_type: 命令类型
-            args: 命令参数
-            timeout: 超时时间（秒）
-            poll_interval: 轮询间隔（秒）
-            
+            command_type: Command type
+            args: Command arguments
+            timeout: Timeout in seconds
+            poll_interval: Polling interval in seconds
+
         Returns:
             IPCResponse
-            
+
         Raises:
-            TimeoutError: 等待响应超时
+            TimeoutError: When waiting for the response times out
         """
         command_id = str(uuid.uuid4())
         command = IPCCommand(
@@ -142,50 +142,50 @@ class SimulationIPCClient:
             command_type=command_type,
             args=args
         )
-        
-        # 写入命令文件
+
+        # Write the command file
         command_file = os.path.join(self.commands_dir, f"{command_id}.json")
         with open(command_file, 'w', encoding='utf-8') as f:
             json.dump(command.to_dict(), f, ensure_ascii=False, indent=2)
-        
-        logger.info(f"发送IPC命令: {command_type.value}, command_id={command_id}")
-        
-        # 等待响应
+
+        logger.info(f"Sending IPC command: {command_type.value}, command_id={command_id}")
+
+        # Wait for the response
         response_file = os.path.join(self.responses_dir, f"{command_id}.json")
         start_time = time.time()
-        
+
         while time.time() - start_time < timeout:
             if os.path.exists(response_file):
                 try:
                     with open(response_file, 'r', encoding='utf-8') as f:
                         response_data = json.load(f)
                     response = IPCResponse.from_dict(response_data)
-                    
-                    # 清理命令和响应文件
+
+                    # Clean up command and response files
                     try:
                         os.remove(command_file)
                         os.remove(response_file)
                     except OSError:
                         pass
-                    
-                    logger.info(f"收到IPC响应: command_id={command_id}, status={response.status.value}")
+
+                    logger.info(f"Received IPC response: command_id={command_id}, status={response.status.value}")
                     return response
                 except (json.JSONDecodeError, KeyError) as e:
-                    logger.warning(f"解析响应失败: {e}")
-            
+                    logger.warning(f"Failed to parse response: {e}")
+
             time.sleep(poll_interval)
-        
-        # 超时
-        logger.error(f"等待IPC响应超时: command_id={command_id}")
-        
-        # 清理命令文件
+
+        # Timeout
+        logger.error(f"Timed out waiting for IPC response: command_id={command_id}")
+
+        # Clean up the command file
         try:
             os.remove(command_file)
         except OSError:
             pass
-        
-        raise TimeoutError(f"等待命令响应超时 ({timeout}秒)")
-    
+
+        raise TimeoutError(f"Timed out waiting for command response ({timeout} seconds)")
+
     def send_interview(
         self,
         agent_id: int,
@@ -194,19 +194,19 @@ class SimulationIPCClient:
         timeout: float = 60.0
     ) -> IPCResponse:
         """
-        发送单个Agent采访命令
-        
+        Send a single-agent interview command.
+
         Args:
             agent_id: Agent ID
-            prompt: 采访问题
-            platform: 指定平台（可选）
-                - "twitter": 只采访Twitter平台
-                - "reddit": 只采访Reddit平台  
-                - None: 双平台模拟时同时采访两个平台，单平台模拟时采访该平台
-            timeout: 超时时间
-            
+            prompt: Interview question
+            platform: Specific platform (optional)
+                - "twitter": Interview only on the Twitter platform
+                - "reddit": Interview only on the Reddit platform
+                - None: For dual-platform simulations, interview both platforms simultaneously; for single-platform simulations, interview that platform
+            timeout: Timeout
+
         Returns:
-            IPCResponse，result字段包含采访结果
+            IPCResponse, where the result field contains the interview result
         """
         args = {
             "agent_id": agent_id,
@@ -214,13 +214,13 @@ class SimulationIPCClient:
         }
         if platform:
             args["platform"] = platform
-            
+
         return self.send_command(
             command_type=CommandType.INTERVIEW,
             args=args,
             timeout=timeout
         )
-    
+
     def send_batch_interview(
         self,
         interviews: List[Dict[str, Any]],
@@ -228,36 +228,36 @@ class SimulationIPCClient:
         timeout: float = 120.0
     ) -> IPCResponse:
         """
-        发送批量采访命令
-        
+        Send a batch interview command.
+
         Args:
-            interviews: 采访列表，每个元素包含 {"agent_id": int, "prompt": str, "platform": str(可选)}
-            platform: 默认平台（可选，会被每个采访项的platform覆盖）
-                - "twitter": 默认只采访Twitter平台
-                - "reddit": 默认只采访Reddit平台
-                - None: 双平台模拟时每个Agent同时采访两个平台
-            timeout: 超时时间
-            
+            interviews: Interview list, each item containing {"agent_id": int, "prompt": str, "platform": str (optional)}
+            platform: Default platform (optional, overridden by each item's platform)
+                - "twitter": Default to interviewing only the Twitter platform
+                - "reddit": Default to interviewing only the Reddit platform
+                - None: For dual-platform simulations, interview each agent on both platforms simultaneously
+            timeout: Timeout
+
         Returns:
-            IPCResponse，result字段包含所有采访结果
+            IPCResponse, where the result field contains all interview results
         """
         args = {"interviews": interviews}
         if platform:
             args["platform"] = platform
-            
+
         return self.send_command(
             command_type=CommandType.BATCH_INTERVIEW,
             args=args,
             timeout=timeout
         )
-    
+
     def send_close_env(self, timeout: float = 30.0) -> IPCResponse:
         """
-        发送关闭环境命令
-        
+        Send the close-environment command.
+
         Args:
-            timeout: 超时时间
-            
+            timeout: Timeout
+
         Returns:
             IPCResponse
         """
@@ -266,17 +266,17 @@ class SimulationIPCClient:
             args={},
             timeout=timeout
         )
-    
+
     def check_env_alive(self) -> bool:
         """
-        检查模拟环境是否存活
-        
-        通过检查 env_status.json 文件来判断
+        Check whether the simulation environment is alive.
+
+        Determined by inspecting the env_status.json file.
         """
         status_file = os.path.join(self.simulation_dir, "env_status.json")
         if not os.path.exists(status_file):
             return False
-        
+
         try:
             with open(status_file, 'r', encoding='utf-8') as f:
                 status = json.load(f)
@@ -287,106 +287,106 @@ class SimulationIPCClient:
 
 class SimulationIPCServer:
     """
-    模拟IPC服务器（模拟脚本端使用）
-    
-    轮询命令目录，执行命令并返回响应
+    Simulation IPC server (used on the simulation script side)
+
+    Polls the command directory, executes commands, and returns responses.
     """
-    
+
     def __init__(self, simulation_dir: str):
         """
-        初始化IPC服务器
-        
+        Initialize the IPC server.
+
         Args:
-            simulation_dir: 模拟数据目录
+            simulation_dir: Simulation data directory
         """
         self.simulation_dir = simulation_dir
         self.commands_dir = os.path.join(simulation_dir, "ipc_commands")
         self.responses_dir = os.path.join(simulation_dir, "ipc_responses")
-        
-        # 确保目录存在
+
+        # Ensure directories exist
         os.makedirs(self.commands_dir, exist_ok=True)
         os.makedirs(self.responses_dir, exist_ok=True)
-        
-        # 环境状态
+
+        # Environment state
         self._running = False
-    
+
     def start(self):
-        """标记服务器为运行状态"""
+        """Mark the server as running"""
         self._running = True
         self._update_env_status("alive")
-    
+
     def stop(self):
-        """标记服务器为停止状态"""
+        """Mark the server as stopped"""
         self._running = False
         self._update_env_status("stopped")
-    
+
     def _update_env_status(self, status: str):
-        """更新环境状态文件"""
+        """Update the environment status file"""
         status_file = os.path.join(self.simulation_dir, "env_status.json")
         with open(status_file, 'w', encoding='utf-8') as f:
             json.dump({
                 "status": status,
                 "timestamp": datetime.now().isoformat()
             }, f, ensure_ascii=False, indent=2)
-    
+
     def poll_commands(self) -> Optional[IPCCommand]:
         """
-        轮询命令目录，返回第一个待处理的命令
-        
+        Poll the command directory and return the first pending command.
+
         Returns:
-            IPCCommand 或 None
+            IPCCommand or None
         """
         if not os.path.exists(self.commands_dir):
             return None
-        
-        # 按时间排序获取命令文件
+
+        # Get command files sorted by time
         command_files = []
         for filename in os.listdir(self.commands_dir):
             if filename.endswith('.json'):
                 filepath = os.path.join(self.commands_dir, filename)
                 command_files.append((filepath, os.path.getmtime(filepath)))
-        
+
         command_files.sort(key=lambda x: x[1])
-        
+
         for filepath, _ in command_files:
             try:
                 with open(filepath, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                 return IPCCommand.from_dict(data)
             except (json.JSONDecodeError, KeyError, OSError) as e:
-                logger.warning(f"读取命令文件失败: {filepath}, {e}")
+                logger.warning(f"Failed to read command file: {filepath}, {e}")
                 continue
-        
+
         return None
-    
+
     def send_response(self, response: IPCResponse):
         """
-        发送响应
-        
+        Send a response.
+
         Args:
-            response: IPC响应
+            response: IPC response
         """
         response_file = os.path.join(self.responses_dir, f"{response.command_id}.json")
         with open(response_file, 'w', encoding='utf-8') as f:
             json.dump(response.to_dict(), f, ensure_ascii=False, indent=2)
-        
-        # 删除命令文件
+
+        # Delete the command file
         command_file = os.path.join(self.commands_dir, f"{response.command_id}.json")
         try:
             os.remove(command_file)
         except OSError:
             pass
-    
+
     def send_success(self, command_id: str, result: Dict[str, Any]):
-        """发送成功响应"""
+        """Send a success response"""
         self.send_response(IPCResponse(
             command_id=command_id,
             status=CommandStatus.COMPLETED,
             result=result
         ))
-    
+
     def send_error(self, command_id: str, error: str):
-        """发送错误响应"""
+        """Send an error response"""
         self.send_response(IPCResponse(
             command_id=command_id,
             status=CommandStatus.FAILED,

--- a/backend/app/services/simulation_manager.py
+++ b/backend/app/services/simulation_manager.py
@@ -1,7 +1,7 @@
 """
-OASIS模拟管理器
-管理Twitter和Reddit双平台并行模拟
-使用预设脚本 + LLM智能生成配置参数
+OASIS simulation manager
+Manages parallel Twitter and Reddit dual-platform simulations.
+Uses preset scripts plus LLM-based intelligent generation of configuration parameters.
 """
 
 import os
@@ -23,60 +23,60 @@ logger = get_logger('mirofish.simulation')
 
 
 class SimulationStatus(str, Enum):
-    """模拟状态"""
+    """Simulation status"""
     CREATED = "created"
     PREPARING = "preparing"
     READY = "ready"
     RUNNING = "running"
     PAUSED = "paused"
-    STOPPED = "stopped"      # 模拟被手动停止
-    COMPLETED = "completed"  # 模拟自然完成
+    STOPPED = "stopped"      # Simulation was stopped manually
+    COMPLETED = "completed"  # Simulation finished naturally
     FAILED = "failed"
 
 
 class PlatformType(str, Enum):
-    """平台类型"""
+    """Platform type"""
     TWITTER = "twitter"
     REDDIT = "reddit"
 
 
 @dataclass
 class SimulationState:
-    """模拟状态"""
+    """Simulation state"""
     simulation_id: str
     project_id: str
     graph_id: str
-    
-    # 平台启用状态
+
+    # Platform enable flags
     enable_twitter: bool = True
     enable_reddit: bool = True
-    
-    # 状态
+
+    # Status
     status: SimulationStatus = SimulationStatus.CREATED
-    
-    # 准备阶段数据
+
+    # Preparation-stage data
     entities_count: int = 0
     profiles_count: int = 0
     entity_types: List[str] = field(default_factory=list)
-    
-    # 配置生成信息
+
+    # Configuration generation info
     config_generated: bool = False
     config_reasoning: str = ""
-    
-    # 运行时数据
+
+    # Runtime data
     current_round: int = 0
     twitter_status: str = "not_started"
     reddit_status: str = "not_started"
-    
-    # 时间戳
+
+    # Timestamps
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
     updated_at: str = field(default_factory=lambda: datetime.now().isoformat())
-    
-    # 错误信息
+
+    # Error info
     error: Optional[str] = None
-    
+
     def to_dict(self) -> Dict[str, Any]:
-        """完整状态字典（内部使用）"""
+        """Full state dictionary (internal use)"""
         return {
             "simulation_id": self.simulation_id,
             "project_id": self.project_id,
@@ -96,9 +96,9 @@ class SimulationState:
             "updated_at": self.updated_at,
             "error": self.error,
         }
-    
+
     def to_simple_dict(self) -> Dict[str, Any]:
-        """简化状态字典（API返回使用）"""
+        """Simplified state dictionary (used for API responses)"""
         return {
             "simulation_id": self.simulation_id,
             "project_id": self.project_id,
@@ -114,60 +114,60 @@ class SimulationState:
 
 class SimulationManager:
     """
-    模拟管理器
-    
-    核心功能：
-    1. 从Zep图谱读取实体并过滤
-    2. 生成OASIS Agent Profile
-    3. 使用LLM智能生成模拟配置参数
-    4. 准备预设脚本所需的所有文件
+    Simulation manager
+
+    Core responsibilities:
+    1. Read entities from the Zep graph and filter them
+    2. Generate OASIS Agent Profiles
+    3. Use an LLM to intelligently generate simulation configuration parameters
+    4. Prepare all files required by the preset scripts
     """
-    
-    # 模拟数据存储目录
+
+    # Simulation data storage directory
     SIMULATION_DATA_DIR = os.path.join(
-        os.path.dirname(__file__), 
+        os.path.dirname(__file__),
         '../../uploads/simulations'
     )
-    
+
     def __init__(self):
-        # 确保目录存在
+        # Ensure the directory exists
         os.makedirs(self.SIMULATION_DATA_DIR, exist_ok=True)
-        
-        # 内存中的模拟状态缓存
+
+        # In-memory simulation state cache
         self._simulations: Dict[str, SimulationState] = {}
-    
+
     def _get_simulation_dir(self, simulation_id: str) -> str:
-        """获取模拟数据目录"""
+        """Get the simulation data directory"""
         sim_dir = os.path.join(self.SIMULATION_DATA_DIR, simulation_id)
         os.makedirs(sim_dir, exist_ok=True)
         return sim_dir
-    
+
     def _save_simulation_state(self, state: SimulationState):
-        """保存模拟状态到文件"""
+        """Save the simulation state to a file"""
         sim_dir = self._get_simulation_dir(state.simulation_id)
         state_file = os.path.join(sim_dir, "state.json")
-        
+
         state.updated_at = datetime.now().isoformat()
-        
+
         with open(state_file, 'w', encoding='utf-8') as f:
             json.dump(state.to_dict(), f, ensure_ascii=False, indent=2)
-        
+
         self._simulations[state.simulation_id] = state
-    
+
     def _load_simulation_state(self, simulation_id: str) -> Optional[SimulationState]:
-        """从文件加载模拟状态"""
+        """Load the simulation state from a file"""
         if simulation_id in self._simulations:
             return self._simulations[simulation_id]
-        
+
         sim_dir = self._get_simulation_dir(simulation_id)
         state_file = os.path.join(sim_dir, "state.json")
-        
+
         if not os.path.exists(state_file):
             return None
-        
+
         with open(state_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
-        
+
         state = SimulationState(
             simulation_id=simulation_id,
             project_id=data.get("project_id", ""),
@@ -187,10 +187,10 @@ class SimulationManager:
             updated_at=data.get("updated_at", datetime.now().isoformat()),
             error=data.get("error"),
         )
-        
+
         self._simulations[simulation_id] = state
         return state
-    
+
     def create_simulation(
         self,
         project_id: str,
@@ -199,20 +199,20 @@ class SimulationManager:
         enable_reddit: bool = True,
     ) -> SimulationState:
         """
-        创建新的模拟
-        
+        Create a new simulation.
+
         Args:
-            project_id: 项目ID
-            graph_id: Zep图谱ID
-            enable_twitter: 是否启用Twitter模拟
-            enable_reddit: 是否启用Reddit模拟
-            
+            project_id: Project ID
+            graph_id: Zep graph ID
+            enable_twitter: Whether to enable Twitter simulation
+            enable_reddit: Whether to enable Reddit simulation
+
         Returns:
             SimulationState
         """
         import uuid
         simulation_id = f"sim_{uuid.uuid4().hex[:12]}"
-        
+
         state = SimulationState(
             simulation_id=simulation_id,
             project_id=project_id,
@@ -221,12 +221,12 @@ class SimulationManager:
             enable_reddit=enable_reddit,
             status=SimulationStatus.CREATED,
         )
-        
+
         self._save_simulation_state(state)
-        logger.info(f"创建模拟: {simulation_id}, project={project_id}, graph={graph_id}")
-        
+        logger.info(f"Created simulation: {simulation_id}, project={project_id}, graph={graph_id}")
+
         return state
-    
+
     def prepare_simulation(
         self,
         simulation_id: str,
@@ -238,55 +238,55 @@ class SimulationManager:
         parallel_profile_count: int = 3
     ) -> SimulationState:
         """
-        准备模拟环境（全程自动化）
-        
-        步骤：
-        1. 从Zep图谱读取并过滤实体
-        2. 为每个实体生成OASIS Agent Profile（可选LLM增强，支持并行）
-        3. 使用LLM智能生成模拟配置参数（时间、活跃度、发言频率等）
-        4. 保存配置文件和Profile文件
-        5. 复制预设脚本到模拟目录
-        
+        Prepare the simulation environment (fully automated).
+
+        Steps:
+        1. Read and filter entities from the Zep graph
+        2. Generate an OASIS Agent Profile for each entity (optional LLM enhancement, supports parallelism)
+        3. Use an LLM to intelligently generate simulation configuration parameters (time, activity level, posting frequency, etc.)
+        4. Save the configuration file and Profile files
+        5. Copy preset scripts into the simulation directory
+
         Args:
-            simulation_id: 模拟ID
-            simulation_requirement: 模拟需求描述（用于LLM生成配置）
-            document_text: 原始文档内容（用于LLM理解背景）
-            defined_entity_types: 预定义的实体类型（可选）
-            use_llm_for_profiles: 是否使用LLM生成详细人设
-            progress_callback: 进度回调函数 (stage, progress, message)
-            parallel_profile_count: 并行生成人设的数量，默认3
-            
+            simulation_id: Simulation ID
+            simulation_requirement: Description of the simulation requirement (used by the LLM to generate the configuration)
+            document_text: Original document content (used by the LLM to understand the background)
+            defined_entity_types: Predefined entity types (optional)
+            use_llm_for_profiles: Whether to use the LLM to generate detailed personas
+            progress_callback: Progress callback function (stage, progress, message)
+            parallel_profile_count: Number of personas to generate in parallel; defaults to 3
+
         Returns:
             SimulationState
         """
         state = self._load_simulation_state(simulation_id)
         if not state:
-            raise ValueError(f"模拟不存在: {simulation_id}")
-        
+            raise ValueError(f"Simulation does not exist: {simulation_id}")
+
         try:
             state.status = SimulationStatus.PREPARING
             self._save_simulation_state(state)
-            
+
             sim_dir = self._get_simulation_dir(simulation_id)
-            
-            # ========== 阶段1: 读取并过滤实体 ==========
+
+            # ========== Stage 1: Read and filter entities ==========
             if progress_callback:
                 progress_callback("reading", 0, t('progress.connectingZepGraph'))
-            
+
             reader = ZepEntityReader()
-            
+
             if progress_callback:
                 progress_callback("reading", 30, t('progress.readingNodeData'))
-            
+
             filtered = reader.filter_defined_entities(
                 graph_id=state.graph_id,
                 defined_entity_types=defined_entity_types,
                 enrich_with_edges=True
             )
-            
+
             state.entities_count = filtered.filtered_count
             state.entity_types = list(filtered.entity_types)
-            
+
             if progress_callback:
                 progress_callback(
                     "reading", 100,
@@ -294,16 +294,16 @@ class SimulationManager:
                     current=filtered.filtered_count,
                     total=filtered.filtered_count
                 )
-            
+
             if filtered.filtered_count == 0:
                 state.status = SimulationStatus.FAILED
-                state.error = "没有找到符合条件的实体，请检查图谱是否正确构建"
+                state.error = "No qualifying entities were found; please check whether the graph was built correctly"
                 self._save_simulation_state(state)
                 return state
-            
-            # ========== 阶段2: 生成Agent Profile ==========
+
+            # ========== Stage 2: Generate Agent Profiles ==========
             total_entities = len(filtered.entities)
-            
+
             if progress_callback:
                 progress_callback(
                     "generating_profiles", 0,
@@ -311,22 +311,22 @@ class SimulationManager:
                     current=0,
                     total=total_entities
                 )
-            
-            # 传入graph_id以启用Zep检索功能，获取更丰富的上下文
+
+            # Pass graph_id to enable Zep retrieval and obtain richer context
             generator = OasisProfileGenerator(graph_id=state.graph_id)
-            
+
             def profile_progress(current, total, msg):
                 if progress_callback:
                     progress_callback(
-                        "generating_profiles", 
-                        int(current / total * 100), 
+                        "generating_profiles",
+                        int(current / total * 100),
                         msg,
                         current=current,
                         total=total,
                         item_name=msg
                     )
-            
-            # 设置实时保存的文件路径（优先使用 Reddit JSON 格式）
+
+            # Set the file path for real-time saving (prefer Reddit JSON format)
             realtime_output_path = None
             realtime_platform = "reddit"
             if state.enable_reddit:
@@ -335,21 +335,21 @@ class SimulationManager:
             elif state.enable_twitter:
                 realtime_output_path = os.path.join(sim_dir, "twitter_profiles.csv")
                 realtime_platform = "twitter"
-            
+
             profiles = generator.generate_profiles_from_entities(
                 entities=filtered.entities,
                 use_llm=use_llm_for_profiles,
                 progress_callback=profile_progress,
-                graph_id=state.graph_id,  # 传入graph_id用于Zep检索
-                parallel_count=parallel_profile_count,  # 并行生成数量
-                realtime_output_path=realtime_output_path,  # 实时保存路径
-                output_platform=realtime_platform  # 输出格式
+                graph_id=state.graph_id,  # Pass graph_id for Zep retrieval
+                parallel_count=parallel_profile_count,  # Number of profiles to generate in parallel
+                realtime_output_path=realtime_output_path,  # Real-time save path
+                output_platform=realtime_platform  # Output format
             )
-            
+
             state.profiles_count = len(profiles)
-            
-            # 保存Profile文件（注意：Twitter使用CSV格式，Reddit使用JSON格式）
-            # Reddit 已经在生成过程中实时保存了，这里再保存一次确保完整性
+
+            # Save the Profile file (note: Twitter uses CSV format, Reddit uses JSON format)
+            # Reddit was already saved in real time during generation; we save again here to ensure completeness
             if progress_callback:
                 progress_callback(
                     "generating_profiles", 95,
@@ -357,22 +357,22 @@ class SimulationManager:
                     current=total_entities,
                     total=total_entities
                 )
-            
+
             if state.enable_reddit:
                 generator.save_profiles(
                     profiles=profiles,
                     file_path=os.path.join(sim_dir, "reddit_profiles.json"),
                     platform="reddit"
                 )
-            
+
             if state.enable_twitter:
-                # Twitter使用CSV格式！这是OASIS的要求
+                # Twitter uses CSV format! This is required by OASIS.
                 generator.save_profiles(
                     profiles=profiles,
                     file_path=os.path.join(sim_dir, "twitter_profiles.csv"),
                     platform="twitter"
                 )
-            
+
             if progress_callback:
                 progress_callback(
                     "generating_profiles", 100,
@@ -380,8 +380,8 @@ class SimulationManager:
                     current=len(profiles),
                     total=len(profiles)
                 )
-            
-            # ========== 阶段3: LLM智能生成模拟配置 ==========
+
+            # ========== Stage 3: Intelligently generate simulation config via LLM ==========
             if progress_callback:
                 progress_callback(
                     "generating_config", 0,
@@ -389,9 +389,9 @@ class SimulationManager:
                     current=0,
                     total=3
                 )
-            
+
             config_generator = SimulationConfigGenerator()
-            
+
             if progress_callback:
                 progress_callback(
                     "generating_config", 30,
@@ -399,7 +399,7 @@ class SimulationManager:
                     current=1,
                     total=3
                 )
-            
+
             sim_params = config_generator.generate_config(
                 simulation_id=simulation_id,
                 project_id=state.project_id,
@@ -410,7 +410,7 @@ class SimulationManager:
                 enable_twitter=state.enable_twitter,
                 enable_reddit=state.enable_reddit
             )
-            
+
             if progress_callback:
                 progress_callback(
                     "generating_config", 70,
@@ -418,15 +418,15 @@ class SimulationManager:
                     current=2,
                     total=3
                 )
-            
-            # 保存配置文件
+
+            # Save the configuration file
             config_path = os.path.join(sim_dir, "simulation_config.json")
             with open(config_path, 'w', encoding='utf-8') as f:
                 f.write(sim_params.to_json())
-            
+
             state.config_generated = True
             state.config_reasoning = sim_params.generation_reasoning
-            
+
             if progress_callback:
                 progress_callback(
                     "generating_config", 100,
@@ -434,82 +434,82 @@ class SimulationManager:
                     current=3,
                     total=3
                 )
-            
-            # 注意：运行脚本保留在 backend/scripts/ 目录，不再复制到模拟目录
-            # 启动模拟时，simulation_runner 会从 scripts/ 目录运行脚本
-            
-            # 更新状态
+
+            # Note: the run scripts remain in the backend/scripts/ directory and are no longer copied into the simulation directory.
+            # When starting the simulation, simulation_runner runs the scripts directly from scripts/.
+
+            # Update state
             state.status = SimulationStatus.READY
             self._save_simulation_state(state)
-            
-            logger.info(f"模拟准备完成: {simulation_id}, "
+
+            logger.info(f"Simulation preparation complete: {simulation_id}, "
                        f"entities={state.entities_count}, profiles={state.profiles_count}")
-            
+
             return state
-            
+
         except Exception as e:
-            logger.error(f"模拟准备失败: {simulation_id}, error={str(e)}")
+            logger.error(f"Simulation preparation failed: {simulation_id}, error={str(e)}")
             import traceback
             logger.error(traceback.format_exc())
             state.status = SimulationStatus.FAILED
             state.error = str(e)
             self._save_simulation_state(state)
             raise
-    
+
     def get_simulation(self, simulation_id: str) -> Optional[SimulationState]:
-        """获取模拟状态"""
+        """Get the simulation state"""
         return self._load_simulation_state(simulation_id)
-    
+
     def list_simulations(self, project_id: Optional[str] = None) -> List[SimulationState]:
-        """列出所有模拟"""
+        """List all simulations"""
         simulations = []
-        
+
         if os.path.exists(self.SIMULATION_DATA_DIR):
             for sim_id in os.listdir(self.SIMULATION_DATA_DIR):
-                # 跳过隐藏文件（如 .DS_Store）和非目录文件
+                # Skip hidden files (e.g., .DS_Store) and non-directory entries
                 sim_path = os.path.join(self.SIMULATION_DATA_DIR, sim_id)
                 if sim_id.startswith('.') or not os.path.isdir(sim_path):
                     continue
-                
+
                 state = self._load_simulation_state(sim_id)
                 if state:
                     if project_id is None or state.project_id == project_id:
                         simulations.append(state)
-        
+
         return simulations
-    
+
     def get_profiles(self, simulation_id: str, platform: str = "reddit") -> List[Dict[str, Any]]:
-        """获取模拟的Agent Profile"""
+        """Get the simulation's Agent Profiles"""
         state = self._load_simulation_state(simulation_id)
         if not state:
-            raise ValueError(f"模拟不存在: {simulation_id}")
-        
+            raise ValueError(f"Simulation does not exist: {simulation_id}")
+
         sim_dir = self._get_simulation_dir(simulation_id)
         profile_path = os.path.join(sim_dir, f"{platform}_profiles.json")
-        
+
         if not os.path.exists(profile_path):
             return []
-        
+
         with open(profile_path, 'r', encoding='utf-8') as f:
             return json.load(f)
-    
+
     def get_simulation_config(self, simulation_id: str) -> Optional[Dict[str, Any]]:
-        """获取模拟配置"""
+        """Get the simulation configuration"""
         sim_dir = self._get_simulation_dir(simulation_id)
         config_path = os.path.join(sim_dir, "simulation_config.json")
-        
+
         if not os.path.exists(config_path):
             return None
-        
+
         with open(config_path, 'r', encoding='utf-8') as f:
             return json.load(f)
-    
+
     def get_run_instructions(self, simulation_id: str) -> Dict[str, str]:
-        """获取运行说明"""
+        """Get the run instructions"""
         sim_dir = self._get_simulation_dir(simulation_id)
         config_path = os.path.join(sim_dir, "simulation_config.json")
         scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../scripts'))
-        
+
         return {
             "simulation_dir": sim_dir,
             "scripts_dir": scripts_dir,
@@ -520,10 +520,10 @@ class SimulationManager:
                 "parallel": f"python {scripts_dir}/run_parallel_simulation.py --config {config_path}",
             },
             "instructions": (
-                f"1. 激活conda环境: conda activate MiroFish\n"
-                f"2. 运行模拟 (脚本位于 {scripts_dir}):\n"
-                f"   - 单独运行Twitter: python {scripts_dir}/run_twitter_simulation.py --config {config_path}\n"
-                f"   - 单独运行Reddit: python {scripts_dir}/run_reddit_simulation.py --config {config_path}\n"
-                f"   - 并行运行双平台: python {scripts_dir}/run_parallel_simulation.py --config {config_path}"
+                f"1. Activate the conda environment: conda activate MiroFish\n"
+                f"2. Run the simulation (scripts located in {scripts_dir}):\n"
+                f"   - Run Twitter only: python {scripts_dir}/run_twitter_simulation.py --config {config_path}\n"
+                f"   - Run Reddit only: python {scripts_dir}/run_reddit_simulation.py --config {config_path}\n"
+                f"   - Run both platforms in parallel: python {scripts_dir}/run_parallel_simulation.py --config {config_path}"
             )
         }

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -1,6 +1,6 @@
 """
-OASIS模拟运行器
-在后台运行模拟并记录每个Agent的动作，支持实时状态监控
+OASIS simulation runner
+Runs simulations in the background and records each agent's actions, supporting real-time status monitoring.
 """
 
 import os
@@ -26,15 +26,15 @@ from .simulation_ipc import SimulationIPCClient, CommandType, IPCResponse
 
 logger = get_logger('mirofish.simulation_runner')
 
-# 标记是否已注册清理函数
+# Whether the cleanup function has been registered
 _cleanup_registered = False
 
-# 平台检测
+# Platform detection
 IS_WINDOWS = sys.platform == 'win32'
 
 
 class RunnerStatus(str, Enum):
-    """运行器状态"""
+    """Runner status"""
     IDLE = "idle"
     STARTING = "starting"
     RUNNING = "running"
@@ -47,7 +47,7 @@ class RunnerStatus(str, Enum):
 
 @dataclass
 class AgentAction:
-    """Agent动作记录"""
+    """Agent action record"""
     round_num: int
     timestamp: str
     platform: str  # twitter / reddit
@@ -57,7 +57,7 @@ class AgentAction:
     action_args: Dict[str, Any] = field(default_factory=dict)
     result: Optional[str] = None
     success: bool = True
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "round_num": self.round_num,
@@ -74,7 +74,7 @@ class AgentAction:
 
 @dataclass
 class RoundSummary:
-    """每轮摘要"""
+    """Per-round summary"""
     round_num: int
     start_time: str
     end_time: Optional[str] = None
@@ -83,7 +83,7 @@ class RoundSummary:
     reddit_actions: int = 0
     active_agents: List[int] = field(default_factory=list)
     actions: List[AgentAction] = field(default_factory=list)
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "round_num": self.round_num,
@@ -100,63 +100,63 @@ class RoundSummary:
 
 @dataclass
 class SimulationRunState:
-    """模拟运行状态（实时）"""
+    """Simulation run state (real-time)"""
     simulation_id: str
     runner_status: RunnerStatus = RunnerStatus.IDLE
-    
-    # 进度信息
+
+    # Progress info
     current_round: int = 0
     total_rounds: int = 0
     simulated_hours: int = 0
     total_simulation_hours: int = 0
-    
-    # 各平台独立轮次和模拟时间（用于双平台并行显示）
+
+    # Per-platform independent round and simulated time (for dual-platform parallel display)
     twitter_current_round: int = 0
     reddit_current_round: int = 0
     twitter_simulated_hours: int = 0
     reddit_simulated_hours: int = 0
-    
-    # 平台状态
+
+    # Platform status
     twitter_running: bool = False
     reddit_running: bool = False
     twitter_actions_count: int = 0
     reddit_actions_count: int = 0
-    
-    # 平台完成状态（通过检测 actions.jsonl 中的 simulation_end 事件）
+
+    # Platform completion status (detected from simulation_end events in actions.jsonl)
     twitter_completed: bool = False
     reddit_completed: bool = False
-    
-    # 每轮摘要
+
+    # Per-round summaries
     rounds: List[RoundSummary] = field(default_factory=list)
-    
-    # 最近动作（用于前端实时展示）
+
+    # Recent actions (for real-time display on the frontend)
     recent_actions: List[AgentAction] = field(default_factory=list)
     max_recent_actions: int = 50
-    
-    # 时间戳
+
+    # Timestamps
     started_at: Optional[str] = None
     updated_at: str = field(default_factory=lambda: datetime.now().isoformat())
     completed_at: Optional[str] = None
-    
-    # 错误信息
+
+    # Error info
     error: Optional[str] = None
-    
-    # 进程ID（用于停止）
+
+    # Process ID (used for stopping)
     process_pid: Optional[int] = None
-    
+
     def add_action(self, action: AgentAction):
-        """添加动作到最近动作列表"""
+        """Add an action to the recent actions list"""
         self.recent_actions.insert(0, action)
         if len(self.recent_actions) > self.max_recent_actions:
             self.recent_actions = self.recent_actions[:self.max_recent_actions]
-        
+
         if action.platform == "twitter":
             self.twitter_actions_count += 1
         else:
             self.reddit_actions_count += 1
-        
+
         self.updated_at = datetime.now().isoformat()
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "simulation_id": self.simulation_id,
@@ -166,7 +166,7 @@ class SimulationRunState:
             "simulated_hours": self.simulated_hours,
             "total_simulation_hours": self.total_simulation_hours,
             "progress_percent": round(self.current_round / max(self.total_rounds, 1) * 100, 1),
-            # 各平台独立轮次和时间
+            # Per-platform independent rounds and times
             "twitter_current_round": self.twitter_current_round,
             "reddit_current_round": self.reddit_current_round,
             "twitter_simulated_hours": self.twitter_simulated_hours,
@@ -184,9 +184,9 @@ class SimulationRunState:
             "error": self.error,
             "process_pid": self.process_pid,
         }
-    
+
     def to_detail_dict(self) -> Dict[str, Any]:
-        """包含最近动作的详细信息"""
+        """Detailed information including recent actions"""
         result = self.to_dict()
         result["recent_actions"] = [a.to_dict() for a in self.recent_actions]
         result["rounds_count"] = len(self.rounds)
@@ -195,61 +195,61 @@ class SimulationRunState:
 
 class SimulationRunner:
     """
-    模拟运行器
-    
-    负责：
-    1. 在后台进程中运行OASIS模拟
-    2. 解析运行日志，记录每个Agent的动作
-    3. 提供实时状态查询接口
-    4. 支持暂停/停止/恢复操作
+    Simulation runner
+
+    Responsibilities:
+    1. Run the OASIS simulation in a background process
+    2. Parse the run logs and record each agent's actions
+    3. Provide a real-time status query interface
+    4. Support pause/stop/resume operations
     """
-    
-    # 运行状态存储目录
+
+    # Run-state storage directory
     RUN_STATE_DIR = os.path.join(
         os.path.dirname(__file__),
         '../../uploads/simulations'
     )
-    
-    # 脚本目录
+
+    # Scripts directory
     SCRIPTS_DIR = os.path.join(
         os.path.dirname(__file__),
         '../../scripts'
     )
-    
-    # 内存中的运行状态
+
+    # In-memory run states
     _run_states: Dict[str, SimulationRunState] = {}
     _processes: Dict[str, subprocess.Popen] = {}
     _action_queues: Dict[str, Queue] = {}
     _monitor_threads: Dict[str, threading.Thread] = {}
-    _stdout_files: Dict[str, Any] = {}  # 存储 stdout 文件句柄
-    _stderr_files: Dict[str, Any] = {}  # 存储 stderr 文件句柄
-    
-    # 图谱记忆更新配置
+    _stdout_files: Dict[str, Any] = {}  # Stores stdout file handles
+    _stderr_files: Dict[str, Any] = {}  # Stores stderr file handles
+
+    # Graph memory update configuration
     _graph_memory_enabled: Dict[str, bool] = {}  # simulation_id -> enabled
-    
+
     @classmethod
     def get_run_state(cls, simulation_id: str) -> Optional[SimulationRunState]:
-        """获取运行状态"""
+        """Get the run state"""
         if simulation_id in cls._run_states:
             return cls._run_states[simulation_id]
-        
-        # 尝试从文件加载
+
+        # Try loading from file
         state = cls._load_run_state(simulation_id)
         if state:
             cls._run_states[simulation_id] = state
         return state
-    
+
     @classmethod
     def _load_run_state(cls, simulation_id: str) -> Optional[SimulationRunState]:
-        """从文件加载运行状态"""
+        """Load the run state from a file"""
         state_file = os.path.join(cls.RUN_STATE_DIR, simulation_id, "run_state.json")
         if not os.path.exists(state_file):
             return None
-        
+
         try:
             with open(state_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
-            
+
             state = SimulationRunState(
                 simulation_id=simulation_id,
                 runner_status=RunnerStatus(data.get("runner_status", "idle")),
@@ -257,7 +257,7 @@ class SimulationRunner:
                 total_rounds=data.get("total_rounds", 0),
                 simulated_hours=data.get("simulated_hours", 0),
                 total_simulation_hours=data.get("total_simulation_hours", 0),
-                # 各平台独立轮次和时间
+                # Per-platform independent rounds and times
                 twitter_current_round=data.get("twitter_current_round", 0),
                 reddit_current_round=data.get("reddit_current_round", 0),
                 twitter_simulated_hours=data.get("twitter_simulated_hours", 0),
@@ -274,8 +274,8 @@ class SimulationRunner:
                 error=data.get("error"),
                 process_pid=data.get("process_pid"),
             )
-            
-            # 加载最近动作
+
+            # Load recent actions
             actions_data = data.get("recent_actions", [])
             for a in actions_data:
                 state.recent_actions.append(AgentAction(
@@ -289,76 +289,76 @@ class SimulationRunner:
                     result=a.get("result"),
                     success=a.get("success", True),
                 ))
-            
+
             return state
         except Exception as e:
-            logger.error(f"加载运行状态失败: {str(e)}")
+            logger.error(f"Failed to load run state: {str(e)}")
             return None
-    
+
     @classmethod
     def _save_run_state(cls, state: SimulationRunState):
-        """保存运行状态到文件"""
+        """Save the run state to a file"""
         sim_dir = os.path.join(cls.RUN_STATE_DIR, state.simulation_id)
         os.makedirs(sim_dir, exist_ok=True)
         state_file = os.path.join(sim_dir, "run_state.json")
-        
+
         data = state.to_detail_dict()
-        
+
         with open(state_file, 'w', encoding='utf-8') as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
-        
+
         cls._run_states[state.simulation_id] = state
-    
+
     @classmethod
     def start_simulation(
         cls,
         simulation_id: str,
         platform: str = "parallel",  # twitter / reddit / parallel
-        max_rounds: int = None,  # 最大模拟轮数（可选，用于截断过长的模拟）
-        enable_graph_memory_update: bool = False,  # 是否将活动更新到Zep图谱
-        graph_id: str = None  # Zep图谱ID（启用图谱更新时必需）
+        max_rounds: int = None,  # Maximum number of simulation rounds (optional, used to truncate overly long simulations)
+        enable_graph_memory_update: bool = False,  # Whether to push activity updates to the Zep graph
+        graph_id: str = None  # Zep graph ID (required when graph updates are enabled)
     ) -> SimulationRunState:
         """
-        启动模拟
-        
+        Start the simulation.
+
         Args:
-            simulation_id: 模拟ID
-            platform: 运行平台 (twitter/reddit/parallel)
-            max_rounds: 最大模拟轮数（可选，用于截断过长的模拟）
-            enable_graph_memory_update: 是否将Agent活动动态更新到Zep图谱
-            graph_id: Zep图谱ID（启用图谱更新时必需）
-            
+            simulation_id: Simulation ID
+            platform: Run platform (twitter/reddit/parallel)
+            max_rounds: Maximum number of simulation rounds (optional, used to truncate overly long simulations)
+            enable_graph_memory_update: Whether to dynamically push agent activity to the Zep graph
+            graph_id: Zep graph ID (required when graph updates are enabled)
+
         Returns:
             SimulationRunState
         """
-        # 检查是否已在运行
+        # Check whether it is already running
         existing = cls.get_run_state(simulation_id)
         if existing and existing.runner_status in [RunnerStatus.RUNNING, RunnerStatus.STARTING]:
-            raise ValueError(f"模拟已在运行中: {simulation_id}")
-        
-        # 加载模拟配置
+            raise ValueError(f"Simulation is already running: {simulation_id}")
+
+        # Load the simulation configuration
         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
         config_path = os.path.join(sim_dir, "simulation_config.json")
-        
+
         if not os.path.exists(config_path):
-            raise ValueError(f"模拟配置不存在，请先调用 /prepare 接口")
-        
+            raise ValueError(f"Simulation configuration does not exist; please call /prepare first")
+
         with open(config_path, 'r', encoding='utf-8') as f:
             config = json.load(f)
-        
-        # 初始化运行状态
+
+        # Initialize run state
         time_config = config.get("time_config", {})
         total_hours = time_config.get("total_simulation_hours", 72)
         minutes_per_round = time_config.get("minutes_per_round", 30)
         total_rounds = int(total_hours * 60 / minutes_per_round)
-        
-        # 如果指定了最大轮数，则截断
+
+        # Truncate if a maximum round count was specified
         if max_rounds is not None and max_rounds > 0:
             original_rounds = total_rounds
             total_rounds = min(total_rounds, max_rounds)
             if total_rounds < original_rounds:
-                logger.info(f"轮数已截断: {original_rounds} -> {total_rounds} (max_rounds={max_rounds})")
-        
+                logger.info(f"Round count truncated: {original_rounds} -> {total_rounds} (max_rounds={max_rounds})")
+
         state = SimulationRunState(
             simulation_id=simulation_id,
             runner_status=RunnerStatus.STARTING,
@@ -366,25 +366,25 @@ class SimulationRunner:
             total_simulation_hours=total_hours,
             started_at=datetime.now().isoformat(),
         )
-        
+
         cls._save_run_state(state)
-        
-        # 如果启用图谱记忆更新，创建更新器
+
+        # If graph memory updates are enabled, create the updater
         if enable_graph_memory_update:
             if not graph_id:
-                raise ValueError("启用图谱记忆更新时必须提供 graph_id")
-            
+                raise ValueError("graph_id must be provided when graph memory updates are enabled")
+
             try:
                 ZepGraphMemoryManager.create_updater(simulation_id, graph_id)
                 cls._graph_memory_enabled[simulation_id] = True
-                logger.info(f"已启用图谱记忆更新: simulation_id={simulation_id}, graph_id={graph_id}")
+                logger.info(f"Graph memory updates enabled: simulation_id={simulation_id}, graph_id={graph_id}")
             except Exception as e:
-                logger.error(f"创建图谱记忆更新器失败: {e}")
+                logger.error(f"Failed to create graph memory updater: {e}")
                 cls._graph_memory_enabled[simulation_id] = False
         else:
             cls._graph_memory_enabled[simulation_id] = False
-        
-        # 确定运行哪个脚本（脚本位于 backend/scripts/ 目录）
+
+        # Determine which script to run (scripts live under backend/scripts/)
         if platform == "twitter":
             script_name = "run_twitter_simulation.py"
             state.twitter_running = True
@@ -395,71 +395,71 @@ class SimulationRunner:
             script_name = "run_parallel_simulation.py"
             state.twitter_running = True
             state.reddit_running = True
-        
+
         script_path = os.path.join(cls.SCRIPTS_DIR, script_name)
-        
+
         if not os.path.exists(script_path):
-            raise ValueError(f"脚本不存在: {script_path}")
-        
-        # 创建动作队列
+            raise ValueError(f"Script does not exist: {script_path}")
+
+        # Create action queue
         action_queue = Queue()
         cls._action_queues[simulation_id] = action_queue
-        
-        # 启动模拟进程
+
+        # Start the simulation process
         try:
-            # 构建运行命令，使用完整路径
-            # 新的日志结构：
-            #   twitter/actions.jsonl - Twitter 动作日志
-            #   reddit/actions.jsonl  - Reddit 动作日志
-            #   simulation.log        - 主进程日志
-            
+            # Build the run command using full paths.
+            # New log layout:
+            #   twitter/actions.jsonl - Twitter action log
+            #   reddit/actions.jsonl  - Reddit action log
+            #   simulation.log        - Main process log
+
             cmd = [
-                sys.executable,  # Python解释器
+                sys.executable,  # Python interpreter
                 script_path,
-                "--config", config_path,  # 使用完整配置文件路径
+                "--config", config_path,  # Use the full config-file path
             ]
-            
-            # 如果指定了最大轮数，添加到命令行参数
+
+            # If a maximum round count was specified, append it to the command-line args
             if max_rounds is not None and max_rounds > 0:
                 cmd.extend(["--max-rounds", str(max_rounds)])
-            
-            # 创建主日志文件，避免 stdout/stderr 管道缓冲区满导致进程阻塞
+
+            # Create a main log file to avoid the process blocking when stdout/stderr pipe buffers fill up
             main_log_path = os.path.join(sim_dir, "simulation.log")
             main_log_file = open(main_log_path, 'w', encoding='utf-8')
-            
-            # 设置子进程环境变量，确保 Windows 上使用 UTF-8 编码
-            # 这可以修复第三方库（如 OASIS）读取文件时未指定编码的问题
+
+            # Set the child process environment variables to ensure UTF-8 encoding on Windows.
+            # This works around third-party libraries (e.g., OASIS) that read files without specifying an encoding.
             env = os.environ.copy()
-            env['PYTHONUTF8'] = '1'  # Python 3.7+ 支持，让所有 open() 默认使用 UTF-8
-            env['PYTHONIOENCODING'] = 'utf-8'  # 确保 stdout/stderr 使用 UTF-8
-            
-            # 设置工作目录为模拟目录（数据库等文件会生成在此）
-            # 使用 start_new_session=True 创建新的进程组，确保可以通过 os.killpg 终止所有子进程
+            env['PYTHONUTF8'] = '1'  # Supported on Python 3.7+; makes all open() calls default to UTF-8
+            env['PYTHONIOENCODING'] = 'utf-8'  # Ensure stdout/stderr use UTF-8
+
+            # Set the working directory to the simulation directory (databases and other files will be generated here).
+            # Use start_new_session=True to create a new process group so that all child processes can be terminated via os.killpg.
             process = subprocess.Popen(
                 cmd,
                 cwd=sim_dir,
                 stdout=main_log_file,
-                stderr=subprocess.STDOUT,  # stderr 也写入同一个文件
+                stderr=subprocess.STDOUT,  # stderr is also written to the same file
                 text=True,
-                encoding='utf-8',  # 显式指定编码
+                encoding='utf-8',  # Specify encoding explicitly
                 bufsize=1,
-                env=env,  # 传递带有 UTF-8 设置的环境变量
-                start_new_session=True,  # 创建新进程组，确保服务器关闭时能终止所有相关进程
+                env=env,  # Pass environment variables containing the UTF-8 settings
+                start_new_session=True,  # Create a new process group so all related processes can be terminated when the server shuts down
             )
-            
-            # 保存文件句柄以便后续关闭
+
+            # Save file handles so they can be closed later
             cls._stdout_files[simulation_id] = main_log_file
-            cls._stderr_files[simulation_id] = None  # 不再需要单独的 stderr
-            
+            cls._stderr_files[simulation_id] = None  # Separate stderr is no longer needed
+
             state.process_pid = process.pid
             state.runner_status = RunnerStatus.RUNNING
             cls._processes[simulation_id] = process
             cls._save_run_state(state)
-            
+
             # Capture locale before spawning monitor thread
             current_locale = get_locale()
 
-            # 启动监控线程
+            # Start the monitor thread
             monitor_thread = threading.Thread(
                 target=cls._monitor_simulation,
                 args=(simulation_id, current_locale),
@@ -467,106 +467,106 @@ class SimulationRunner:
             )
             monitor_thread.start()
             cls._monitor_threads[simulation_id] = monitor_thread
-            
-            logger.info(f"模拟启动成功: {simulation_id}, pid={process.pid}, platform={platform}")
-            
+
+            logger.info(f"Simulation started successfully: {simulation_id}, pid={process.pid}, platform={platform}")
+
         except Exception as e:
             state.runner_status = RunnerStatus.FAILED
             state.error = str(e)
             cls._save_run_state(state)
             raise
-        
+
         return state
-    
+
     @classmethod
     def _monitor_simulation(cls, simulation_id: str, locale: str = 'zh'):
-        """监控模拟进程，解析动作日志"""
+        """Monitor the simulation process and parse the action log"""
         set_locale(locale)
         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
-        
-        # 新的日志结构：分平台的动作日志
+
+        # New log layout: per-platform action logs
         twitter_actions_log = os.path.join(sim_dir, "twitter", "actions.jsonl")
         reddit_actions_log = os.path.join(sim_dir, "reddit", "actions.jsonl")
-        
+
         process = cls._processes.get(simulation_id)
         state = cls.get_run_state(simulation_id)
-        
+
         if not process or not state:
             return
-        
+
         twitter_position = 0
         reddit_position = 0
-        
+
         try:
-            while process.poll() is None:  # 进程仍在运行
-                # 读取 Twitter 动作日志
+            while process.poll() is None:  # Process is still running
+                # Read the Twitter action log
                 if os.path.exists(twitter_actions_log):
                     twitter_position = cls._read_action_log(
                         twitter_actions_log, twitter_position, state, "twitter"
                     )
-                
-                # 读取 Reddit 动作日志
+
+                # Read the Reddit action log
                 if os.path.exists(reddit_actions_log):
                     reddit_position = cls._read_action_log(
                         reddit_actions_log, reddit_position, state, "reddit"
                     )
-                
-                # 更新状态
+
+                # Update state
                 cls._save_run_state(state)
                 time.sleep(2)
-            
-            # 进程结束后，最后读取一次日志
+
+            # After the process exits, do one final read of the logs
             if os.path.exists(twitter_actions_log):
                 cls._read_action_log(twitter_actions_log, twitter_position, state, "twitter")
             if os.path.exists(reddit_actions_log):
                 cls._read_action_log(reddit_actions_log, reddit_position, state, "reddit")
-            
-            # 进程结束
+
+            # Process has exited
             exit_code = process.returncode
-            
+
             if exit_code == 0:
                 state.runner_status = RunnerStatus.COMPLETED
                 state.completed_at = datetime.now().isoformat()
-                logger.info(f"模拟完成: {simulation_id}")
+                logger.info(f"Simulation complete: {simulation_id}")
             else:
                 state.runner_status = RunnerStatus.FAILED
-                # 从主日志文件读取错误信息
+                # Read the error info from the main log file
                 main_log_path = os.path.join(sim_dir, "simulation.log")
                 error_info = ""
                 try:
                     if os.path.exists(main_log_path):
                         with open(main_log_path, 'r', encoding='utf-8') as f:
-                            error_info = f.read()[-2000:]  # 取最后2000字符
+                            error_info = f.read()[-2000:]  # Take the last 2000 characters
                 except Exception:
                     pass
-                state.error = f"进程退出码: {exit_code}, 错误: {error_info}"
-                logger.error(f"模拟失败: {simulation_id}, error={state.error}")
-            
+                state.error = f"Process exit code: {exit_code}, error: {error_info}"
+                logger.error(f"Simulation failed: {simulation_id}, error={state.error}")
+
             state.twitter_running = False
             state.reddit_running = False
             cls._save_run_state(state)
-            
+
         except Exception as e:
-            logger.error(f"监控线程异常: {simulation_id}, error={str(e)}")
+            logger.error(f"Monitor thread exception: {simulation_id}, error={str(e)}")
             state.runner_status = RunnerStatus.FAILED
             state.error = str(e)
             cls._save_run_state(state)
-        
+
         finally:
-            # 停止图谱记忆更新器
+            # Stop the graph memory updater
             if cls._graph_memory_enabled.get(simulation_id, False):
                 try:
                     ZepGraphMemoryManager.stop_updater(simulation_id)
-                    logger.info(f"已停止图谱记忆更新: simulation_id={simulation_id}")
+                    logger.info(f"Graph memory updates stopped: simulation_id={simulation_id}")
                 except Exception as e:
-                    logger.error(f"停止图谱记忆更新器失败: {e}")
+                    logger.error(f"Failed to stop graph memory updater: {e}")
                 cls._graph_memory_enabled.pop(simulation_id, None)
-            
-            # 清理进程资源
+
+            # Clean up process resources
             cls._processes.pop(simulation_id, None)
             cls._action_queues.pop(simulation_id, None)
-            
-            # 关闭日志文件句柄
+
+            # Close the log file handles
             if simulation_id in cls._stdout_files:
                 try:
                     cls._stdout_files[simulation_id].close()
@@ -579,33 +579,33 @@ class SimulationRunner:
                 except Exception:
                     pass
                 cls._stderr_files.pop(simulation_id, None)
-    
+
     @classmethod
     def _read_action_log(
-        cls, 
-        log_path: str, 
-        position: int, 
+        cls,
+        log_path: str,
+        position: int,
         state: SimulationRunState,
         platform: str
     ) -> int:
         """
-        读取动作日志文件
-        
+        Read the action log file.
+
         Args:
-            log_path: 日志文件路径
-            position: 上次读取位置
-            state: 运行状态对象
-            platform: 平台名称 (twitter/reddit)
-            
+            log_path: Log file path
+            position: Last read position
+            state: Run state object
+            platform: Platform name (twitter/reddit)
+
         Returns:
-            新的读取位置
+            New read position
         """
-        # 检查是否启用了图谱记忆更新
+        # Check whether graph memory updates are enabled
         graph_memory_enabled = cls._graph_memory_enabled.get(state.simulation_id, False)
         graph_updater = None
         if graph_memory_enabled:
             graph_updater = ZepGraphMemoryManager.get_updater(state.simulation_id)
-        
+
         try:
             with open(log_path, 'r', encoding='utf-8') as f:
                 f.seek(position)
@@ -614,37 +614,37 @@ class SimulationRunner:
                     if line:
                         try:
                             action_data = json.loads(line)
-                            
-                            # 处理事件类型的条目
+
+                            # Handle event-type entries
                             if "event_type" in action_data:
                                 event_type = action_data.get("event_type")
-                                
-                                # 检测 simulation_end 事件，标记平台已完成
+
+                                # Detect simulation_end events and mark the platform as completed
                                 if event_type == "simulation_end":
                                     if platform == "twitter":
                                         state.twitter_completed = True
                                         state.twitter_running = False
-                                        logger.info(f"Twitter 模拟已完成: {state.simulation_id}, total_rounds={action_data.get('total_rounds')}, total_actions={action_data.get('total_actions')}")
+                                        logger.info(f"Twitter simulation completed: {state.simulation_id}, total_rounds={action_data.get('total_rounds')}, total_actions={action_data.get('total_actions')}")
                                     elif platform == "reddit":
                                         state.reddit_completed = True
                                         state.reddit_running = False
-                                        logger.info(f"Reddit 模拟已完成: {state.simulation_id}, total_rounds={action_data.get('total_rounds')}, total_actions={action_data.get('total_actions')}")
-                                    
-                                    # 检查是否所有启用的平台都已完成
-                                    # 如果只运行了一个平台，只检查那个平台
-                                    # 如果运行了两个平台，需要两个都完成
+                                        logger.info(f"Reddit simulation completed: {state.simulation_id}, total_rounds={action_data.get('total_rounds')}, total_actions={action_data.get('total_actions')}")
+
+                                    # Check whether all enabled platforms have completed.
+                                    # If only one platform was run, only that one is checked.
+                                    # If both platforms were run, both must complete.
                                     all_completed = cls._check_all_platforms_completed(state)
                                     if all_completed:
                                         state.runner_status = RunnerStatus.COMPLETED
                                         state.completed_at = datetime.now().isoformat()
-                                        logger.info(f"所有平台模拟已完成: {state.simulation_id}")
-                                
-                                # 更新轮次信息（从 round_end 事件）
+                                        logger.info(f"All platform simulations completed: {state.simulation_id}")
+
+                                # Update round info (from round_end events)
                                 elif event_type == "round_end":
                                     round_num = action_data.get("round", 0)
                                     simulated_hours = action_data.get("simulated_hours", 0)
-                                    
-                                    # 更新各平台独立的轮次和时间
+
+                                    # Update each platform's independent round and time
                                     if platform == "twitter":
                                         if round_num > state.twitter_current_round:
                                             state.twitter_current_round = round_num
@@ -653,15 +653,15 @@ class SimulationRunner:
                                         if round_num > state.reddit_current_round:
                                             state.reddit_current_round = round_num
                                         state.reddit_simulated_hours = simulated_hours
-                                    
-                                    # 总体轮次取两个平台的最大值
+
+                                    # Overall round number takes the max of both platforms
                                     if round_num > state.current_round:
                                         state.current_round = round_num
-                                    # 总体时间取两个平台的最大值
+                                    # Overall time takes the max of both platforms
                                     state.simulated_hours = max(state.twitter_simulated_hours, state.reddit_simulated_hours)
-                                
+
                                 continue
-                            
+
                             action = AgentAction(
                                 round_num=action_data.get("round", 0),
                                 timestamp=action_data.get("timestamp", datetime.now().isoformat()),
@@ -674,65 +674,66 @@ class SimulationRunner:
                                 success=action_data.get("success", True),
                             )
                             state.add_action(action)
-                            
-                            # 更新轮次
+
+                            # Update round
                             if action.round_num and action.round_num > state.current_round:
                                 state.current_round = action.round_num
-                            
-                            # 如果启用了图谱记忆更新，将活动发送到Zep
+
+                            # If graph memory updates are enabled, send the activity to Zep
                             if graph_updater:
                                 graph_updater.add_activity_from_dict(action_data, platform)
-                            
+
                         except json.JSONDecodeError:
                             pass
                 return f.tell()
         except Exception as e:
-            logger.warning(f"读取动作日志失败: {log_path}, error={e}")
+            logger.warning(f"Failed to read action log: {log_path}, error={e}")
             return position
-    
+
     @classmethod
     def _check_all_platforms_completed(cls, state: SimulationRunState) -> bool:
         """
-        检查所有启用的平台是否都已完成模拟
-        
-        通过检查对应的 actions.jsonl 文件是否存在来判断平台是否被启用
-        
+        Check whether all enabled platforms have completed simulation.
+
+        Determines whether a platform is enabled by checking the existence of the corresponding
+        actions.jsonl file.
+
         Returns:
-            True 如果所有启用的平台都已完成
+            True if every enabled platform has completed.
         """
         sim_dir = os.path.join(cls.RUN_STATE_DIR, state.simulation_id)
         twitter_log = os.path.join(sim_dir, "twitter", "actions.jsonl")
         reddit_log = os.path.join(sim_dir, "reddit", "actions.jsonl")
-        
-        # 检查哪些平台被启用（通过文件是否存在判断）
+
+        # Determine which platforms are enabled (based on file existence)
         twitter_enabled = os.path.exists(twitter_log)
         reddit_enabled = os.path.exists(reddit_log)
-        
-        # 如果平台被启用但未完成，则返回 False
+
+        # If a platform is enabled but has not finished, return False
         if twitter_enabled and not state.twitter_completed:
             return False
         if reddit_enabled and not state.reddit_completed:
             return False
-        
-        # 至少有一个平台被启用且已完成
+
+        # At least one platform is enabled and has completed
         return twitter_enabled or reddit_enabled
-    
+
     @classmethod
     def _terminate_process(cls, process: subprocess.Popen, simulation_id: str, timeout: int = 10):
         """
-        跨平台终止进程及其子进程
-        
+        Cross-platform termination of a process and its children.
+
         Args:
-            process: 要终止的进程
-            simulation_id: 模拟ID（用于日志）
-            timeout: 等待进程退出的超时时间（秒）
+            process: Process to terminate
+            simulation_id: Simulation ID (used in logs)
+            timeout: How long to wait (seconds) for the process to exit
         """
         if IS_WINDOWS:
-            # Windows: 使用 taskkill 命令终止进程树
-            # /F = 强制终止, /T = 终止进程树（包括子进程）
-            logger.info(f"终止进程树 (Windows): simulation={simulation_id}, pid={process.pid}")
+            # Windows: use the taskkill command to terminate the process tree
+            # /F = force termination, /T = terminate the process tree (including child processes)
+            logger.info(f"Terminating process tree (Windows): simulation={simulation_id}, pid={process.pid}")
             try:
-                # 先尝试优雅终止
+                # Try a graceful termination first
                 subprocess.run(
                     ['taskkill', '/PID', str(process.pid), '/T'],
                     capture_output=True,
@@ -741,8 +742,8 @@ class SimulationRunner:
                 try:
                     process.wait(timeout=timeout)
                 except subprocess.TimeoutExpired:
-                    # 强制终止
-                    logger.warning(f"进程未响应，强制终止: {simulation_id}")
+                    # Force termination
+                    logger.warning(f"Process did not respond, forcing termination: {simulation_id}")
                     subprocess.run(
                         ['taskkill', '/F', '/PID', str(process.pid), '/T'],
                         capture_output=True,
@@ -750,77 +751,77 @@ class SimulationRunner:
                     )
                     process.wait(timeout=5)
             except Exception as e:
-                logger.warning(f"taskkill 失败，尝试 terminate: {e}")
+                logger.warning(f"taskkill failed; trying terminate: {e}")
                 process.terminate()
                 try:
                     process.wait(timeout=5)
                 except subprocess.TimeoutExpired:
                     process.kill()
         else:
-            # Unix: 使用进程组终止
-            # 由于使用了 start_new_session=True，进程组 ID 等于主进程 PID
+            # Unix: terminate via the process group.
+            # Because start_new_session=True was used, the process group ID equals the main process PID.
             pgid = os.getpgid(process.pid)
-            logger.info(f"终止进程组 (Unix): simulation={simulation_id}, pgid={pgid}")
-            
-            # 先发送 SIGTERM 给整个进程组
+            logger.info(f"Terminating process group (Unix): simulation={simulation_id}, pgid={pgid}")
+
+            # First send SIGTERM to the entire process group
             os.killpg(pgid, signal.SIGTERM)
-            
+
             try:
                 process.wait(timeout=timeout)
             except subprocess.TimeoutExpired:
-                # 如果超时后还没结束，强制发送 SIGKILL
-                logger.warning(f"进程组未响应 SIGTERM，强制终止: {simulation_id}")
+                # If the process is still alive after the timeout, force-send SIGKILL
+                logger.warning(f"Process group did not respond to SIGTERM, forcing termination: {simulation_id}")
                 os.killpg(pgid, signal.SIGKILL)
                 process.wait(timeout=5)
-    
+
     @classmethod
     def stop_simulation(cls, simulation_id: str) -> SimulationRunState:
-        """停止模拟"""
+        """Stop the simulation"""
         state = cls.get_run_state(simulation_id)
         if not state:
-            raise ValueError(f"模拟不存在: {simulation_id}")
-        
+            raise ValueError(f"Simulation does not exist: {simulation_id}")
+
         if state.runner_status not in [RunnerStatus.RUNNING, RunnerStatus.PAUSED]:
-            raise ValueError(f"模拟未在运行: {simulation_id}, status={state.runner_status}")
-        
+            raise ValueError(f"Simulation is not running: {simulation_id}, status={state.runner_status}")
+
         state.runner_status = RunnerStatus.STOPPING
         cls._save_run_state(state)
-        
-        # 终止进程
+
+        # Terminate the process
         process = cls._processes.get(simulation_id)
         if process and process.poll() is None:
             try:
                 cls._terminate_process(process, simulation_id)
             except ProcessLookupError:
-                # 进程已经不存在
+                # The process no longer exists
                 pass
             except Exception as e:
-                logger.error(f"终止进程组失败: {simulation_id}, error={e}")
-                # 回退到直接终止进程
+                logger.error(f"Failed to terminate process group: {simulation_id}, error={e}")
+                # Fall back to terminating the process directly
                 try:
                     process.terminate()
                     process.wait(timeout=5)
                 except Exception:
                     process.kill()
-        
+
         state.runner_status = RunnerStatus.STOPPED
         state.twitter_running = False
         state.reddit_running = False
         state.completed_at = datetime.now().isoformat()
         cls._save_run_state(state)
-        
-        # 停止图谱记忆更新器
+
+        # Stop the graph memory updater
         if cls._graph_memory_enabled.get(simulation_id, False):
             try:
                 ZepGraphMemoryManager.stop_updater(simulation_id)
-                logger.info(f"已停止图谱记忆更新: simulation_id={simulation_id}")
+                logger.info(f"Graph memory updates stopped: simulation_id={simulation_id}")
             except Exception as e:
-                logger.error(f"停止图谱记忆更新器失败: {e}")
+                logger.error(f"Failed to stop graph memory updater: {e}")
             cls._graph_memory_enabled.pop(simulation_id, None)
-        
-        logger.info(f"模拟已停止: {simulation_id}")
+
+        logger.info(f"Simulation stopped: {simulation_id}")
         return state
-    
+
     @classmethod
     def _read_actions_from_file(
         cls,
@@ -831,48 +832,48 @@ class SimulationRunner:
         round_num: Optional[int] = None
     ) -> List[AgentAction]:
         """
-        从单个动作文件中读取动作
-        
+        Read actions from a single action file.
+
         Args:
-            file_path: 动作日志文件路径
-            default_platform: 默认平台（当动作记录中没有 platform 字段时使用）
-            platform_filter: 过滤平台
-            agent_id: 过滤 Agent ID
-            round_num: 过滤轮次
+            file_path: Action log file path
+            default_platform: Default platform (used when the action record does not contain a platform field)
+            platform_filter: Filter by platform
+            agent_id: Filter by agent ID
+            round_num: Filter by round
         """
         if not os.path.exists(file_path):
             return []
-        
+
         actions = []
-        
+
         with open(file_path, 'r', encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
                 if not line:
                     continue
-                
+
                 try:
                     data = json.loads(line)
-                    
-                    # 跳过非动作记录（如 simulation_start, round_start, round_end 等事件）
+
+                    # Skip non-action records (e.g., simulation_start, round_start, round_end events)
                     if "event_type" in data:
                         continue
-                    
-                    # 跳过没有 agent_id 的记录（非 Agent 动作）
+
+                    # Skip records without an agent_id (non-agent actions)
                     if "agent_id" not in data:
                         continue
-                    
-                    # 获取平台：优先使用记录中的 platform，否则使用默认平台
+
+                    # Determine platform: prefer the record's platform, otherwise use the default
                     record_platform = data.get("platform") or default_platform or ""
-                    
-                    # 过滤
+
+                    # Filtering
                     if platform_filter and record_platform != platform_filter:
                         continue
                     if agent_id is not None and data.get("agent_id") != agent_id:
                         continue
                     if round_num is not None and data.get("round") != round_num:
                         continue
-                    
+
                     actions.append(AgentAction(
                         round_num=data.get("round", 0),
                         timestamp=data.get("timestamp", ""),
@@ -884,12 +885,12 @@ class SimulationRunner:
                         result=data.get("result"),
                         success=data.get("success", True),
                     ))
-                    
+
                 except json.JSONDecodeError:
                     continue
-        
+
         return actions
-    
+
     @classmethod
     def get_all_actions(
         cls,
@@ -899,58 +900,58 @@ class SimulationRunner:
         round_num: Optional[int] = None
     ) -> List[AgentAction]:
         """
-        获取所有平台的完整动作历史（无分页限制）
-        
+        Get the complete action history across all platforms (no pagination).
+
         Args:
-            simulation_id: 模拟ID
-            platform: 过滤平台（twitter/reddit）
-            agent_id: 过滤Agent
-            round_num: 过滤轮次
-            
+            simulation_id: Simulation ID
+            platform: Filter by platform (twitter/reddit)
+            agent_id: Filter by agent
+            round_num: Filter by round
+
         Returns:
-            完整的动作列表（按时间戳排序，新的在前）
+            Complete list of actions (sorted by timestamp, newest first)
         """
         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
         actions = []
-        
-        # 读取 Twitter 动作文件（根据文件路径自动设置 platform 为 twitter）
+
+        # Read the Twitter actions file (auto-set platform to twitter based on path)
         twitter_actions_log = os.path.join(sim_dir, "twitter", "actions.jsonl")
         if not platform or platform == "twitter":
             actions.extend(cls._read_actions_from_file(
                 twitter_actions_log,
-                default_platform="twitter",  # 自动填充 platform 字段
+                default_platform="twitter",  # Auto-fill the platform field
                 platform_filter=platform,
-                agent_id=agent_id, 
+                agent_id=agent_id,
                 round_num=round_num
             ))
-        
-        # 读取 Reddit 动作文件（根据文件路径自动设置 platform 为 reddit）
+
+        # Read the Reddit actions file (auto-set platform to reddit based on path)
         reddit_actions_log = os.path.join(sim_dir, "reddit", "actions.jsonl")
         if not platform or platform == "reddit":
             actions.extend(cls._read_actions_from_file(
                 reddit_actions_log,
-                default_platform="reddit",  # 自动填充 platform 字段
+                default_platform="reddit",  # Auto-fill the platform field
                 platform_filter=platform,
                 agent_id=agent_id,
                 round_num=round_num
             ))
-        
-        # 如果分平台文件不存在，尝试读取旧的单一文件格式
+
+        # If the per-platform files do not exist, try the legacy single-file format
         if not actions:
             actions_log = os.path.join(sim_dir, "actions.jsonl")
             actions = cls._read_actions_from_file(
                 actions_log,
-                default_platform=None,  # 旧格式文件中应该有 platform 字段
+                default_platform=None,  # Legacy files should already have a platform field
                 platform_filter=platform,
                 agent_id=agent_id,
                 round_num=round_num
             )
-        
-        # 按时间戳排序（新的在前）
+
+        # Sort by timestamp (newest first)
         actions.sort(key=lambda x: x.timestamp, reverse=True)
-        
+
         return actions
-    
+
     @classmethod
     def get_actions(
         cls,
@@ -962,18 +963,18 @@ class SimulationRunner:
         round_num: Optional[int] = None
     ) -> List[AgentAction]:
         """
-        获取动作历史（带分页）
-        
+        Get the action history (paginated).
+
         Args:
-            simulation_id: 模拟ID
-            limit: 返回数量限制
-            offset: 偏移量
-            platform: 过滤平台
-            agent_id: 过滤Agent
-            round_num: 过滤轮次
-            
+            simulation_id: Simulation ID
+            limit: Maximum number of items to return
+            offset: Offset
+            platform: Filter by platform
+            agent_id: Filter by agent
+            round_num: Filter by round
+
         Returns:
-            动作列表
+            List of actions
         """
         actions = cls.get_all_actions(
             simulation_id=simulation_id,
@@ -981,10 +982,10 @@ class SimulationRunner:
             agent_id=agent_id,
             round_num=round_num
         )
-        
-        # 分页
+
+        # Pagination
         return actions[offset:offset + limit]
-    
+
     @classmethod
     def get_timeline(
         cls,
@@ -993,29 +994,29 @@ class SimulationRunner:
         end_round: Optional[int] = None
     ) -> List[Dict[str, Any]]:
         """
-        获取模拟时间线（按轮次汇总）
-        
+        Get the simulation timeline (aggregated by round).
+
         Args:
-            simulation_id: 模拟ID
-            start_round: 起始轮次
-            end_round: 结束轮次
-            
+            simulation_id: Simulation ID
+            start_round: Starting round
+            end_round: Ending round
+
         Returns:
-            每轮的汇总信息
+            Per-round summary information
         """
         actions = cls.get_actions(simulation_id, limit=10000)
-        
-        # 按轮次分组
+
+        # Group by round
         rounds: Dict[int, Dict[str, Any]] = {}
-        
+
         for action in actions:
             round_num = action.round_num
-            
+
             if round_num < start_round:
                 continue
             if end_round is not None and round_num > end_round:
                 continue
-            
+
             if round_num not in rounds:
                 rounds[round_num] = {
                     "round_num": round_num,
@@ -1026,19 +1027,19 @@ class SimulationRunner:
                     "first_action_time": action.timestamp,
                     "last_action_time": action.timestamp,
                 }
-            
+
             r = rounds[round_num]
-            
+
             if action.platform == "twitter":
                 r["twitter_actions"] += 1
             else:
                 r["reddit_actions"] += 1
-            
+
             r["active_agents"].add(action.agent_id)
             r["action_types"][action.action_type] = r["action_types"].get(action.action_type, 0) + 1
             r["last_action_time"] = action.timestamp
-        
-        # 转换为列表
+
+        # Convert to a list
         result = []
         for round_num in sorted(rounds.keys()):
             r = rounds[round_num]
@@ -1053,24 +1054,24 @@ class SimulationRunner:
                 "first_action_time": r["first_action_time"],
                 "last_action_time": r["last_action_time"],
             })
-        
+
         return result
-    
+
     @classmethod
     def get_agent_stats(cls, simulation_id: str) -> List[Dict[str, Any]]:
         """
-        获取每个Agent的统计信息
-        
+        Get statistics for each agent.
+
         Returns:
-            Agent统计列表
+            List of agent statistics
         """
         actions = cls.get_actions(simulation_id, limit=10000)
-        
+
         agent_stats: Dict[int, Dict[str, Any]] = {}
-        
+
         for action in actions:
             agent_id = action.agent_id
-            
+
             if agent_id not in agent_stats:
                 agent_stats[agent_id] = {
                     "agent_id": agent_id,
@@ -1082,71 +1083,71 @@ class SimulationRunner:
                     "first_action_time": action.timestamp,
                     "last_action_time": action.timestamp,
                 }
-            
+
             stats = agent_stats[agent_id]
             stats["total_actions"] += 1
-            
+
             if action.platform == "twitter":
                 stats["twitter_actions"] += 1
             else:
                 stats["reddit_actions"] += 1
-            
+
             stats["action_types"][action.action_type] = stats["action_types"].get(action.action_type, 0) + 1
             stats["last_action_time"] = action.timestamp
-        
-        # 按总动作数排序
+
+        # Sort by total action count
         result = sorted(agent_stats.values(), key=lambda x: x["total_actions"], reverse=True)
-        
+
         return result
-    
+
     @classmethod
     def cleanup_simulation_logs(cls, simulation_id: str) -> Dict[str, Any]:
         """
-        清理模拟的运行日志（用于强制重新开始模拟）
-        
-        会删除以下文件：
+        Clean up the simulation's run logs (used to force-restart a simulation).
+
+        Deletes the following files:
         - run_state.json
         - twitter/actions.jsonl
         - reddit/actions.jsonl
         - simulation.log
         - stdout.log / stderr.log
-        - twitter_simulation.db（模拟数据库）
-        - reddit_simulation.db（模拟数据库）
-        - env_status.json（环境状态）
-        
-        注意：不会删除配置文件（simulation_config.json）和 profile 文件
-        
+        - twitter_simulation.db (simulation database)
+        - reddit_simulation.db (simulation database)
+        - env_status.json (environment status)
+
+        Note: configuration files (simulation_config.json) and profile files are not deleted.
+
         Args:
-            simulation_id: 模拟ID
-            
+            simulation_id: Simulation ID
+
         Returns:
-            清理结果信息
+            Cleanup result information
         """
         import shutil
-        
+
         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
-        
+
         if not os.path.exists(sim_dir):
-            return {"success": True, "message": "模拟目录不存在，无需清理"}
-        
+            return {"success": True, "message": "Simulation directory does not exist; no cleanup needed"}
+
         cleaned_files = []
         errors = []
-        
-        # 要删除的文件列表（包括数据库文件）
+
+        # List of files to delete (including database files)
         files_to_delete = [
             "run_state.json",
             "simulation.log",
             "stdout.log",
             "stderr.log",
-            "twitter_simulation.db",  # Twitter 平台数据库
-            "reddit_simulation.db",   # Reddit 平台数据库
-            "env_status.json",        # 环境状态文件
+            "twitter_simulation.db",  # Twitter platform database
+            "reddit_simulation.db",   # Reddit platform database
+            "env_status.json",        # Environment status file
         ]
-        
-        # 要删除的目录列表（包含动作日志）
+
+        # List of directories to clean (containing action logs)
         dirs_to_clean = ["twitter", "reddit"]
-        
-        # 删除文件
+
+        # Delete files
         for filename in files_to_delete:
             file_path = os.path.join(sim_dir, filename)
             if os.path.exists(file_path):
@@ -1154,9 +1155,9 @@ class SimulationRunner:
                     os.remove(file_path)
                     cleaned_files.append(filename)
                 except Exception as e:
-                    errors.append(f"删除 {filename} 失败: {str(e)}")
-        
-        # 清理平台目录中的动作日志
+                    errors.append(f"Failed to delete {filename}: {str(e)}")
+
+        # Clean up action logs in the platform directories
         for dir_name in dirs_to_clean:
             dir_path = os.path.join(sim_dir, dir_name)
             if os.path.exists(dir_path):
@@ -1166,85 +1167,85 @@ class SimulationRunner:
                         os.remove(actions_file)
                         cleaned_files.append(f"{dir_name}/actions.jsonl")
                     except Exception as e:
-                        errors.append(f"删除 {dir_name}/actions.jsonl 失败: {str(e)}")
-        
-        # 清理内存中的运行状态
+                        errors.append(f"Failed to delete {dir_name}/actions.jsonl: {str(e)}")
+
+        # Clean up the in-memory run state
         if simulation_id in cls._run_states:
             del cls._run_states[simulation_id]
-        
-        logger.info(f"清理模拟日志完成: {simulation_id}, 删除文件: {cleaned_files}")
-        
+
+        logger.info(f"Simulation log cleanup complete: {simulation_id}, deleted files: {cleaned_files}")
+
         return {
             "success": len(errors) == 0,
             "cleaned_files": cleaned_files,
             "errors": errors if errors else None
         }
-    
-    # 防止重复清理的标志
+
+    # Flag to prevent repeated cleanup
     _cleanup_done = False
-    
+
     @classmethod
     def cleanup_all_simulations(cls):
         """
-        清理所有运行中的模拟进程
-        
-        在服务器关闭时调用，确保所有子进程被终止
+        Clean up all running simulation processes.
+
+        Called during server shutdown to ensure all child processes are terminated.
         """
-        # 防止重复清理
+        # Prevent duplicate cleanup
         if cls._cleanup_done:
             return
         cls._cleanup_done = True
-        
-        # 检查是否有内容需要清理（避免空进程的进程打印无用日志）
+
+        # Check whether there is anything to clean up (avoids spurious empty-process logs)
         has_processes = bool(cls._processes)
         has_updaters = bool(cls._graph_memory_enabled)
-        
+
         if not has_processes and not has_updaters:
-            return  # 没有需要清理的内容，静默返回
-        
-        logger.info("正在清理所有模拟进程...")
-        
-        # 首先停止所有图谱记忆更新器（stop_all 内部会打印日志）
+            return  # Nothing to clean up; return silently
+
+        logger.info("Cleaning up all simulation processes...")
+
+        # First stop all graph memory updaters (stop_all logs internally)
         try:
             ZepGraphMemoryManager.stop_all()
         except Exception as e:
-            logger.error(f"停止图谱记忆更新器失败: {e}")
+            logger.error(f"Failed to stop graph memory updaters: {e}")
         cls._graph_memory_enabled.clear()
-        
-        # 复制字典以避免在迭代时修改
+
+        # Copy the dict to avoid modification during iteration
         processes = list(cls._processes.items())
-        
+
         for simulation_id, process in processes:
             try:
-                if process.poll() is None:  # 进程仍在运行
-                    logger.info(f"终止模拟进程: {simulation_id}, pid={process.pid}")
-                    
+                if process.poll() is None:  # Process is still running
+                    logger.info(f"Terminating simulation process: {simulation_id}, pid={process.pid}")
+
                     try:
-                        # 使用跨平台的进程终止方法
+                        # Use the cross-platform process termination helper
                         cls._terminate_process(process, simulation_id, timeout=5)
                     except (ProcessLookupError, OSError):
-                        # 进程可能已经不存在，尝试直接终止
+                        # Process may already be gone; try terminating directly
                         try:
                             process.terminate()
                             process.wait(timeout=3)
                         except Exception:
                             process.kill()
-                    
-                    # 更新 run_state.json
+
+                    # Update run_state.json
                     state = cls.get_run_state(simulation_id)
                     if state:
                         state.runner_status = RunnerStatus.STOPPED
                         state.twitter_running = False
                         state.reddit_running = False
                         state.completed_at = datetime.now().isoformat()
-                        state.error = "服务器关闭，模拟被终止"
+                        state.error = "Server shutdown; simulation was terminated"
                         cls._save_run_state(state)
-                    
-                    # 同时更新 state.json，将状态设为 stopped
+
+                    # Also update state.json to set status to stopped
                     try:
                         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
                         state_file = os.path.join(sim_dir, "state.json")
-                        logger.info(f"尝试更新 state.json: {state_file}")
+                        logger.info(f"Attempting to update state.json: {state_file}")
                         if os.path.exists(state_file):
                             with open(state_file, 'r', encoding='utf-8') as f:
                                 state_data = json.load(f)
@@ -1252,16 +1253,16 @@ class SimulationRunner:
                             state_data['updated_at'] = datetime.now().isoformat()
                             with open(state_file, 'w', encoding='utf-8') as f:
                                 json.dump(state_data, f, indent=2, ensure_ascii=False)
-                            logger.info(f"已更新 state.json 状态为 stopped: {simulation_id}")
+                            logger.info(f"Updated state.json status to stopped: {simulation_id}")
                         else:
-                            logger.warning(f"state.json 不存在: {state_file}")
+                            logger.warning(f"state.json does not exist: {state_file}")
                     except Exception as state_err:
-                        logger.warning(f"更新 state.json 失败: {simulation_id}, error={state_err}")
-                        
+                        logger.warning(f"Failed to update state.json: {simulation_id}, error={state_err}")
+
             except Exception as e:
-                logger.error(f"清理进程失败: {simulation_id}, error={e}")
-        
-        # 清理文件句柄
+                logger.error(f"Failed to clean up process: {simulation_id}, error={e}")
+
+        # Clean up file handles
         for simulation_id, file_handle in list(cls._stdout_files.items()):
             try:
                 if file_handle:
@@ -1269,7 +1270,7 @@ class SimulationRunner:
             except Exception:
                 pass
         cls._stdout_files.clear()
-        
+
         for simulation_id, file_handle in list(cls._stderr_files.items()):
             try:
                 if file_handle:
@@ -1277,109 +1278,110 @@ class SimulationRunner:
             except Exception:
                 pass
         cls._stderr_files.clear()
-        
-        # 清理内存中的状态
+
+        # Clean up in-memory state
         cls._processes.clear()
         cls._action_queues.clear()
-        
-        logger.info("模拟进程清理完成")
-    
+
+        logger.info("Simulation process cleanup complete")
+
     @classmethod
     def register_cleanup(cls):
         """
-        注册清理函数
-        
-        在 Flask 应用启动时调用，确保服务器关闭时清理所有模拟进程
+        Register the cleanup function.
+
+        Called at Flask application startup to ensure all simulation processes are
+        cleaned up when the server shuts down.
         """
         global _cleanup_registered
-        
+
         if _cleanup_registered:
             return
-        
-        # Flask debug 模式下，只在 reloader 子进程中注册清理（实际运行应用的进程）
-        # WERKZEUG_RUN_MAIN=true 表示是 reloader 子进程
-        # 如果不是 debug 模式，则没有这个环境变量，也需要注册
+
+        # In Flask debug mode, only register cleanup in the reloader child process (the one that actually runs the app)
+        # WERKZEUG_RUN_MAIN=true indicates the reloader child process
+        # Outside debug mode this env var is absent, and we must still register
         is_reloader_process = os.environ.get('WERKZEUG_RUN_MAIN') == 'true'
         is_debug_mode = os.environ.get('FLASK_DEBUG') == '1' or os.environ.get('WERKZEUG_RUN_MAIN') is not None
-        
-        # 在 debug 模式下，只在 reloader 子进程中注册；非 debug 模式下始终注册
+
+        # In debug mode, only register in the reloader child; outside debug mode, always register
         if is_debug_mode and not is_reloader_process:
-            _cleanup_registered = True  # 标记已注册，防止子进程再次尝试
+            _cleanup_registered = True  # Mark as registered to prevent the child from re-registering
             return
-        
-        # 保存原有的信号处理器
+
+        # Save existing signal handlers
         original_sigint = signal.getsignal(signal.SIGINT)
         original_sigterm = signal.getsignal(signal.SIGTERM)
-        # SIGHUP 只在 Unix 系统存在（macOS/Linux），Windows 没有
+        # SIGHUP only exists on Unix systems (macOS/Linux); Windows does not have it
         original_sighup = None
         has_sighup = hasattr(signal, 'SIGHUP')
         if has_sighup:
             original_sighup = signal.getsignal(signal.SIGHUP)
-        
+
         def cleanup_handler(signum=None, frame=None):
-            """信号处理器：先清理模拟进程，再调用原处理器"""
-            # 只有在有进程需要清理时才打印日志
+            """Signal handler: clean up simulation processes first, then call the original handler"""
+            # Only log when there are actually processes to clean up
             if cls._processes or cls._graph_memory_enabled:
-                logger.info(f"收到信号 {signum}，开始清理...")
+                logger.info(f"Received signal {signum}; starting cleanup...")
             cls.cleanup_all_simulations()
-            
-            # 调用原有的信号处理器，让 Flask 正常退出
+
+            # Call the original signal handler so Flask exits cleanly
             if signum == signal.SIGINT and callable(original_sigint):
                 original_sigint(signum, frame)
             elif signum == signal.SIGTERM and callable(original_sigterm):
                 original_sigterm(signum, frame)
             elif has_sighup and signum == signal.SIGHUP:
-                # SIGHUP: 终端关闭时发送
+                # SIGHUP: sent when the terminal closes
                 if callable(original_sighup):
                     original_sighup(signum, frame)
                 else:
-                    # 默认行为：正常退出
+                    # Default behavior: exit normally
                     sys.exit(0)
             else:
-                # 如果原处理器不可调用（如 SIG_DFL），则使用默认行为
+                # If the original handler is not callable (e.g., SIG_DFL), use the default behavior
                 raise KeyboardInterrupt
-        
-        # 注册 atexit 处理器（作为备用）
+
+        # Register the atexit handler (as a fallback)
         atexit.register(cls.cleanup_all_simulations)
-        
-        # 注册信号处理器（仅在主线程中）
+
+        # Register signal handlers (only in the main thread)
         try:
-            # SIGTERM: kill 命令默认信号
+            # SIGTERM: default signal sent by the kill command
             signal.signal(signal.SIGTERM, cleanup_handler)
             # SIGINT: Ctrl+C
             signal.signal(signal.SIGINT, cleanup_handler)
-            # SIGHUP: 终端关闭（仅 Unix 系统）
+            # SIGHUP: terminal close (Unix only)
             if has_sighup:
                 signal.signal(signal.SIGHUP, cleanup_handler)
         except ValueError:
-            # 不在主线程中，只能使用 atexit
-            logger.warning("无法注册信号处理器（不在主线程），仅使用 atexit")
-        
+            # Not in the main thread; can only use atexit
+            logger.warning("Unable to register signal handlers (not in the main thread); using atexit only")
+
         _cleanup_registered = True
-    
+
     @classmethod
     def get_running_simulations(cls) -> List[str]:
         """
-        获取所有正在运行的模拟ID列表
+        Get a list of all currently running simulation IDs.
         """
         running = []
         for sim_id, process in cls._processes.items():
             if process.poll() is None:
                 running.append(sim_id)
         return running
-    
-    # ============== Interview 功能 ==============
-    
+
+    # ============== Interview features ==============
+
     @classmethod
     def check_env_alive(cls, simulation_id: str) -> bool:
         """
-        检查模拟环境是否存活（可以接收Interview命令）
+        Check whether the simulation environment is alive (can accept Interview commands).
 
         Args:
-            simulation_id: 模拟ID
+            simulation_id: Simulation ID
 
         Returns:
-            True 表示环境存活，False 表示环境已关闭
+            True if the environment is alive, False if it has shut down.
         """
         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
         if not os.path.exists(sim_dir):
@@ -1391,27 +1393,27 @@ class SimulationRunner:
     @classmethod
     def get_env_status_detail(cls, simulation_id: str) -> Dict[str, Any]:
         """
-        获取模拟环境的详细状态信息
+        Get detailed status information for the simulation environment.
 
         Args:
-            simulation_id: 模拟ID
+            simulation_id: Simulation ID
 
         Returns:
-            状态详情字典，包含 status, twitter_available, reddit_available, timestamp
+            Status detail dict containing status, twitter_available, reddit_available, timestamp
         """
         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
         status_file = os.path.join(sim_dir, "env_status.json")
-        
+
         default_status = {
             "status": "stopped",
             "twitter_available": False,
             "reddit_available": False,
             "timestamp": None
         }
-        
+
         if not os.path.exists(status_file):
             return default_status
-        
+
         try:
             with open(status_file, 'r', encoding='utf-8') as f:
                 status = json.load(f)
@@ -1434,35 +1436,35 @@ class SimulationRunner:
         timeout: float = 60.0
     ) -> Dict[str, Any]:
         """
-        采访单个Agent
+        Interview a single agent.
 
         Args:
-            simulation_id: 模拟ID
+            simulation_id: Simulation ID
             agent_id: Agent ID
-            prompt: 采访问题
-            platform: 指定平台（可选）
-                - "twitter": 只采访Twitter平台
-                - "reddit": 只采访Reddit平台
-                - None: 双平台模拟时同时采访两个平台，返回整合结果
-            timeout: 超时时间（秒）
+            prompt: Interview question
+            platform: Specific platform (optional)
+                - "twitter": interview only the Twitter platform
+                - "reddit": interview only the Reddit platform
+                - None: for dual-platform simulations, interview both platforms simultaneously and return a combined result
+            timeout: Timeout in seconds
 
         Returns:
-            采访结果字典
+            Interview result dict
 
         Raises:
-            ValueError: 模拟不存在或环境未运行
-            TimeoutError: 等待响应超时
+            ValueError: simulation does not exist or environment is not running
+            TimeoutError: timed out waiting for the response
         """
         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            raise ValueError(f"模拟不存在: {simulation_id}")
+            raise ValueError(f"Simulation does not exist: {simulation_id}")
 
         ipc_client = SimulationIPCClient(sim_dir)
 
         if not ipc_client.check_env_alive():
-            raise ValueError(f"模拟环境未运行或已关闭，无法执行Interview: {simulation_id}")
+            raise ValueError(f"Simulation environment is not running or has shut down; cannot perform Interview: {simulation_id}")
 
-        logger.info(f"发送Interview命令: simulation_id={simulation_id}, agent_id={agent_id}, platform={platform}")
+        logger.info(f"Sending Interview command: simulation_id={simulation_id}, agent_id={agent_id}, platform={platform}")
 
         response = ipc_client.send_interview(
             agent_id=agent_id,
@@ -1487,7 +1489,7 @@ class SimulationRunner:
                 "error": response.error,
                 "timestamp": response.timestamp
             }
-    
+
     @classmethod
     def interview_agents_batch(
         cls,
@@ -1497,34 +1499,34 @@ class SimulationRunner:
         timeout: float = 120.0
     ) -> Dict[str, Any]:
         """
-        批量采访多个Agent
+        Batch interview multiple agents.
 
         Args:
-            simulation_id: 模拟ID
-            interviews: 采访列表，每个元素包含 {"agent_id": int, "prompt": str, "platform": str(可选)}
-            platform: 默认平台（可选，会被每个采访项的platform覆盖）
-                - "twitter": 默认只采访Twitter平台
-                - "reddit": 默认只采访Reddit平台
-                - None: 双平台模拟时每个Agent同时采访两个平台
-            timeout: 超时时间（秒）
+            simulation_id: Simulation ID
+            interviews: Interview list, each item containing {"agent_id": int, "prompt": str, "platform": str (optional)}
+            platform: Default platform (optional, overridden by each item's platform)
+                - "twitter": default to interviewing only the Twitter platform
+                - "reddit": default to interviewing only the Reddit platform
+                - None: for dual-platform simulations, interview each agent on both platforms simultaneously
+            timeout: Timeout in seconds
 
         Returns:
-            批量采访结果字典
+            Batch interview result dict
 
         Raises:
-            ValueError: 模拟不存在或环境未运行
-            TimeoutError: 等待响应超时
+            ValueError: simulation does not exist or environment is not running
+            TimeoutError: timed out waiting for the response
         """
         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            raise ValueError(f"模拟不存在: {simulation_id}")
+            raise ValueError(f"Simulation does not exist: {simulation_id}")
 
         ipc_client = SimulationIPCClient(sim_dir)
 
         if not ipc_client.check_env_alive():
-            raise ValueError(f"模拟环境未运行或已关闭，无法执行Interview: {simulation_id}")
+            raise ValueError(f"Simulation environment is not running or has shut down; cannot perform Interview: {simulation_id}")
 
-        logger.info(f"发送批量Interview命令: simulation_id={simulation_id}, count={len(interviews)}, platform={platform}")
+        logger.info(f"Sending batch Interview command: simulation_id={simulation_id}, count={len(interviews)}, platform={platform}")
 
         response = ipc_client.send_batch_interview(
             interviews=interviews,
@@ -1546,7 +1548,7 @@ class SimulationRunner:
                 "error": response.error,
                 "timestamp": response.timestamp
             }
-    
+
     @classmethod
     def interview_all_agents(
         cls,
@@ -1556,39 +1558,39 @@ class SimulationRunner:
         timeout: float = 180.0
     ) -> Dict[str, Any]:
         """
-        采访所有Agent（全局采访）
+        Interview all agents (global interview).
 
-        使用相同的问题采访模拟中的所有Agent
+        Uses the same question to interview every agent in the simulation.
 
         Args:
-            simulation_id: 模拟ID
-            prompt: 采访问题（所有Agent使用相同问题）
-            platform: 指定平台（可选）
-                - "twitter": 只采访Twitter平台
-                - "reddit": 只采访Reddit平台
-                - None: 双平台模拟时每个Agent同时采访两个平台
-            timeout: 超时时间（秒）
+            simulation_id: Simulation ID
+            prompt: Interview question (the same question is used for all agents)
+            platform: Specific platform (optional)
+                - "twitter": interview only the Twitter platform
+                - "reddit": interview only the Reddit platform
+                - None: for dual-platform simulations, interview each agent on both platforms simultaneously
+            timeout: Timeout in seconds
 
         Returns:
-            全局采访结果字典
+            Global interview result dict
         """
         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            raise ValueError(f"模拟不存在: {simulation_id}")
+            raise ValueError(f"Simulation does not exist: {simulation_id}")
 
-        # 从配置文件获取所有Agent信息
+        # Read all agent info from the configuration file
         config_path = os.path.join(sim_dir, "simulation_config.json")
         if not os.path.exists(config_path):
-            raise ValueError(f"模拟配置不存在: {simulation_id}")
+            raise ValueError(f"Simulation configuration does not exist: {simulation_id}")
 
         with open(config_path, 'r', encoding='utf-8') as f:
             config = json.load(f)
 
         agent_configs = config.get("agent_configs", [])
         if not agent_configs:
-            raise ValueError(f"模拟配置中没有Agent: {simulation_id}")
+            raise ValueError(f"No agents in the simulation configuration: {simulation_id}")
 
-        # 构建批量采访列表
+        # Build the batch interview list
         interviews = []
         for agent_config in agent_configs:
             agent_id = agent_config.get("agent_id")
@@ -1598,7 +1600,7 @@ class SimulationRunner:
                     "prompt": prompt
                 })
 
-        logger.info(f"发送全局Interview命令: simulation_id={simulation_id}, agent_count={len(interviews)}, platform={platform}")
+        logger.info(f"Sending global Interview command: simulation_id={simulation_id}, agent_count={len(interviews)}, platform={platform}")
 
         return cls.interview_agents_batch(
             simulation_id=simulation_id,
@@ -1606,7 +1608,7 @@ class SimulationRunner:
             platform=platform,
             timeout=timeout
         )
-    
+
     @classmethod
     def close_simulation_env(
         cls,
@@ -1614,47 +1616,48 @@ class SimulationRunner:
         timeout: float = 30.0
     ) -> Dict[str, Any]:
         """
-        关闭模拟环境（而不是停止模拟进程）
-        
-        向模拟发送关闭环境命令，使其优雅退出等待命令模式
-        
+        Close the simulation environment (rather than stop the simulation process).
+
+        Sends a close-environment command to the simulation so it gracefully exits
+        the command-waiting mode.
+
         Args:
-            simulation_id: 模拟ID
-            timeout: 超时时间（秒）
-            
+            simulation_id: Simulation ID
+            timeout: Timeout in seconds
+
         Returns:
-            操作结果字典
+            Operation result dict
         """
         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            raise ValueError(f"模拟不存在: {simulation_id}")
-        
+            raise ValueError(f"Simulation does not exist: {simulation_id}")
+
         ipc_client = SimulationIPCClient(sim_dir)
-        
+
         if not ipc_client.check_env_alive():
             return {
                 "success": True,
-                "message": "环境已经关闭"
+                "message": "Environment is already closed"
             }
-        
-        logger.info(f"发送关闭环境命令: simulation_id={simulation_id}")
-        
+
+        logger.info(f"Sending close-environment command: simulation_id={simulation_id}")
+
         try:
             response = ipc_client.send_close_env(timeout=timeout)
-            
+
             return {
                 "success": response.status.value == "completed",
-                "message": "环境关闭命令已发送",
+                "message": "Close-environment command sent",
                 "result": response.result,
                 "timestamp": response.timestamp
             }
         except TimeoutError:
-            # 超时可能是因为环境正在关闭
+            # Timeout may occur because the environment is in the process of closing
             return {
                 "success": True,
-                "message": "环境关闭命令已发送（等待响应超时，环境可能正在关闭）"
+                "message": "Close-environment command sent (response timed out; the environment may be in the process of closing)"
             }
-    
+
     @classmethod
     def _get_interview_history_from_db(
         cls,
@@ -1663,18 +1666,18 @@ class SimulationRunner:
         agent_id: Optional[int] = None,
         limit: int = 100
     ) -> List[Dict[str, Any]]:
-        """从单个数据库获取Interview历史"""
+        """Get Interview history from a single database"""
         import sqlite3
-        
+
         if not os.path.exists(db_path):
             return []
-        
+
         results = []
-        
+
         try:
             conn = sqlite3.connect(db_path)
             cursor = conn.cursor()
-            
+
             if agent_id is not None:
                 cursor.execute("""
                     SELECT user_id, info, created_at
@@ -1691,13 +1694,13 @@ class SimulationRunner:
                     ORDER BY created_at DESC
                     LIMIT ?
                 """, (limit,))
-            
+
             for user_id, info_json, created_at in cursor.fetchall():
                 try:
                     info = json.loads(info_json) if info_json else {}
                 except json.JSONDecodeError:
                     info = {"raw": info_json}
-                
+
                 results.append({
                     "agent_id": user_id,
                     "response": info.get("response", info),
@@ -1705,12 +1708,12 @@ class SimulationRunner:
                     "timestamp": created_at,
                     "platform": platform_name
                 })
-            
+
             conn.close()
-            
+
         except Exception as e:
-            logger.error(f"读取Interview历史失败 ({platform_name}): {e}")
-        
+            logger.error(f"Failed to read Interview history ({platform_name}): {e}")
+
         return results
 
     @classmethod
@@ -1722,31 +1725,31 @@ class SimulationRunner:
         limit: int = 100
     ) -> List[Dict[str, Any]]:
         """
-        获取Interview历史记录（从数据库读取）
-        
+        Get Interview history records (read from the database).
+
         Args:
-            simulation_id: 模拟ID
-            platform: 平台类型（reddit/twitter/None）
-                - "reddit": 只获取Reddit平台的历史
-                - "twitter": 只获取Twitter平台的历史
-                - None: 获取两个平台的所有历史
-            agent_id: 指定Agent ID（可选，只获取该Agent的历史）
-            limit: 每个平台返回数量限制
-            
+            simulation_id: Simulation ID
+            platform: Platform type (reddit/twitter/None)
+                - "reddit": get only Reddit history
+                - "twitter": get only Twitter history
+                - None: get history for both platforms
+            agent_id: Specific agent ID (optional; only fetch history for this agent)
+            limit: Maximum number of items to return per platform
+
         Returns:
-            Interview历史记录列表
+            List of Interview history records
         """
         sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
-        
+
         results = []
-        
-        # 确定要查询的平台
+
+        # Determine which platforms to query
         if platform in ("reddit", "twitter"):
             platforms = [platform]
         else:
-            # 不指定platform时，查询两个平台
+            # When no platform is specified, query both platforms
             platforms = ["twitter", "reddit"]
-        
+
         for p in platforms:
             db_path = os.path.join(sim_dir, f"{p}_simulation.db")
             platform_results = cls._get_interview_history_from_db(
@@ -1756,13 +1759,13 @@ class SimulationRunner:
                 limit=limit
             )
             results.extend(platform_results)
-        
-        # 按时间降序排序
+
+        # Sort by timestamp descending
         results.sort(key=lambda x: x.get("timestamp", ""), reverse=True)
-        
-        # 如果查询了多个平台，限制总数
+
+        # If multiple platforms were queried, cap the total
         if len(platforms) > 1 and len(results) > limit:
             results = results[:limit]
-        
+
         return results
 

--- a/backend/app/services/text_processor.py
+++ b/backend/app/services/text_processor.py
@@ -1,5 +1,5 @@
 """
-文本处理服务
+Text processing service
 """
 
 from typing import List, Optional
@@ -7,13 +7,13 @@ from ..utils.file_parser import FileParser, split_text_into_chunks
 
 
 class TextProcessor:
-    """文本处理器"""
-    
+    """Text processor"""
+
     @staticmethod
     def extract_from_files(file_paths: List[str]) -> str:
-        """从多个文件提取文本"""
+        """Extract text from multiple files"""
         return FileParser.extract_from_multiple(file_paths)
-    
+
     @staticmethod
     def split_text(
         text: str,
@@ -21,48 +21,48 @@ class TextProcessor:
         overlap: int = 50
     ) -> List[str]:
         """
-        分割文本
-        
+        Split text into chunks
+
         Args:
-            text: 原始文本
-            chunk_size: 块大小
-            overlap: 重叠大小
-            
+            text: Original text
+            chunk_size: Chunk size
+            overlap: Overlap size
+
         Returns:
-            文本块列表
+            List of text chunks
         """
         return split_text_into_chunks(text, chunk_size, overlap)
-    
+
     @staticmethod
     def preprocess_text(text: str) -> str:
         """
-        预处理文本
-        - 移除多余空白
-        - 标准化换行
-        
+        Preprocess text
+        - Remove extra whitespace
+        - Normalize line breaks
+
         Args:
-            text: 原始文本
-            
+            text: Original text
+
         Returns:
-            处理后的文本
+            Processed text
         """
         import re
-        
-        # 标准化换行
+
+        # Normalize line breaks
         text = text.replace('\r\n', '\n').replace('\r', '\n')
-        
-        # 移除连续空行（保留最多两个换行）
+
+        # Remove consecutive blank lines (keep at most two newlines)
         text = re.sub(r'\n{3,}', '\n\n', text)
-        
-        # 移除行首行尾空白
+
+        # Strip whitespace from each line
         lines = [line.strip() for line in text.split('\n')]
         text = '\n'.join(lines)
-        
+
         return text.strip()
-    
+
     @staticmethod
     def get_text_stats(text: str) -> dict:
-        """获取文本统计信息"""
+        """Get text statistics"""
         return {
             "total_chars": len(text),
             "total_lines": text.count('\n') + 1,

--- a/backend/app/services/zep_entity_reader.py
+++ b/backend/app/services/zep_entity_reader.py
@@ -1,6 +1,6 @@
 """
-Zep实体读取与过滤服务
-从Zep图谱中读取节点，筛选出符合预定义实体类型的节点
+Zep entity reading and filtering service
+Reads nodes from a Zep graph and filters out nodes matching predefined entity types
 """
 
 import time
@@ -15,21 +15,21 @@ from ..utils.zep_paging import fetch_all_nodes, fetch_all_edges
 
 logger = get_logger('mirofish.zep_entity_reader')
 
-# 用于泛型返回类型
+# Used for generic return types
 T = TypeVar('T')
 
 
 @dataclass
 class EntityNode:
-    """实体节点数据结构"""
+    """Entity node data structure"""
     uuid: str
     name: str
     labels: List[str]
     summary: str
     attributes: Dict[str, Any]
-    # 相关的边信息
+    # Related edge information
     related_edges: List[Dict[str, Any]] = field(default_factory=list)
-    # 相关的其他节点信息
+    # Related other-node information
     related_nodes: List[Dict[str, Any]] = field(default_factory=list)
     
     def to_dict(self) -> Dict[str, Any]:
@@ -44,7 +44,7 @@ class EntityNode:
         }
     
     def get_entity_type(self) -> Optional[str]:
-        """获取实体类型（排除默认的Entity标签）"""
+        """Get the entity type (excluding the default Entity label)"""
         for label in self.labels:
             if label not in ["Entity", "Node"]:
                 return label
@@ -53,7 +53,7 @@ class EntityNode:
 
 @dataclass
 class FilteredEntities:
-    """过滤后的实体集合"""
+    """Collection of filtered entities"""
     entities: List[EntityNode]
     entity_types: Set[str]
     total_count: int
@@ -70,18 +70,18 @@ class FilteredEntities:
 
 class ZepEntityReader:
     """
-    Zep实体读取与过滤服务
-    
-    主要功能：
-    1. 从Zep图谱读取所有节点
-    2. 筛选出符合预定义实体类型的节点（Labels不只是Entity的节点）
-    3. 获取每个实体的相关边和关联节点信息
+    Zep entity reading and filtering service
+
+    Main functions:
+    1. Read all nodes from a Zep graph
+    2. Filter nodes that match predefined entity types (nodes whose labels are not just "Entity")
+    3. Fetch each entity's related edges and connected-node info
     """
-    
+
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = api_key or Config.ZEP_API_KEY
         if not self.api_key:
-            raise ValueError("ZEP_API_KEY 未配置")
+            raise ValueError("ZEP_API_KEY is not configured")
         
         self.client = Zep(api_key=self.api_key)
     
@@ -93,16 +93,16 @@ class ZepEntityReader:
         initial_delay: float = 2.0
     ) -> T:
         """
-        带重试机制的Zep API调用
-        
+        Zep API call with retry mechanism
+
         Args:
-            func: 要执行的函数（无参数的lambda或callable）
-            operation_name: 操作名称，用于日志
-            max_retries: 最大重试次数（默认3次，即最多尝试3次）
-            initial_delay: 初始延迟秒数
-            
+            func: Function to execute (zero-argument lambda or callable)
+            operation_name: Operation name, used for logging
+            max_retries: Maximum number of retries (default 3, meaning up to 3 attempts)
+            initial_delay: Initial delay in seconds
+
         Returns:
-            API调用结果
+            API call result
         """
         last_exception = None
         delay = initial_delay
@@ -114,27 +114,27 @@ class ZepEntityReader:
                 last_exception = e
                 if attempt < max_retries - 1:
                     logger.warning(
-                        f"Zep {operation_name} 第 {attempt + 1} 次尝试失败: {str(e)[:100]}, "
-                        f"{delay:.1f}秒后重试..."
+                        f"Zep {operation_name} attempt {attempt + 1} failed: {str(e)[:100]}, "
+                        f"retrying in {delay:.1f}s..."
                     )
                     time.sleep(delay)
-                    delay *= 2  # 指数退避
+                    delay *= 2  # exponential backoff
                 else:
-                    logger.error(f"Zep {operation_name} 在 {max_retries} 次尝试后仍失败: {str(e)}")
+                    logger.error(f"Zep {operation_name} still failing after {max_retries} attempts: {str(e)}")
         
         raise last_exception
     
     def get_all_nodes(self, graph_id: str) -> List[Dict[str, Any]]:
         """
-        获取图谱的所有节点（分页获取）
+        Get all nodes from the graph (paginated)
 
         Args:
-            graph_id: 图谱ID
+            graph_id: Graph ID
 
         Returns:
-            节点列表
+            List of nodes
         """
-        logger.info(f"获取图谱 {graph_id} 的所有节点...")
+        logger.info(f"Fetching all nodes for graph {graph_id}...")
 
         nodes = fetch_all_nodes(self.client, graph_id)
 
@@ -148,20 +148,20 @@ class ZepEntityReader:
                 "attributes": node.attributes or {},
             })
 
-        logger.info(f"共获取 {len(nodes_data)} 个节点")
+        logger.info(f"Fetched {len(nodes_data)} nodes in total")
         return nodes_data
 
     def get_all_edges(self, graph_id: str) -> List[Dict[str, Any]]:
         """
-        获取图谱的所有边（分页获取）
+        Get all edges from the graph (paginated)
 
         Args:
-            graph_id: 图谱ID
+            graph_id: Graph ID
 
         Returns:
-            边列表
+            List of edges
         """
-        logger.info(f"获取图谱 {graph_id} 的所有边...")
+        logger.info(f"Fetching all edges for graph {graph_id}...")
 
         edges = fetch_all_edges(self.client, graph_id)
 
@@ -176,24 +176,24 @@ class ZepEntityReader:
                 "attributes": edge.attributes or {},
             })
 
-        logger.info(f"共获取 {len(edges_data)} 条边")
+        logger.info(f"Fetched {len(edges_data)} edges in total")
         return edges_data
-    
+
     def get_node_edges(self, node_uuid: str) -> List[Dict[str, Any]]:
         """
-        获取指定节点的所有相关边（带重试机制）
-        
+        Get all edges related to the given node (with retry)
+
         Args:
-            node_uuid: 节点UUID
-            
+            node_uuid: Node UUID
+
         Returns:
-            边列表
+            List of edges
         """
         try:
-            # 使用重试机制调用Zep API
+            # Call Zep API with retry mechanism
             edges = self._call_with_retry(
                 func=lambda: self.client.graph.node.get_entity_edges(node_uuid=node_uuid),
-                operation_name=f"获取节点边(node={node_uuid[:8]}...)"
+                operation_name=f"get node edges(node={node_uuid[:8]}...)"
             )
             
             edges_data = []
@@ -209,7 +209,7 @@ class ZepEntityReader:
             
             return edges_data
         except Exception as e:
-            logger.warning(f"获取节点 {node_uuid} 的边失败: {str(e)}")
+            logger.warning(f"Failed to get edges for node {node_uuid}: {str(e)}")
             return []
     
     def filter_defined_entities(
@@ -219,47 +219,47 @@ class ZepEntityReader:
         enrich_with_edges: bool = True
     ) -> FilteredEntities:
         """
-        筛选出符合预定义实体类型的节点
-        
-        筛选逻辑：
-        - 如果节点的Labels只有一个"Entity"，说明这个实体不符合我们预定义的类型，跳过
-        - 如果节点的Labels包含除"Entity"和"Node"之外的标签，说明符合预定义类型，保留
-        
+        Filter out nodes matching predefined entity types
+
+        Filtering logic:
+        - If a node's labels only contain "Entity", that entity does not match a predefined type — skip
+        - If a node's labels contain any label other than "Entity" or "Node", it matches a predefined type — keep
+
         Args:
-            graph_id: 图谱ID
-            defined_entity_types: 预定义的实体类型列表（可选，如果提供则只保留这些类型）
-            enrich_with_edges: 是否获取每个实体的相关边信息
-            
+            graph_id: Graph ID
+            defined_entity_types: Predefined entity-type list (optional; if provided, only these types are kept)
+            enrich_with_edges: Whether to also fetch related-edge information for each entity
+
         Returns:
-            FilteredEntities: 过滤后的实体集合
+            FilteredEntities: Collection of filtered entities
         """
-        logger.info(f"开始筛选图谱 {graph_id} 的实体...")
-        
-        # 获取所有节点
+        logger.info(f"Starting entity filtering for graph {graph_id}...")
+
+        # Fetch all nodes
         all_nodes = self.get_all_nodes(graph_id)
         total_count = len(all_nodes)
-        
-        # 获取所有边（用于后续关联查找）
+
+        # Fetch all edges (used for later relationship lookup)
         all_edges = self.get_all_edges(graph_id) if enrich_with_edges else []
-        
-        # 构建节点UUID到节点数据的映射
+
+        # Build node-UUID to node-data map
         node_map = {n["uuid"]: n for n in all_nodes}
-        
-        # 筛选符合条件的实体
+
+        # Filter the matching entities
         filtered_entities = []
         entity_types_found = set()
-        
+
         for node in all_nodes:
             labels = node.get("labels", [])
-            
-            # 筛选逻辑：Labels必须包含除"Entity"和"Node"之外的标签
+
+            # Filter logic: labels must contain something other than "Entity" and "Node"
             custom_labels = [l for l in labels if l not in ["Entity", "Node"]]
-            
+
             if not custom_labels:
-                # 只有默认标签，跳过
+                # Only default labels — skip
                 continue
-            
-            # 如果指定了预定义类型，检查是否匹配
+
+            # If predefined types are specified, check for a match
             if defined_entity_types:
                 matching_labels = [l for l in custom_labels if l in defined_entity_types]
                 if not matching_labels:
@@ -269,8 +269,8 @@ class ZepEntityReader:
                 entity_type = custom_labels[0]
             
             entity_types_found.add(entity_type)
-            
-            # 创建实体节点对象
+
+            # Create entity node object
             entity = EntityNode(
                 uuid=node["uuid"],
                 name=node["name"],
@@ -279,7 +279,7 @@ class ZepEntityReader:
                 attributes=node["attributes"],
             )
             
-            # 获取相关边和节点
+            # Fetch related edges and nodes
             if enrich_with_edges:
                 related_edges = []
                 related_node_uuids = set()
@@ -303,8 +303,8 @@ class ZepEntityReader:
                         related_node_uuids.add(edge["source_node_uuid"])
                 
                 entity.related_edges = related_edges
-                
-                # 获取关联节点的基本信息
+
+                # Get basic info on related nodes
                 related_nodes = []
                 for related_uuid in related_node_uuids:
                     if related_uuid in node_map:
@@ -320,8 +320,8 @@ class ZepEntityReader:
             
             filtered_entities.append(entity)
         
-        logger.info(f"筛选完成: 总节点 {total_count}, 符合条件 {len(filtered_entities)}, "
-                   f"实体类型: {entity_types_found}")
+        logger.info(f"Filtering complete: total nodes {total_count}, matched {len(filtered_entities)}, "
+                   f"entity types: {entity_types_found}")
         
         return FilteredEntities(
             entities=filtered_entities,
@@ -336,33 +336,33 @@ class ZepEntityReader:
         entity_uuid: str
     ) -> Optional[EntityNode]:
         """
-        获取单个实体及其完整上下文（边和关联节点，带重试机制）
-        
+        Get a single entity with its full context (edges and related nodes, with retry)
+
         Args:
-            graph_id: 图谱ID
-            entity_uuid: 实体UUID
-            
+            graph_id: Graph ID
+            entity_uuid: Entity UUID
+
         Returns:
-            EntityNode或None
+            EntityNode or None
         """
         try:
-            # 使用重试机制获取节点
+            # Fetch the node with retry
             node = self._call_with_retry(
                 func=lambda: self.client.graph.node.get(uuid_=entity_uuid),
-                operation_name=f"获取节点详情(uuid={entity_uuid[:8]}...)"
+                operation_name=f"get node detail(uuid={entity_uuid[:8]}...)"
             )
-            
+
             if not node:
                 return None
-            
-            # 获取节点的边
+
+            # Fetch the node's edges
             edges = self.get_node_edges(entity_uuid)
-            
-            # 获取所有节点用于关联查找
+
+            # Fetch all nodes for relationship lookup
             all_nodes = self.get_all_nodes(graph_id)
             node_map = {n["uuid"]: n for n in all_nodes}
-            
-            # 处理相关边和节点
+
+            # Process related edges and nodes
             related_edges = []
             related_node_uuids = set()
             
@@ -384,7 +384,7 @@ class ZepEntityReader:
                     })
                     related_node_uuids.add(edge["source_node_uuid"])
             
-            # 获取关联节点信息
+            # Get related-node information
             related_nodes = []
             for related_uuid in related_node_uuids:
                 if related_uuid in node_map:
@@ -407,7 +407,7 @@ class ZepEntityReader:
             )
             
         except Exception as e:
-            logger.error(f"获取实体 {entity_uuid} 失败: {str(e)}")
+            logger.error(f"Failed to get entity {entity_uuid}: {str(e)}")
             return None
     
     def get_entities_by_type(
@@ -417,15 +417,15 @@ class ZepEntityReader:
         enrich_with_edges: bool = True
     ) -> List[EntityNode]:
         """
-        获取指定类型的所有实体
-        
+        Get all entities of the given type
+
         Args:
-            graph_id: 图谱ID
-            entity_type: 实体类型（如 "Student", "PublicFigure" 等）
-            enrich_with_edges: 是否获取相关边信息
-            
+            graph_id: Graph ID
+            entity_type: Entity type (e.g., "Student", "PublicFigure", etc.)
+            enrich_with_edges: Whether to fetch related-edge info
+
         Returns:
-            实体列表
+            List of entities
         """
         result = self.filter_defined_entities(
             graph_id=graph_id,

--- a/backend/app/services/zep_graph_memory_updater.py
+++ b/backend/app/services/zep_graph_memory_updater.py
@@ -1,6 +1,6 @@
 """
-Zep图谱记忆更新服务
-将模拟中的Agent活动动态更新到Zep图谱中
+Zep graph memory updater service
+Dynamically pushes Agent activity from a simulation into a Zep graph
 """
 
 import os
@@ -23,7 +23,7 @@ logger = get_logger('mirofish.zep_graph_memory_updater')
 
 @dataclass
 class AgentActivity:
-    """Agent活动记录"""
+    """Agent activity record"""
     platform: str           # twitter / reddit
     agent_id: int
     agent_name: str
@@ -31,15 +31,16 @@ class AgentActivity:
     action_args: Dict[str, Any]
     round_num: int
     timestamp: str
-    
+
     def to_episode_text(self) -> str:
         """
-        将活动转换为可以发送给Zep的文本描述
-        
-        采用自然语言描述格式，让Zep能够从中提取实体和关系
-        不添加模拟相关的前缀，避免误导图谱更新
+        Convert the activity into a text description that can be sent to Zep.
+
+        Uses a natural-language description format so Zep can extract entities and
+        relationships from it. No simulation-related prefix is added so as not to
+        mislead the graph update.
         """
-        # 根据不同的动作类型生成不同的描述
+        # Generate different descriptions based on action type
         action_descriptions = {
             "CREATE_POST": self._describe_create_post,
             "LIKE_POST": self._describe_like_post,
@@ -54,226 +55,228 @@ class AgentActivity:
             "SEARCH_USER": self._describe_search_user,
             "MUTE": self._describe_mute,
         }
-        
+
         describe_func = action_descriptions.get(self.action_type, self._describe_generic)
         description = describe_func()
-        
-        # 直接返回 "agent名称: 活动描述" 格式，不添加模拟前缀
+
+        # Return "<agent name>: <activity description>" — no simulation prefix
         return f"{self.agent_name}: {description}"
-    
+
     def _describe_create_post(self) -> str:
         content = self.action_args.get("content", "")
         if content:
-            return f"发布了一条帖子：「{content}」"
-        return "发布了一条帖子"
-    
+            return f'posted: "{content}"'
+        return "published a post"
+
     def _describe_like_post(self) -> str:
-        """点赞帖子 - 包含帖子原文和作者信息"""
+        """Like a post — includes original post text and author info"""
         post_content = self.action_args.get("post_content", "")
         post_author = self.action_args.get("post_author_name", "")
-        
+
         if post_content and post_author:
-            return f"点赞了{post_author}的帖子：「{post_content}」"
+            return f'liked {post_author}\'s post: "{post_content}"'
         elif post_content:
-            return f"点赞了一条帖子：「{post_content}」"
+            return f'liked a post: "{post_content}"'
         elif post_author:
-            return f"点赞了{post_author}的一条帖子"
-        return "点赞了一条帖子"
-    
+            return f"liked a post by {post_author}"
+        return "liked a post"
+
     def _describe_dislike_post(self) -> str:
-        """踩帖子 - 包含帖子原文和作者信息"""
+        """Dislike a post — includes original post text and author info"""
         post_content = self.action_args.get("post_content", "")
         post_author = self.action_args.get("post_author_name", "")
-        
+
         if post_content and post_author:
-            return f"踩了{post_author}的帖子：「{post_content}」"
+            return f'disliked {post_author}\'s post: "{post_content}"'
         elif post_content:
-            return f"踩了一条帖子：「{post_content}」"
+            return f'disliked a post: "{post_content}"'
         elif post_author:
-            return f"踩了{post_author}的一条帖子"
-        return "踩了一条帖子"
-    
+            return f"disliked a post by {post_author}"
+        return "disliked a post"
+
     def _describe_repost(self) -> str:
-        """转发帖子 - 包含原帖内容和作者信息"""
+        """Repost — includes original post content and author info"""
         original_content = self.action_args.get("original_content", "")
         original_author = self.action_args.get("original_author_name", "")
-        
+
         if original_content and original_author:
-            return f"转发了{original_author}的帖子：「{original_content}」"
+            return f'reposted {original_author}\'s post: "{original_content}"'
         elif original_content:
-            return f"转发了一条帖子：「{original_content}」"
+            return f'reposted a post: "{original_content}"'
         elif original_author:
-            return f"转发了{original_author}的一条帖子"
-        return "转发了一条帖子"
-    
+            return f"reposted a post by {original_author}"
+        return "reposted a post"
+
     def _describe_quote_post(self) -> str:
-        """引用帖子 - 包含原帖内容、作者信息和引用评论"""
+        """Quote a post — includes original content, author info, and the quote comment"""
         original_content = self.action_args.get("original_content", "")
         original_author = self.action_args.get("original_author_name", "")
         quote_content = self.action_args.get("quote_content", "") or self.action_args.get("content", "")
-        
+
         base = ""
         if original_content and original_author:
-            base = f"引用了{original_author}的帖子「{original_content}」"
+            base = f'quoted {original_author}\'s post "{original_content}"'
         elif original_content:
-            base = f"引用了一条帖子「{original_content}」"
+            base = f'quoted a post "{original_content}"'
         elif original_author:
-            base = f"引用了{original_author}的一条帖子"
+            base = f"quoted a post by {original_author}"
         else:
-            base = "引用了一条帖子"
-        
+            base = "quoted a post"
+
         if quote_content:
-            base += f"，并评论道：「{quote_content}」"
+            base += f', commenting: "{quote_content}"'
         return base
-    
+
     def _describe_follow(self) -> str:
-        """关注用户 - 包含被关注用户的名称"""
+        """Follow user — includes the followed user's name"""
         target_user_name = self.action_args.get("target_user_name", "")
-        
+
         if target_user_name:
-            return f"关注了用户「{target_user_name}」"
-        return "关注了一个用户"
-    
+            return f'followed user "{target_user_name}"'
+        return "followed a user"
+
     def _describe_create_comment(self) -> str:
-        """发表评论 - 包含评论内容和所评论的帖子信息"""
+        """Post a comment — includes comment text and the post being commented on"""
         content = self.action_args.get("content", "")
         post_content = self.action_args.get("post_content", "")
         post_author = self.action_args.get("post_author_name", "")
-        
+
         if content:
             if post_content and post_author:
-                return f"在{post_author}的帖子「{post_content}」下评论道：「{content}」"
+                return f'commented on {post_author}\'s post "{post_content}": "{content}"'
             elif post_content:
-                return f"在帖子「{post_content}」下评论道：「{content}」"
+                return f'commented on the post "{post_content}": "{content}"'
             elif post_author:
-                return f"在{post_author}的帖子下评论道：「{content}」"
-            return f"评论道：「{content}」"
-        return "发表了评论"
-    
+                return f'commented on a post by {post_author}: "{content}"'
+            return f'commented: "{content}"'
+        return "posted a comment"
+
     def _describe_like_comment(self) -> str:
-        """点赞评论 - 包含评论内容和作者信息"""
+        """Like a comment — includes comment text and author info"""
         comment_content = self.action_args.get("comment_content", "")
         comment_author = self.action_args.get("comment_author_name", "")
-        
+
         if comment_content and comment_author:
-            return f"点赞了{comment_author}的评论：「{comment_content}」"
+            return f'liked {comment_author}\'s comment: "{comment_content}"'
         elif comment_content:
-            return f"点赞了一条评论：「{comment_content}」"
+            return f'liked a comment: "{comment_content}"'
         elif comment_author:
-            return f"点赞了{comment_author}的一条评论"
-        return "点赞了一条评论"
-    
+            return f"liked a comment by {comment_author}"
+        return "liked a comment"
+
     def _describe_dislike_comment(self) -> str:
-        """踩评论 - 包含评论内容和作者信息"""
+        """Dislike a comment — includes comment text and author info"""
         comment_content = self.action_args.get("comment_content", "")
         comment_author = self.action_args.get("comment_author_name", "")
-        
+
         if comment_content and comment_author:
-            return f"踩了{comment_author}的评论：「{comment_content}」"
+            return f'disliked {comment_author}\'s comment: "{comment_content}"'
         elif comment_content:
-            return f"踩了一条评论：「{comment_content}」"
+            return f'disliked a comment: "{comment_content}"'
         elif comment_author:
-            return f"踩了{comment_author}的一条评论"
-        return "踩了一条评论"
-    
+            return f"disliked a comment by {comment_author}"
+        return "disliked a comment"
+
     def _describe_search(self) -> str:
-        """搜索帖子 - 包含搜索关键词"""
+        """Search posts — includes search keywords"""
         query = self.action_args.get("query", "") or self.action_args.get("keyword", "")
-        return f"搜索了「{query}」" if query else "进行了搜索"
-    
+        return f'searched for "{query}"' if query else "performed a search"
+
     def _describe_search_user(self) -> str:
-        """搜索用户 - 包含搜索关键词"""
+        """Search users — includes search keywords"""
         query = self.action_args.get("query", "") or self.action_args.get("username", "")
-        return f"搜索了用户「{query}」" if query else "搜索了用户"
-    
+        return f'searched for user "{query}"' if query else "searched for a user"
+
     def _describe_mute(self) -> str:
-        """屏蔽用户 - 包含被屏蔽用户的名称"""
+        """Mute user — includes the muted user's name"""
         target_user_name = self.action_args.get("target_user_name", "")
-        
+
         if target_user_name:
-            return f"屏蔽了用户「{target_user_name}」"
-        return "屏蔽了一个用户"
-    
+            return f'muted user "{target_user_name}"'
+        return "muted a user"
+
     def _describe_generic(self) -> str:
-        # 对于未知的动作类型，生成通用描述
-        return f"执行了{self.action_type}操作"
+        # For unknown action types, generate a generic description
+        return f"performed action {self.action_type}"
 
 
 class ZepGraphMemoryUpdater:
     """
-    Zep图谱记忆更新器
-    
-    监控模拟的actions日志文件，将新的agent活动实时更新到Zep图谱中。
-    按平台分组，每累积BATCH_SIZE条活动后批量发送到Zep。
-    
-    所有有意义的行为都会被更新到Zep，action_args中会包含完整的上下文信息：
-    - 点赞/踩的帖子原文
-    - 转发/引用的帖子原文
-    - 关注/屏蔽的用户名
-    - 点赞/踩的评论原文
+    Zep graph memory updater
+
+    Watches the simulation's actions log file and pushes new agent activity into
+    the Zep graph in real time. Activity is grouped by platform; once BATCH_SIZE
+    activities have accumulated for a platform, the batch is sent to Zep.
+
+    All meaningful behaviors are pushed to Zep, and action_args contains full
+    context information:
+    - Original text of the post being liked/disliked
+    - Original text of the post being reposted/quoted
+    - Username of the user being followed/muted
+    - Original text of the comment being liked/disliked
     """
-    
-    # 批量发送大小（每个平台累积多少条后发送）
+
+    # Batch send size (how many activities accumulate per platform before sending)
     BATCH_SIZE = 5
-    
-    # 平台名称映射（用于控制台显示）
+
+    # Platform display-name map (used for console display)
     PLATFORM_DISPLAY_NAMES = {
-        'twitter': '世界1',
-        'reddit': '世界2',
+        'twitter': 'World 1',
+        'reddit': 'World 2',
     }
-    
-    # 发送间隔（秒），避免请求过快
+
+    # Send interval (seconds), to avoid sending requests too quickly
     SEND_INTERVAL = 0.5
-    
-    # 重试配置
+
+    # Retry configuration
     MAX_RETRIES = 3
-    RETRY_DELAY = 2  # 秒
-    
+    RETRY_DELAY = 2  # seconds
+
     def __init__(self, graph_id: str, api_key: Optional[str] = None):
         """
-        初始化更新器
-        
+        Initialize the updater
+
         Args:
-            graph_id: Zep图谱ID
-            api_key: Zep API Key（可选，默认从配置读取）
+            graph_id: Zep graph ID
+            api_key: Zep API key (optional; defaults to value from config)
         """
         self.graph_id = graph_id
         self.api_key = api_key or Config.ZEP_API_KEY
-        
+
         if not self.api_key:
-            raise ValueError("ZEP_API_KEY未配置")
-        
+            raise ValueError("ZEP_API_KEY is not configured")
+
         self.client = Zep(api_key=self.api_key)
-        
-        # 活动队列
+
+        # Activity queue
         self._activity_queue: Queue = Queue()
-        
-        # 按平台分组的活动缓冲区（每个平台各自累积到BATCH_SIZE后批量发送）
+
+        # Per-platform activity buffers (each platform accumulates to BATCH_SIZE then sends)
         self._platform_buffers: Dict[str, List[AgentActivity]] = {
             'twitter': [],
             'reddit': [],
         }
         self._buffer_lock = threading.Lock()
-        
-        # 控制标志
+
+        # Control flags
         self._running = False
         self._worker_thread: Optional[threading.Thread] = None
-        
-        # 统计
-        self._total_activities = 0  # 实际添加到队列的活动数
-        self._total_sent = 0        # 成功发送到Zep的批次数
-        self._total_items_sent = 0  # 成功发送到Zep的活动条数
-        self._failed_count = 0      # 发送失败的批次数
-        self._skipped_count = 0     # 被过滤跳过的活动数（DO_NOTHING）
-        
-        logger.info(f"ZepGraphMemoryUpdater 初始化完成: graph_id={graph_id}, batch_size={self.BATCH_SIZE}")
-    
+
+        # Statistics
+        self._total_activities = 0  # number of activities actually added to the queue
+        self._total_sent = 0        # number of batches successfully sent to Zep
+        self._total_items_sent = 0  # number of activity items successfully sent to Zep
+        self._failed_count = 0      # number of batches that failed to send
+        self._skipped_count = 0     # number of activities filtered/skipped (DO_NOTHING)
+
+        logger.info(f"ZepGraphMemoryUpdater initialized: graph_id={graph_id}, batch_size={self.BATCH_SIZE}")
+
     def _get_platform_display_name(self, platform: str) -> str:
-        """获取平台的显示名称"""
+        """Get the display name for the platform"""
         return self.PLATFORM_DISPLAY_NAMES.get(platform.lower(), platform)
-    
+
     def start(self):
-        """启动后台工作线程"""
+        """Start the background worker thread"""
         if self._running:
             return
 
@@ -288,67 +291,67 @@ class ZepGraphMemoryUpdater:
             name=f"ZepMemoryUpdater-{self.graph_id[:8]}"
         )
         self._worker_thread.start()
-        logger.info(f"ZepGraphMemoryUpdater 已启动: graph_id={self.graph_id}")
-    
+        logger.info(f"ZepGraphMemoryUpdater started: graph_id={self.graph_id}")
+
     def stop(self):
-        """停止后台工作线程"""
+        """Stop the background worker thread"""
         self._running = False
-        
-        # 发送剩余的活动
+
+        # Send any remaining activities
         self._flush_remaining()
-        
+
         if self._worker_thread and self._worker_thread.is_alive():
             self._worker_thread.join(timeout=10)
-        
-        logger.info(f"ZepGraphMemoryUpdater 已停止: graph_id={self.graph_id}, "
+
+        logger.info(f"ZepGraphMemoryUpdater stopped: graph_id={self.graph_id}, "
                    f"total_activities={self._total_activities}, "
                    f"batches_sent={self._total_sent}, "
                    f"items_sent={self._total_items_sent}, "
                    f"failed={self._failed_count}, "
                    f"skipped={self._skipped_count}")
-    
+
     def add_activity(self, activity: AgentActivity):
         """
-        添加一个agent活动到队列
-        
-        所有有意义的行为都会被添加到队列，包括：
-        - CREATE_POST（发帖）
-        - CREATE_COMMENT（评论）
-        - QUOTE_POST（引用帖子）
-        - SEARCH_POSTS（搜索帖子）
-        - SEARCH_USER（搜索用户）
-        - LIKE_POST/DISLIKE_POST（点赞/踩帖子）
-        - REPOST（转发）
-        - FOLLOW（关注）
-        - MUTE（屏蔽）
-        - LIKE_COMMENT/DISLIKE_COMMENT（点赞/踩评论）
-        
-        action_args中会包含完整的上下文信息（如帖子原文、用户名等）。
-        
+        Add an agent activity to the queue.
+
+        All meaningful behaviors are added to the queue, including:
+        - CREATE_POST (publish a post)
+        - CREATE_COMMENT (post a comment)
+        - QUOTE_POST (quote a post)
+        - SEARCH_POSTS (search posts)
+        - SEARCH_USER (search users)
+        - LIKE_POST/DISLIKE_POST (like/dislike a post)
+        - REPOST (repost)
+        - FOLLOW (follow)
+        - MUTE (mute)
+        - LIKE_COMMENT/DISLIKE_COMMENT (like/dislike a comment)
+
+        action_args contains the full context (e.g., original post text, usernames, etc.).
+
         Args:
-            activity: Agent活动记录
+            activity: Agent activity record
         """
-        # 跳过DO_NOTHING类型的活动
+        # Skip DO_NOTHING activities
         if activity.action_type == "DO_NOTHING":
             self._skipped_count += 1
             return
-        
+
         self._activity_queue.put(activity)
         self._total_activities += 1
-        logger.debug(f"添加活动到Zep队列: {activity.agent_name} - {activity.action_type}")
-    
+        logger.debug(f"Added activity to Zep queue: {activity.agent_name} - {activity.action_type}")
+
     def add_activity_from_dict(self, data: Dict[str, Any], platform: str):
         """
-        从字典数据添加活动
-        
+        Add an activity from a dict.
+
         Args:
-            data: 从actions.jsonl解析的字典数据
-            platform: 平台名称 (twitter/reddit)
+            data: Dict parsed from actions.jsonl
+            platform: Platform name (twitter/reddit)
         """
-        # 跳过事件类型的条目
+        # Skip event-type entries
         if "event_type" in data:
             return
-        
+
         activity = AgentActivity(
             platform=platform,
             agent_id=data.get("agent_id", 0),
@@ -358,57 +361,57 @@ class ZepGraphMemoryUpdater:
             round_num=data.get("round", 0),
             timestamp=data.get("timestamp", datetime.now().isoformat()),
         )
-        
+
         self.add_activity(activity)
-    
+
     def _worker_loop(self, locale: str = 'zh'):
-        """后台工作循环 - 按平台批量发送活动到Zep"""
+        """Background worker loop — sends activity to Zep in per-platform batches"""
         set_locale(locale)
         while self._running or not self._activity_queue.empty():
             try:
-                # 尝试从队列获取活动（超时1秒）
+                # Try to grab an activity from the queue (1 second timeout)
                 try:
                     activity = self._activity_queue.get(timeout=1)
-                    
-                    # 将活动添加到对应平台的缓冲区
+
+                    # Add the activity to the corresponding platform's buffer
                     platform = activity.platform.lower()
                     with self._buffer_lock:
                         if platform not in self._platform_buffers:
                             self._platform_buffers[platform] = []
                         self._platform_buffers[platform].append(activity)
-                        
-                        # 检查该平台是否达到批量大小
+
+                        # Check whether the platform reached the batch size
                         if len(self._platform_buffers[platform]) >= self.BATCH_SIZE:
                             batch = self._platform_buffers[platform][:self.BATCH_SIZE]
                             self._platform_buffers[platform] = self._platform_buffers[platform][self.BATCH_SIZE:]
-                            # 释放锁后再发送
+                            # Release the lock before sending
                             self._send_batch_activities(batch, platform)
-                            # 发送间隔，避免请求过快
+                            # Send interval, to avoid sending requests too quickly
                             time.sleep(self.SEND_INTERVAL)
-                    
+
                 except Empty:
                     pass
-                    
+
             except Exception as e:
-                logger.error(f"工作循环异常: {e}")
+                logger.error(f"Worker loop exception: {e}")
                 time.sleep(1)
-    
+
     def _send_batch_activities(self, activities: List[AgentActivity], platform: str):
         """
-        批量发送活动到Zep图谱（合并为一条文本）
-        
+        Send a batch of activities to the Zep graph (merged into one text payload)
+
         Args:
-            activities: Agent活动列表
-            platform: 平台名称
+            activities: List of agent activities
+            platform: Platform name
         """
         if not activities:
             return
-        
-        # 将多条活动合并为一条文本，用换行分隔
+
+        # Merge multiple activities into one text payload, separated by newlines
         episode_texts = [activity.to_episode_text() for activity in activities]
         combined_text = "\n".join(episode_texts)
-        
-        # 带重试的发送
+
+        # Send with retry
         for attempt in range(self.MAX_RETRIES):
             try:
                 self.client.graph.add(
@@ -416,25 +419,25 @@ class ZepGraphMemoryUpdater:
                     type="text",
                     data=combined_text
                 )
-                
+
                 self._total_sent += 1
                 self._total_items_sent += len(activities)
                 display_name = self._get_platform_display_name(platform)
-                logger.info(f"成功批量发送 {len(activities)} 条{display_name}活动到图谱 {self.graph_id}")
-                logger.debug(f"批量内容预览: {combined_text[:200]}...")
+                logger.info(f"Successfully sent batch of {len(activities)} {display_name} activities to graph {self.graph_id}")
+                logger.debug(f"Batch content preview: {combined_text[:200]}...")
                 return
-                
+
             except Exception as e:
                 if attempt < self.MAX_RETRIES - 1:
-                    logger.warning(f"批量发送到Zep失败 (尝试 {attempt + 1}/{self.MAX_RETRIES}): {e}")
+                    logger.warning(f"Batch send to Zep failed (attempt {attempt + 1}/{self.MAX_RETRIES}): {e}")
                     time.sleep(self.RETRY_DELAY * (attempt + 1))
                 else:
-                    logger.error(f"批量发送到Zep失败，已重试{self.MAX_RETRIES}次: {e}")
+                    logger.error(f"Batch send to Zep failed after {self.MAX_RETRIES} retries: {e}")
                     self._failed_count += 1
-    
+
     def _flush_remaining(self):
-        """发送队列和缓冲区中剩余的活动"""
-        # 首先处理队列中剩余的活动，添加到缓冲区
+        """Send any activities remaining in the queue and per-platform buffers"""
+        # First, drain remaining activities from the queue into the buffers
         while not self._activity_queue.empty():
             try:
                 activity = self._activity_queue.get_nowait()
@@ -445,110 +448,110 @@ class ZepGraphMemoryUpdater:
                     self._platform_buffers[platform].append(activity)
             except Empty:
                 break
-        
-        # 然后发送各平台缓冲区中剩余的活动（即使不足BATCH_SIZE条）
+
+        # Then send remaining activities in each platform's buffer (even if below BATCH_SIZE)
         with self._buffer_lock:
             for platform, buffer in self._platform_buffers.items():
                 if buffer:
                     display_name = self._get_platform_display_name(platform)
-                    logger.info(f"发送{display_name}平台剩余的 {len(buffer)} 条活动")
+                    logger.info(f"Sending {len(buffer)} remaining activities for {display_name}")
                     self._send_batch_activities(buffer, platform)
-            # 清空所有缓冲区
+            # Clear all buffers
             for platform in self._platform_buffers:
                 self._platform_buffers[platform] = []
-    
+
     def get_stats(self) -> Dict[str, Any]:
-        """获取统计信息"""
+        """Get statistics"""
         with self._buffer_lock:
             buffer_sizes = {p: len(b) for p, b in self._platform_buffers.items()}
-        
+
         return {
             "graph_id": self.graph_id,
             "batch_size": self.BATCH_SIZE,
-            "total_activities": self._total_activities,  # 添加到队列的活动总数
-            "batches_sent": self._total_sent,            # 成功发送的批次数
-            "items_sent": self._total_items_sent,        # 成功发送的活动条数
-            "failed_count": self._failed_count,          # 发送失败的批次数
-            "skipped_count": self._skipped_count,        # 被过滤跳过的活动数（DO_NOTHING）
+            "total_activities": self._total_activities,  # total activities added to queue
+            "batches_sent": self._total_sent,            # number of batches successfully sent
+            "items_sent": self._total_items_sent,        # number of activity items successfully sent
+            "failed_count": self._failed_count,          # number of batches that failed to send
+            "skipped_count": self._skipped_count,        # number of activities filtered/skipped (DO_NOTHING)
             "queue_size": self._activity_queue.qsize(),
-            "buffer_sizes": buffer_sizes,                # 各平台缓冲区大小
+            "buffer_sizes": buffer_sizes,                # per-platform buffer sizes
             "running": self._running,
         }
 
 
 class ZepGraphMemoryManager:
     """
-    管理多个模拟的Zep图谱记忆更新器
-    
-    每个模拟可以有自己的更新器实例
+    Manages multiple simulations' Zep graph memory updaters.
+
+    Each simulation can have its own updater instance.
     """
-    
+
     _updaters: Dict[str, ZepGraphMemoryUpdater] = {}
     _lock = threading.Lock()
-    
+
     @classmethod
     def create_updater(cls, simulation_id: str, graph_id: str) -> ZepGraphMemoryUpdater:
         """
-        为模拟创建图谱记忆更新器
-        
+        Create a graph-memory updater for the given simulation.
+
         Args:
-            simulation_id: 模拟ID
-            graph_id: Zep图谱ID
-            
+            simulation_id: Simulation ID
+            graph_id: Zep graph ID
+
         Returns:
-            ZepGraphMemoryUpdater实例
+            ZepGraphMemoryUpdater instance
         """
         with cls._lock:
-            # 如果已存在，先停止旧的
+            # If one already exists, stop the old one first
             if simulation_id in cls._updaters:
                 cls._updaters[simulation_id].stop()
-            
+
             updater = ZepGraphMemoryUpdater(graph_id)
             updater.start()
             cls._updaters[simulation_id] = updater
-            
-            logger.info(f"创建图谱记忆更新器: simulation_id={simulation_id}, graph_id={graph_id}")
+
+            logger.info(f"Created graph memory updater: simulation_id={simulation_id}, graph_id={graph_id}")
             return updater
-    
+
     @classmethod
     def get_updater(cls, simulation_id: str) -> Optional[ZepGraphMemoryUpdater]:
-        """获取模拟的更新器"""
+        """Get the simulation's updater"""
         return cls._updaters.get(simulation_id)
-    
+
     @classmethod
     def stop_updater(cls, simulation_id: str):
-        """停止并移除模拟的更新器"""
+        """Stop and remove the simulation's updater"""
         with cls._lock:
             if simulation_id in cls._updaters:
                 cls._updaters[simulation_id].stop()
                 del cls._updaters[simulation_id]
-                logger.info(f"已停止图谱记忆更新器: simulation_id={simulation_id}")
-    
-    # 防止 stop_all 重复调用的标志
+                logger.info(f"Stopped graph memory updater: simulation_id={simulation_id}")
+
+    # Flag to prevent stop_all from being called repeatedly
     _stop_all_done = False
-    
+
     @classmethod
     def stop_all(cls):
-        """停止所有更新器"""
-        # 防止重复调用
+        """Stop all updaters"""
+        # Prevent repeated calls
         if cls._stop_all_done:
             return
         cls._stop_all_done = True
-        
+
         with cls._lock:
             if cls._updaters:
                 for simulation_id, updater in list(cls._updaters.items()):
                     try:
                         updater.stop()
                     except Exception as e:
-                        logger.error(f"停止更新器失败: simulation_id={simulation_id}, error={e}")
+                        logger.error(f"Failed to stop updater: simulation_id={simulation_id}, error={e}")
                 cls._updaters.clear()
-            logger.info("已停止所有图谱记忆更新器")
-    
+            logger.info("Stopped all graph memory updaters")
+
     @classmethod
     def get_all_stats(cls) -> Dict[str, Dict[str, Any]]:
-        """获取所有更新器的统计信息"""
+        """Get stats for all updaters"""
         return {
-            sim_id: updater.get_stats() 
+            sim_id: updater.get_stats()
             for sim_id, updater in cls._updaters.items()
         }

--- a/backend/app/services/zep_tools.py
+++ b/backend/app/services/zep_tools.py
@@ -1,11 +1,11 @@
 """
-Zep检索工具服务
-封装图谱搜索、节点读取、边查询等工具，供Report Agent使用
+Zep retrieval tools service
+Wraps graph search, node read, edge query, and other tools used by the Report Agent.
 
-核心检索工具（优化后）：
-1. InsightForge（深度洞察检索）- 最强大的混合检索，自动生成子问题并多维度检索
-2. PanoramaSearch（广度搜索）- 获取全貌，包括过期内容
-3. QuickSearch（简单搜索）- 快速检索
+Core retrieval tools (after optimization):
+1. InsightForge (deep-insight retrieval) — the most powerful hybrid retrieval; auto-generates sub-queries and retrieves across multiple dimensions
+2. PanoramaSearch (breadth search) — get the full panoramic view, including expired content
+3. QuickSearch (simple search) — fast retrieval
 """
 
 import time
@@ -26,13 +26,13 @@ logger = get_logger('mirofish.zep_tools')
 
 @dataclass
 class SearchResult:
-    """搜索结果"""
+    """Search result"""
     facts: List[str]
     edges: List[Dict[str, Any]]
     nodes: List[Dict[str, Any]]
     query: str
     total_count: int
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "facts": self.facts,
@@ -41,28 +41,28 @@ class SearchResult:
             "query": self.query,
             "total_count": self.total_count
         }
-    
+
     def to_text(self) -> str:
-        """转换为文本格式，供LLM理解"""
-        text_parts = [f"搜索查询: {self.query}", f"找到 {self.total_count} 条相关信息"]
-        
+        """Convert to a text format the LLM can understand"""
+        text_parts = [f"Search query: {self.query}", f"Found {self.total_count} relevant items"]
+
         if self.facts:
-            text_parts.append("\n### 相关事实:")
+            text_parts.append("\n### Relevant Facts:")
             for i, fact in enumerate(self.facts, 1):
                 text_parts.append(f"{i}. {fact}")
-        
+
         return "\n".join(text_parts)
 
 
 @dataclass
 class NodeInfo:
-    """节点信息"""
+    """Node information"""
     uuid: str
     name: str
     labels: List[str]
     summary: str
     attributes: Dict[str, Any]
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "uuid": self.uuid,
@@ -71,16 +71,16 @@ class NodeInfo:
             "summary": self.summary,
             "attributes": self.attributes
         }
-    
+
     def to_text(self) -> str:
-        """转换为文本格式"""
-        entity_type = next((l for l in self.labels if l not in ["Entity", "Node"]), "未知类型")
-        return f"实体: {self.name} (类型: {entity_type})\n摘要: {self.summary}"
+        """Convert to text format"""
+        entity_type = next((l for l in self.labels if l not in ["Entity", "Node"]), "Unknown type")
+        return f"Entity: {self.name} (type: {entity_type})\nSummary: {self.summary}"
 
 
 @dataclass
 class EdgeInfo:
-    """边信息"""
+    """Edge information"""
     uuid: str
     name: str
     fact: str
@@ -88,12 +88,12 @@ class EdgeInfo:
     target_node_uuid: str
     source_node_name: Optional[str] = None
     target_node_name: Optional[str] = None
-    # 时间信息
+    # Temporal info
     created_at: Optional[str] = None
     valid_at: Optional[str] = None
     invalid_at: Optional[str] = None
     expired_at: Optional[str] = None
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "uuid": self.uuid,
@@ -108,53 +108,53 @@ class EdgeInfo:
             "invalid_at": self.invalid_at,
             "expired_at": self.expired_at
         }
-    
+
     def to_text(self, include_temporal: bool = False) -> str:
-        """转换为文本格式"""
+        """Convert to text format"""
         source = self.source_node_name or self.source_node_uuid[:8]
         target = self.target_node_name or self.target_node_uuid[:8]
-        base_text = f"关系: {source} --[{self.name}]--> {target}\n事实: {self.fact}"
-        
+        base_text = f"Relation: {source} --[{self.name}]--> {target}\nFact: {self.fact}"
+
         if include_temporal:
-            valid_at = self.valid_at or "未知"
-            invalid_at = self.invalid_at or "至今"
-            base_text += f"\n时效: {valid_at} - {invalid_at}"
+            valid_at = self.valid_at or "Unknown"
+            invalid_at = self.invalid_at or "Present"
+            base_text += f"\nValidity: {valid_at} - {invalid_at}"
             if self.expired_at:
-                base_text += f" (已过期: {self.expired_at})"
-        
+                base_text += f" (expired: {self.expired_at})"
+
         return base_text
-    
+
     @property
     def is_expired(self) -> bool:
-        """是否已过期"""
+        """Whether the edge has expired"""
         return self.expired_at is not None
-    
+
     @property
     def is_invalid(self) -> bool:
-        """是否已失效"""
+        """Whether the edge has been invalidated"""
         return self.invalid_at is not None
 
 
 @dataclass
 class InsightForgeResult:
     """
-    深度洞察检索结果 (InsightForge)
-    包含多个子问题的检索结果，以及综合分析
+    Deep-insight retrieval result (InsightForge)
+    Contains the retrieval results for multiple sub-questions plus a synthesized analysis.
     """
     query: str
     simulation_requirement: str
     sub_queries: List[str]
-    
-    # 各维度检索结果
-    semantic_facts: List[str] = field(default_factory=list)  # 语义搜索结果
-    entity_insights: List[Dict[str, Any]] = field(default_factory=list)  # 实体洞察
-    relationship_chains: List[str] = field(default_factory=list)  # 关系链
-    
-    # 统计信息
+
+    # Per-dimension retrieval results
+    semantic_facts: List[str] = field(default_factory=list)  # semantic-search results
+    entity_insights: List[Dict[str, Any]] = field(default_factory=list)  # entity insights
+    relationship_chains: List[str] = field(default_factory=list)  # relationship chains
+
+    # Statistics
     total_facts: int = 0
     total_entities: int = 0
     total_relationships: int = 0
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "query": self.query,
@@ -167,73 +167,73 @@ class InsightForgeResult:
             "total_entities": self.total_entities,
             "total_relationships": self.total_relationships
         }
-    
+
     def to_text(self) -> str:
-        """转换为详细的文本格式，供LLM理解"""
+        """Convert to a detailed text format the LLM can understand"""
         text_parts = [
-            f"## 未来预测深度分析",
-            f"分析问题: {self.query}",
-            f"预测场景: {self.simulation_requirement}",
-            f"\n### 预测数据统计",
-            f"- 相关预测事实: {self.total_facts}条",
-            f"- 涉及实体: {self.total_entities}个",
-            f"- 关系链: {self.total_relationships}条"
+            f"## Deep Future-Prediction Analysis",
+            f"Analysis question: {self.query}",
+            f"Prediction scenario: {self.simulation_requirement}",
+            f"\n### Prediction Data Statistics",
+            f"- Relevant predicted facts: {self.total_facts}",
+            f"- Entities involved: {self.total_entities}",
+            f"- Relationship chains: {self.total_relationships}"
         ]
-        
-        # 子问题
+
+        # Sub-questions
         if self.sub_queries:
-            text_parts.append(f"\n### 分析的子问题")
+            text_parts.append(f"\n### Sub-Questions Analyzed")
             for i, sq in enumerate(self.sub_queries, 1):
                 text_parts.append(f"{i}. {sq}")
-        
-        # 语义搜索结果
+
+        # Semantic-search results
         if self.semantic_facts:
-            text_parts.append(f"\n### 【关键事实】(请在报告中引用这些原文)")
+            text_parts.append(f"\n### [Key Facts] (please cite these verbatim in the report)")
             for i, fact in enumerate(self.semantic_facts, 1):
                 text_parts.append(f"{i}. \"{fact}\"")
-        
-        # 实体洞察
+
+        # Entity insights
         if self.entity_insights:
-            text_parts.append(f"\n### 【核心实体】")
+            text_parts.append(f"\n### [Core Entities]")
             for entity in self.entity_insights:
-                text_parts.append(f"- **{entity.get('name', '未知')}** ({entity.get('type', '实体')})")
+                text_parts.append(f"- **{entity.get('name', 'Unknown')}** ({entity.get('type', 'Entity')})")
                 if entity.get('summary'):
-                    text_parts.append(f"  摘要: \"{entity.get('summary')}\"")
+                    text_parts.append(f"  Summary: \"{entity.get('summary')}\"")
                 if entity.get('related_facts'):
-                    text_parts.append(f"  相关事实: {len(entity.get('related_facts', []))}条")
-        
-        # 关系链
+                    text_parts.append(f"  Related facts: {len(entity.get('related_facts', []))}")
+
+        # Relationship chains
         if self.relationship_chains:
-            text_parts.append(f"\n### 【关系链】")
+            text_parts.append(f"\n### [Relationship Chains]")
             for chain in self.relationship_chains:
                 text_parts.append(f"- {chain}")
-        
+
         return "\n".join(text_parts)
 
 
 @dataclass
 class PanoramaResult:
     """
-    广度搜索结果 (Panorama)
-    包含所有相关信息，包括过期内容
+    Breadth-search result (Panorama)
+    Contains all relevant information, including expired content.
     """
     query: str
-    
-    # 全部节点
+
+    # All nodes
     all_nodes: List[NodeInfo] = field(default_factory=list)
-    # 全部边（包括过期的）
+    # All edges (including expired ones)
     all_edges: List[EdgeInfo] = field(default_factory=list)
-    # 当前有效的事实
+    # Currently valid facts
     active_facts: List[str] = field(default_factory=list)
-    # 已过期/失效的事实（历史记录）
+    # Expired/invalidated facts (historical record)
     historical_facts: List[str] = field(default_factory=list)
-    
-    # 统计
+
+    # Statistics
     total_nodes: int = 0
     total_edges: int = 0
     active_count: int = 0
     historical_count: int = 0
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "query": self.query,
@@ -246,51 +246,51 @@ class PanoramaResult:
             "active_count": self.active_count,
             "historical_count": self.historical_count
         }
-    
+
     def to_text(self) -> str:
-        """转换为文本格式（完整版本，不截断）"""
+        """Convert to text format (full version, not truncated)"""
         text_parts = [
-            f"## 广度搜索结果（未来全景视图）",
-            f"查询: {self.query}",
-            f"\n### 统计信息",
-            f"- 总节点数: {self.total_nodes}",
-            f"- 总边数: {self.total_edges}",
-            f"- 当前有效事实: {self.active_count}条",
-            f"- 历史/过期事实: {self.historical_count}条"
+            f"## Breadth Search Result (Future Panoramic View)",
+            f"Query: {self.query}",
+            f"\n### Statistics",
+            f"- Total nodes: {self.total_nodes}",
+            f"- Total edges: {self.total_edges}",
+            f"- Currently valid facts: {self.active_count}",
+            f"- Historical / expired facts: {self.historical_count}"
         ]
-        
-        # 当前有效的事实（完整输出，不截断）
+
+        # Currently valid facts (full output, not truncated)
         if self.active_facts:
-            text_parts.append(f"\n### 【当前有效事实】(模拟结果原文)")
+            text_parts.append(f"\n### [Currently Valid Facts] (verbatim simulation results)")
             for i, fact in enumerate(self.active_facts, 1):
                 text_parts.append(f"{i}. \"{fact}\"")
-        
-        # 历史/过期事实（完整输出，不截断）
+
+        # Historical / expired facts (full output, not truncated)
         if self.historical_facts:
-            text_parts.append(f"\n### 【历史/过期事实】(演变过程记录)")
+            text_parts.append(f"\n### [Historical / Expired Facts] (record of how things evolved)")
             for i, fact in enumerate(self.historical_facts, 1):
                 text_parts.append(f"{i}. \"{fact}\"")
-        
-        # 关键实体（完整输出，不截断）
+
+        # Key entities (full output, not truncated)
         if self.all_nodes:
-            text_parts.append(f"\n### 【涉及实体】")
+            text_parts.append(f"\n### [Entities Involved]")
             for node in self.all_nodes:
-                entity_type = next((l for l in node.labels if l not in ["Entity", "Node"]), "实体")
+                entity_type = next((l for l in node.labels if l not in ["Entity", "Node"]), "Entity")
                 text_parts.append(f"- **{node.name}** ({entity_type})")
-        
+
         return "\n".join(text_parts)
 
 
 @dataclass
 class AgentInterview:
-    """单个Agent的采访结果"""
+    """A single agent's interview result"""
     agent_name: str
-    agent_role: str  # 角色类型（如：学生、教师、媒体等）
-    agent_bio: str  # 简介
-    question: str  # 采访问题
-    response: str  # 采访回答
-    key_quotes: List[str] = field(default_factory=list)  # 关键引言
-    
+    agent_role: str  # role type (e.g., student, teacher, media, etc.)
+    agent_bio: str  # bio
+    question: str  # interview question
+    response: str  # interview answer
+    key_quotes: List[str] = field(default_factory=list)  # key quotes
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "agent_name": self.agent_name,
@@ -300,34 +300,34 @@ class AgentInterview:
             "response": self.response,
             "key_quotes": self.key_quotes
         }
-    
+
     def to_text(self) -> str:
         text = f"**{self.agent_name}** ({self.agent_role})\n"
-        # 显示完整的agent_bio，不截断
-        text += f"_简介: {self.agent_bio}_\n\n"
+        # Show the full agent_bio, not truncated
+        text += f"_Bio: {self.agent_bio}_\n\n"
         text += f"**Q:** {self.question}\n\n"
         text += f"**A:** {self.response}\n"
         if self.key_quotes:
-            text += "\n**关键引言:**\n"
+            text += "\n**Key Quotes:**\n"
             for quote in self.key_quotes:
-                # 清理各种引号
-                clean_quote = quote.replace('\u201c', '').replace('\u201d', '').replace('"', '')
-                clean_quote = clean_quote.replace('\u300c', '').replace('\u300d', '')
+                # Strip various quotation marks
+                clean_quote = quote.replace('“', '').replace('”', '').replace('"', '')
+                clean_quote = clean_quote.replace('「', '').replace('」', '')
                 clean_quote = clean_quote.strip()
-                # 去掉开头的标点
+                # Strip leading punctuation
                 while clean_quote and clean_quote[0] in '，,；;：:、。！？\n\r\t ':
                     clean_quote = clean_quote[1:]
-                # 过滤包含问题编号的垃圾内容（问题1-9）
+                # Filter out junk content containing question numbers (questions 1-9)
                 skip = False
                 for d in '123456789':
-                    if f'\u95ee\u9898{d}' in clean_quote:
+                    if f'问题{d}' in clean_quote:
                         skip = True
                         break
                 if skip:
                     continue
-                # 截断过长内容（按句号截断，而非硬截断）
+                # Truncate overly long content (cut at full-stop rather than hard truncate)
                 if len(clean_quote) > 150:
-                    dot_pos = clean_quote.find('\u3002', 80)
+                    dot_pos = clean_quote.find('。', 80)
                     if dot_pos > 0:
                         clean_quote = clean_quote[:dot_pos + 1]
                     else:
@@ -340,26 +340,26 @@ class AgentInterview:
 @dataclass
 class InterviewResult:
     """
-    采访结果 (Interview)
-    包含多个模拟Agent的采访回答
+    Interview result
+    Contains the interview answers from multiple simulation agents.
     """
-    interview_topic: str  # 采访主题
-    interview_questions: List[str]  # 采访问题列表
-    
-    # 采访选择的Agent
+    interview_topic: str  # interview topic
+    interview_questions: List[str]  # interview questions
+
+    # Agents selected for the interview
     selected_agents: List[Dict[str, Any]] = field(default_factory=list)
-    # 各Agent的采访回答
+    # Interview answers from each agent
     interviews: List[AgentInterview] = field(default_factory=list)
-    
-    # 选择Agent的理由
+
+    # Reasoning behind selecting these agents
     selection_reasoning: str = ""
-    # 整合后的采访摘要
+    # Synthesized interview summary
     summary: str = ""
-    
-    # 统计
+
+    # Statistics
     total_agents: int = 0
     interviewed_count: int = 0
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "interview_topic": self.interview_topic,
@@ -371,80 +371,80 @@ class InterviewResult:
             "total_agents": self.total_agents,
             "interviewed_count": self.interviewed_count
         }
-    
+
     def to_text(self) -> str:
-        """转换为详细的文本格式，供LLM理解和报告引用"""
+        """Convert to a detailed text format the LLM can understand and the report can cite"""
         text_parts = [
-            "## 深度采访报告",
-            f"**采访主题:** {self.interview_topic}",
-            f"**采访人数:** {self.interviewed_count} / {self.total_agents} 位模拟Agent",
-            "\n### 采访对象选择理由",
-            self.selection_reasoning or "（自动选择）",
+            "## In-Depth Interview Report",
+            f"**Interview topic:** {self.interview_topic}",
+            f"**Number of interviewees:** {self.interviewed_count} / {self.total_agents} simulation agents",
+            "\n### Reasoning for Selecting Interviewees",
+            self.selection_reasoning or "(automatic selection)",
             "\n---",
-            "\n### 采访实录",
+            "\n### Interview Transcripts",
         ]
 
         if self.interviews:
             for i, interview in enumerate(self.interviews, 1):
-                text_parts.append(f"\n#### 采访 #{i}: {interview.agent_name}")
+                text_parts.append(f"\n#### Interview #{i}: {interview.agent_name}")
                 text_parts.append(interview.to_text())
                 text_parts.append("\n---")
         else:
-            text_parts.append("（无采访记录）\n\n---")
+            text_parts.append("(No interview records)\n\n---")
 
-        text_parts.append("\n### 采访摘要与核心观点")
-        text_parts.append(self.summary or "（无摘要）")
+        text_parts.append("\n### Interview Summary and Key Points")
+        text_parts.append(self.summary or "(No summary)")
 
         return "\n".join(text_parts)
 
 
 class ZepToolsService:
     """
-    Zep检索工具服务
-    
-    【核心检索工具 - 优化后】
-    1. insight_forge - 深度洞察检索（最强大，自动生成子问题，多维度检索）
-    2. panorama_search - 广度搜索（获取全貌，包括过期内容）
-    3. quick_search - 简单搜索（快速检索）
-    4. interview_agents - 深度采访（采访模拟Agent，获取多视角观点）
-    
-    【基础工具】
-    - search_graph - 图谱语义搜索
-    - get_all_nodes - 获取图谱所有节点
-    - get_all_edges - 获取图谱所有边（含时间信息）
-    - get_node_detail - 获取节点详细信息
-    - get_node_edges - 获取节点相关的边
-    - get_entities_by_type - 按类型获取实体
-    - get_entity_summary - 获取实体的关系摘要
+    Zep retrieval tools service
+
+    [Core retrieval tools — after optimization]
+    1. insight_forge - deep-insight retrieval (most powerful; auto-generates sub-questions; multi-dimensional retrieval)
+    2. panorama_search - breadth search (full panorama, including expired content)
+    3. quick_search - simple search (fast retrieval)
+    4. interview_agents - in-depth interview (interview simulation agents to gather multi-perspective viewpoints)
+
+    [Basic tools]
+    - search_graph - graph semantic search
+    - get_all_nodes - get all nodes in the graph
+    - get_all_edges - get all edges in the graph (with temporal info)
+    - get_node_detail - get detailed info for a node
+    - get_node_edges - get edges related to a node
+    - get_entities_by_type - get entities by type
+    - get_entity_summary - get an entity's relationship summary
     """
-    
-    # 重试配置
+
+    # Retry configuration
     MAX_RETRIES = 3
     RETRY_DELAY = 2.0
-    
+
     def __init__(self, api_key: Optional[str] = None, llm_client: Optional[LLMClient] = None):
         self.api_key = api_key or Config.ZEP_API_KEY
         if not self.api_key:
-            raise ValueError("ZEP_API_KEY 未配置")
-        
+            raise ValueError("ZEP_API_KEY is not configured")
+
         self.client = Zep(api_key=self.api_key)
-        # LLM客户端用于InsightForge生成子问题
+        # LLM client used by InsightForge to generate sub-questions
         self._llm_client = llm_client
         logger.info(t("console.zepToolsInitialized"))
-    
+
     @property
     def llm(self) -> LLMClient:
-        """延迟初始化LLM客户端"""
+        """Lazily initialize the LLM client"""
         if self._llm_client is None:
             self._llm_client = LLMClient()
         return self._llm_client
-    
+
     def _call_with_retry(self, func, operation_name: str, max_retries: int = None):
-        """带重试机制的API调用"""
+        """API call with retry mechanism"""
         max_retries = max_retries or self.MAX_RETRIES
         last_exception = None
         delay = self.RETRY_DELAY
-        
+
         for attempt in range(max_retries):
             try:
                 return func()
@@ -458,34 +458,34 @@ class ZepToolsService:
                     delay *= 2
                 else:
                     logger.error(t("console.zepAllRetriesFailed", operation=operation_name, retries=max_retries, error=str(e)))
-        
+
         raise last_exception
-    
+
     def search_graph(
-        self, 
-        graph_id: str, 
-        query: str, 
+        self,
+        graph_id: str,
+        query: str,
         limit: int = 10,
         scope: str = "edges"
     ) -> SearchResult:
         """
-        图谱语义搜索
-        
-        使用混合搜索（语义+BM25）在图谱中搜索相关信息。
-        如果Zep Cloud的search API不可用，则降级为本地关键词匹配。
-        
+        Graph semantic search
+
+        Uses hybrid search (semantic + BM25) to find relevant information in the graph.
+        If the Zep Cloud search API is unavailable, falls back to local keyword matching.
+
         Args:
-            graph_id: 图谱ID (Standalone Graph)
-            query: 搜索查询
-            limit: 返回结果数量
-            scope: 搜索范围，"edges" 或 "nodes"
-            
+            graph_id: Graph ID (Standalone Graph)
+            query: Search query
+            limit: Number of results to return
+            scope: Search scope, "edges" or "nodes"
+
         Returns:
-            SearchResult: 搜索结果
+            SearchResult: Search result
         """
         logger.info(t("console.graphSearch", graphId=graph_id, query=query[:50]))
-        
-        # 尝试使用Zep Cloud Search API
+
+        # Try the Zep Cloud Search API
         try:
             search_results = self._call_with_retry(
                 func=lambda: self.client.graph.search(
@@ -497,12 +497,12 @@ class ZepToolsService:
                 ),
                 operation_name=t("console.graphSearchOp", graphId=graph_id)
             )
-            
+
             facts = []
             edges = []
             nodes = []
-            
-            # 解析边搜索结果
+
+            # Parse edge search results
             if hasattr(search_results, 'edges') and search_results.edges:
                 for edge in search_results.edges:
                     if hasattr(edge, 'fact') and edge.fact:
@@ -514,8 +514,8 @@ class ZepToolsService:
                         "source_node_uuid": getattr(edge, 'source_node_uuid', ''),
                         "target_node_uuid": getattr(edge, 'target_node_uuid', ''),
                     })
-            
-            # 解析节点搜索结果
+
+            # Parse node search results
             if hasattr(search_results, 'nodes') and search_results.nodes:
                 for node in search_results.nodes:
                     nodes.append({
@@ -524,12 +524,12 @@ class ZepToolsService:
                         "labels": getattr(node, 'labels', []),
                         "summary": getattr(node, 'summary', ''),
                     })
-                    # 节点摘要也算作事实
+                    # Node summaries also count as facts
                     if hasattr(node, 'summary') and node.summary:
                         facts.append(f"[{node.name}]: {node.summary}")
-            
+
             logger.info(t("console.searchComplete", count=len(facts)))
-            
+
             return SearchResult(
                 facts=facts,
                 edges=edges,
@@ -537,71 +537,71 @@ class ZepToolsService:
                 query=query,
                 total_count=len(facts)
             )
-            
+
         except Exception as e:
             logger.warning(t("console.zepSearchApiFallback", error=str(e)))
-            # 降级：使用本地关键词匹配搜索
+            # Fallback: local keyword-matching search
             return self._local_search(graph_id, query, limit, scope)
-    
+
     def _local_search(
-        self, 
-        graph_id: str, 
-        query: str, 
+        self,
+        graph_id: str,
+        query: str,
         limit: int = 10,
         scope: str = "edges"
     ) -> SearchResult:
         """
-        本地关键词匹配搜索（作为Zep Search API的降级方案）
-        
-        获取所有边/节点，然后在本地进行关键词匹配
-        
+        Local keyword-matching search (fallback for the Zep Search API)
+
+        Fetches all edges/nodes and performs keyword matching locally.
+
         Args:
-            graph_id: 图谱ID
-            query: 搜索查询
-            limit: 返回结果数量
-            scope: 搜索范围
-            
+            graph_id: Graph ID
+            query: Search query
+            limit: Number of results to return
+            scope: Search scope
+
         Returns:
-            SearchResult: 搜索结果
+            SearchResult: Search result
         """
         logger.info(t("console.usingLocalSearch", query=query[:30]))
-        
+
         facts = []
         edges_result = []
         nodes_result = []
-        
-        # 提取查询关键词（简单分词）
+
+        # Extract query keywords (simple tokenization)
         query_lower = query.lower()
         keywords = [w.strip() for w in query_lower.replace(',', ' ').replace('，', ' ').split() if len(w.strip()) > 1]
-        
+
         def match_score(text: str) -> int:
-            """计算文本与查询的匹配分数"""
+            """Compute the match score between text and the query"""
             if not text:
                 return 0
             text_lower = text.lower()
-            # 完全匹配查询
+            # Full match of the query
             if query_lower in text_lower:
                 return 100
-            # 关键词匹配
+            # Keyword match
             score = 0
             for keyword in keywords:
                 if keyword in text_lower:
                     score += 10
             return score
-        
+
         try:
             if scope in ["edges", "both"]:
-                # 获取所有边并匹配
+                # Fetch all edges and match
                 all_edges = self.get_all_edges(graph_id)
                 scored_edges = []
                 for edge in all_edges:
                     score = match_score(edge.fact) + match_score(edge.name)
                     if score > 0:
                         scored_edges.append((score, edge))
-                
-                # 按分数排序
+
+                # Sort by score
                 scored_edges.sort(key=lambda x: x[0], reverse=True)
-                
+
                 for score, edge in scored_edges[:limit]:
                     if edge.fact:
                         facts.append(edge.fact)
@@ -612,18 +612,18 @@ class ZepToolsService:
                         "source_node_uuid": edge.source_node_uuid,
                         "target_node_uuid": edge.target_node_uuid,
                     })
-            
+
             if scope in ["nodes", "both"]:
-                # 获取所有节点并匹配
+                # Fetch all nodes and match
                 all_nodes = self.get_all_nodes(graph_id)
                 scored_nodes = []
                 for node in all_nodes:
                     score = match_score(node.name) + match_score(node.summary)
                     if score > 0:
                         scored_nodes.append((score, node))
-                
+
                 scored_nodes.sort(key=lambda x: x[0], reverse=True)
-                
+
                 for score, node in scored_nodes[:limit]:
                     nodes_result.append({
                         "uuid": node.uuid,
@@ -633,12 +633,12 @@ class ZepToolsService:
                     })
                     if node.summary:
                         facts.append(f"[{node.name}]: {node.summary}")
-            
+
             logger.info(t("console.localSearchComplete", count=len(facts)))
-            
+
         except Exception as e:
             logger.error(t("console.localSearchFailed", error=str(e)))
-        
+
         return SearchResult(
             facts=facts,
             edges=edges_result,
@@ -646,16 +646,16 @@ class ZepToolsService:
             query=query,
             total_count=len(facts)
         )
-    
+
     def get_all_nodes(self, graph_id: str) -> List[NodeInfo]:
         """
-        获取图谱的所有节点（分页获取）
+        Get all nodes in the graph (paginated)
 
         Args:
-            graph_id: 图谱ID
+            graph_id: Graph ID
 
         Returns:
-            节点列表
+            List of nodes
         """
         logger.info(t("console.fetchingAllNodes", graphId=graph_id))
 
@@ -677,14 +677,14 @@ class ZepToolsService:
 
     def get_all_edges(self, graph_id: str, include_temporal: bool = True) -> List[EdgeInfo]:
         """
-        获取图谱的所有边（分页获取，包含时间信息）
+        Get all edges in the graph (paginated, with temporal info)
 
         Args:
-            graph_id: 图谱ID
-            include_temporal: 是否包含时间信息（默认True）
+            graph_id: Graph ID
+            include_temporal: Whether to include temporal info (default True)
 
         Returns:
-            边列表（包含created_at, valid_at, invalid_at, expired_at）
+            List of edges (including created_at, valid_at, invalid_at, expired_at)
         """
         logger.info(t("console.fetchingAllEdges", graphId=graph_id))
 
@@ -701,7 +701,7 @@ class ZepToolsService:
                 target_node_uuid=edge.target_node_uuid or ""
             )
 
-            # 添加时间信息
+            # Add temporal info
             if include_temporal:
                 edge_info.created_at = getattr(edge, 'created_at', None)
                 edge_info.valid_at = getattr(edge, 'valid_at', None)
@@ -712,28 +712,28 @@ class ZepToolsService:
 
         logger.info(t("console.fetchedEdges", count=len(result)))
         return result
-    
+
     def get_node_detail(self, node_uuid: str) -> Optional[NodeInfo]:
         """
-        获取单个节点的详细信息
-        
+        Get detailed info for a single node
+
         Args:
-            node_uuid: 节点UUID
-            
+            node_uuid: Node UUID
+
         Returns:
-            节点信息或None
+            Node info or None
         """
         logger.info(t("console.fetchingNodeDetail", uuid=node_uuid[:8]))
-        
+
         try:
             node = self._call_with_retry(
                 func=lambda: self.client.graph.node.get(uuid_=node_uuid),
                 operation_name=t("console.fetchNodeDetailOp", uuid=node_uuid[:8])
             )
-            
+
             if not node:
                 return None
-            
+
             return NodeInfo(
                 uuid=getattr(node, 'uuid_', None) or getattr(node, 'uuid', ''),
                 name=node.name or "",
@@ -744,106 +744,106 @@ class ZepToolsService:
         except Exception as e:
             logger.error(t("console.fetchNodeDetailFailed", error=str(e)))
             return None
-    
+
     def get_node_edges(self, graph_id: str, node_uuid: str) -> List[EdgeInfo]:
         """
-        获取节点相关的所有边
-        
-        通过获取图谱所有边，然后过滤出与指定节点相关的边
-        
+        Get all edges related to a node
+
+        Fetches all edges of the graph and filters those related to the given node.
+
         Args:
-            graph_id: 图谱ID
-            node_uuid: 节点UUID
-            
+            graph_id: Graph ID
+            node_uuid: Node UUID
+
         Returns:
-            边列表
+            List of edges
         """
         logger.info(t("console.fetchingNodeEdges", uuid=node_uuid[:8]))
-        
+
         try:
-            # 获取图谱所有边，然后过滤
+            # Fetch all edges in the graph and filter
             all_edges = self.get_all_edges(graph_id)
-            
+
             result = []
             for edge in all_edges:
-                # 检查边是否与指定节点相关（作为源或目标）
+                # Check whether the edge is related to the given node (as source or target)
                 if edge.source_node_uuid == node_uuid or edge.target_node_uuid == node_uuid:
                     result.append(edge)
-            
+
             logger.info(t("console.foundNodeEdges", count=len(result)))
             return result
-            
+
         except Exception as e:
             logger.warning(t("console.fetchNodeEdgesFailed", error=str(e)))
             return []
-    
+
     def get_entities_by_type(
-        self, 
-        graph_id: str, 
+        self,
+        graph_id: str,
         entity_type: str
     ) -> List[NodeInfo]:
         """
-        按类型获取实体
-        
+        Get entities by type
+
         Args:
-            graph_id: 图谱ID
-            entity_type: 实体类型（如 Student, PublicFigure 等）
-            
+            graph_id: Graph ID
+            entity_type: Entity type (e.g., Student, PublicFigure, etc.)
+
         Returns:
-            符合类型的实体列表
+            List of entities matching the type
         """
         logger.info(t("console.fetchingEntitiesByType", type=entity_type))
-        
+
         all_nodes = self.get_all_nodes(graph_id)
-        
+
         filtered = []
         for node in all_nodes:
-            # 检查labels是否包含指定类型
+            # Check whether labels contain the requested type
             if entity_type in node.labels:
                 filtered.append(node)
-        
+
         logger.info(t("console.foundEntitiesByType", count=len(filtered), type=entity_type))
         return filtered
-    
+
     def get_entity_summary(
-        self, 
-        graph_id: str, 
+        self,
+        graph_id: str,
         entity_name: str
     ) -> Dict[str, Any]:
         """
-        获取指定实体的关系摘要
-        
-        搜索与该实体相关的所有信息，并生成摘要
-        
+        Get the relationship summary for the given entity
+
+        Searches all information related to the entity and produces a summary.
+
         Args:
-            graph_id: 图谱ID
-            entity_name: 实体名称
-            
+            graph_id: Graph ID
+            entity_name: Entity name
+
         Returns:
-            实体摘要信息
+            Entity summary information
         """
         logger.info(t("console.fetchingEntitySummary", name=entity_name))
-        
-        # 先搜索该实体相关的信息
+
+        # First, search for information related to the entity
         search_result = self.search_graph(
             graph_id=graph_id,
             query=entity_name,
             limit=20
         )
-        
-        # 尝试在所有节点中找到该实体
+
+        # Try to find the entity among all nodes
         all_nodes = self.get_all_nodes(graph_id)
         entity_node = None
         for node in all_nodes:
             if node.name.lower() == entity_name.lower():
                 entity_node = node
                 break
-        
+
         related_edges = []
         if entity_node:
-            # 传入graph_id参数
+            # Pass the graph_id parameter
             related_edges = self.get_node_edges(graph_id, entity_node.uuid)
-        
+
         return {
             "entity_name": entity_name,
             "entity_info": entity_node.to_dict() if entity_node else None,
@@ -851,34 +851,34 @@ class ZepToolsService:
             "related_edges": [e.to_dict() for e in related_edges],
             "total_relations": len(related_edges)
         }
-    
+
     def get_graph_statistics(self, graph_id: str) -> Dict[str, Any]:
         """
-        获取图谱的统计信息
-        
+        Get statistics about the graph
+
         Args:
-            graph_id: 图谱ID
-            
+            graph_id: Graph ID
+
         Returns:
-            统计信息
+            Statistics
         """
         logger.info(t("console.fetchingGraphStats", graphId=graph_id))
-        
+
         nodes = self.get_all_nodes(graph_id)
         edges = self.get_all_edges(graph_id)
-        
-        # 统计实体类型分布
+
+        # Distribution of entity types
         entity_types = {}
         for node in nodes:
             for label in node.labels:
                 if label not in ["Entity", "Node"]:
                     entity_types[label] = entity_types.get(label, 0) + 1
-        
-        # 统计关系类型分布
+
+        # Distribution of relationship types
         relation_types = {}
         for edge in edges:
             relation_types[edge.name] = relation_types.get(edge.name, 0) + 1
-        
+
         return {
             "graph_id": graph_id,
             "total_nodes": len(nodes),
@@ -886,42 +886,42 @@ class ZepToolsService:
             "entity_types": entity_types,
             "relation_types": relation_types
         }
-    
+
     def get_simulation_context(
-        self, 
+        self,
         graph_id: str,
         simulation_requirement: str,
         limit: int = 30
     ) -> Dict[str, Any]:
         """
-        获取模拟相关的上下文信息
-        
-        综合搜索与模拟需求相关的所有信息
-        
+        Get the simulation-related context
+
+        Aggregates a search of all information relevant to the simulation requirement.
+
         Args:
-            graph_id: 图谱ID
-            simulation_requirement: 模拟需求描述
-            limit: 每类信息的数量限制
-            
+            graph_id: Graph ID
+            simulation_requirement: Simulation requirement description
+            limit: Limit on the count of each information category
+
         Returns:
-            模拟上下文信息
+            Simulation context information
         """
         logger.info(t("console.fetchingSimContext", requirement=simulation_requirement[:50]))
-        
-        # 搜索与模拟需求相关的信息
+
+        # Search for information relevant to the simulation requirement
         search_result = self.search_graph(
             graph_id=graph_id,
             query=simulation_requirement,
             limit=limit
         )
-        
-        # 获取图谱统计
+
+        # Get graph statistics
         stats = self.get_graph_statistics(graph_id)
-        
-        # 获取所有实体节点
+
+        # Get all entity nodes
         all_nodes = self.get_all_nodes(graph_id)
-        
-        # 筛选有实际类型的实体（非纯Entity节点）
+
+        # Filter entities that have an actual type (not pure "Entity" nodes)
         entities = []
         for node in all_nodes:
             custom_labels = [l for l in node.labels if l not in ["Entity", "Node"]]
@@ -931,17 +931,17 @@ class ZepToolsService:
                     "type": custom_labels[0],
                     "summary": node.summary
                 })
-        
+
         return {
             "simulation_requirement": simulation_requirement,
             "related_facts": search_result.facts,
             "graph_statistics": stats,
-            "entities": entities[:limit],  # 限制数量
+            "entities": entities[:limit],  # cap the count
             "total_entities": len(entities)
         }
-    
-    # ========== 核心检索工具（优化后） ==========
-    
+
+    # ========== Core retrieval tools (after optimization) ==========
+
     def insight_forge(
         self,
         graph_id: str,
@@ -951,34 +951,35 @@ class ZepToolsService:
         max_sub_queries: int = 5
     ) -> InsightForgeResult:
         """
-        【InsightForge - 深度洞察检索】
-        
-        最强大的混合检索函数，自动分解问题并多维度检索：
-        1. 使用LLM将问题分解为多个子问题
-        2. 对每个子问题进行语义搜索
-        3. 提取相关实体并获取其详细信息
-        4. 追踪关系链
-        5. 整合所有结果，生成深度洞察
-        
+        [InsightForge - deep-insight retrieval]
+
+        The most powerful hybrid retrieval; automatically decomposes the question
+        and retrieves across multiple dimensions:
+        1. Use the LLM to break the question into multiple sub-questions
+        2. Run a semantic search for each sub-question
+        3. Extract the relevant entities and fetch their details
+        4. Trace relationship chains
+        5. Aggregate all results to produce deep insights
+
         Args:
-            graph_id: 图谱ID
-            query: 用户问题
-            simulation_requirement: 模拟需求描述
-            report_context: 报告上下文（可选，用于更精准的子问题生成）
-            max_sub_queries: 最大子问题数量
-            
+            graph_id: Graph ID
+            query: User's question
+            simulation_requirement: Simulation requirement description
+            report_context: Report context (optional, used for more accurate sub-question generation)
+            max_sub_queries: Maximum number of sub-questions
+
         Returns:
-            InsightForgeResult: 深度洞察检索结果
+            InsightForgeResult: Deep-insight retrieval result
         """
         logger.info(t("console.insightForgeStart", query=query[:50]))
-        
+
         result = InsightForgeResult(
             query=query,
             simulation_requirement=simulation_requirement,
             sub_queries=[]
         )
-        
-        # Step 1: 使用LLM生成子问题
+
+        # Step 1: Use the LLM to generate sub-questions
         sub_queries = self._generate_sub_queries(
             query=query,
             simulation_requirement=simulation_requirement,
@@ -987,12 +988,12 @@ class ZepToolsService:
         )
         result.sub_queries = sub_queries
         logger.info(t("console.generatedSubQueries", count=len(sub_queries)))
-        
-        # Step 2: 对每个子问题进行语义搜索
+
+        # Step 2: Run a semantic search for each sub-question
         all_facts = []
         all_edges = []
         seen_facts = set()
-        
+
         for sub_query in sub_queries:
             search_result = self.search_graph(
                 graph_id=graph_id,
@@ -1000,15 +1001,15 @@ class ZepToolsService:
                 limit=15,
                 scope="edges"
             )
-            
+
             for fact in search_result.facts:
                 if fact not in seen_facts:
                     all_facts.append(fact)
                     seen_facts.add(fact)
-            
+
             all_edges.extend(search_result.edges)
-        
-        # 对原始问题也进行搜索
+
+        # Also search for the original question
         main_search = self.search_graph(
             graph_id=graph_id,
             query=query,
@@ -1019,11 +1020,11 @@ class ZepToolsService:
             if fact not in seen_facts:
                 all_facts.append(fact)
                 seen_facts.add(fact)
-        
+
         result.semantic_facts = all_facts
         result.total_facts = len(all_facts)
-        
-        # Step 3: 从边中提取相关实体UUID，只获取这些实体的信息（不获取全部节点）
+
+        # Step 3: Extract relevant entity UUIDs from edges and fetch only those entities (not all nodes)
         entity_uuids = set()
         for edge_data in all_edges:
             if isinstance(edge_data, dict):
@@ -1033,62 +1034,62 @@ class ZepToolsService:
                     entity_uuids.add(source_uuid)
                 if target_uuid:
                     entity_uuids.add(target_uuid)
-        
-        # 获取所有相关实体的详情（不限制数量，完整输出）
+
+        # Get details of all relevant entities (no count limit, full output)
         entity_insights = []
-        node_map = {}  # 用于后续关系链构建
-        
-        for uuid in list(entity_uuids):  # 处理所有实体，不截断
+        node_map = {}  # used later for relationship-chain construction
+
+        for uuid in list(entity_uuids):  # process all entities, do not truncate
             if not uuid:
                 continue
             try:
-                # 单独获取每个相关节点的信息
+                # Fetch info for each related node individually
                 node = self.get_node_detail(uuid)
                 if node:
                     node_map[uuid] = node
-                    entity_type = next((l for l in node.labels if l not in ["Entity", "Node"]), "实体")
-                    
-                    # 获取该实体相关的所有事实（不截断）
+                    entity_type = next((l for l in node.labels if l not in ["Entity", "Node"]), "Entity")
+
+                    # Get all facts related to this entity (no truncation)
                     related_facts = [
-                        f for f in all_facts 
+                        f for f in all_facts
                         if node.name.lower() in f.lower()
                     ]
-                    
+
                     entity_insights.append({
                         "uuid": node.uuid,
                         "name": node.name,
                         "type": entity_type,
                         "summary": node.summary,
-                        "related_facts": related_facts  # 完整输出，不截断
+                        "related_facts": related_facts  # full output, no truncation
                     })
             except Exception as e:
-                logger.debug(f"获取节点 {uuid} 失败: {e}")
+                logger.debug(f"Failed to fetch node {uuid}: {e}")
                 continue
-        
+
         result.entity_insights = entity_insights
         result.total_entities = len(entity_insights)
-        
-        # Step 4: 构建所有关系链（不限制数量）
+
+        # Step 4: Build all relationship chains (no count limit)
         relationship_chains = []
-        for edge_data in all_edges:  # 处理所有边，不截断
+        for edge_data in all_edges:  # process all edges, do not truncate
             if isinstance(edge_data, dict):
                 source_uuid = edge_data.get('source_node_uuid', '')
                 target_uuid = edge_data.get('target_node_uuid', '')
                 relation_name = edge_data.get('name', '')
-                
+
                 source_name = node_map.get(source_uuid, NodeInfo('', '', [], '', {})).name or source_uuid[:8]
                 target_name = node_map.get(target_uuid, NodeInfo('', '', [], '', {})).name or target_uuid[:8]
-                
+
                 chain = f"{source_name} --[{relation_name}]--> {target_name}"
                 if chain not in relationship_chains:
                     relationship_chains.append(chain)
-        
+
         result.relationship_chains = relationship_chains
         result.total_relationships = len(relationship_chains)
-        
+
         logger.info(t("console.insightForgeComplete", facts=result.total_facts, entities=result.total_entities, relationships=result.total_relationships))
         return result
-    
+
     def _generate_sub_queries(
         self,
         query: str,
@@ -1097,27 +1098,27 @@ class ZepToolsService:
         max_queries: int = 5
     ) -> List[str]:
         """
-        使用LLM生成子问题
-        
-        将复杂问题分解为多个可以独立检索的子问题
+        Use the LLM to generate sub-questions
+
+        Decomposes a complex question into multiple sub-questions that can be retrieved independently.
         """
-        system_prompt = """你是一个专业的问题分析专家。你的任务是将一个复杂问题分解为多个可以在模拟世界中独立观察的子问题。
+        system_prompt = """You are a professional question-analysis expert. Your task is to break a complex question into several sub-questions that can each be observed independently in the simulated world.
 
-要求：
-1. 每个子问题应该足够具体，可以在模拟世界中找到相关的Agent行为或事件
-2. 子问题应该覆盖原问题的不同维度（如：谁、什么、为什么、怎么样、何时、何地）
-3. 子问题应该与模拟场景相关
-4. 返回JSON格式：{"sub_queries": ["子问题1", "子问题2", ...]}"""
+Requirements:
+1. Each sub-question should be specific enough that relevant agent behaviors or events can be found in the simulated world
+2. Sub-questions should cover different dimensions of the original question (e.g., who, what, why, how, when, where)
+3. Sub-questions should be relevant to the simulation scenario
+4. Return JSON: {"sub_queries": ["sub-question 1", "sub-question 2", ...]}"""
 
-        user_prompt = f"""模拟需求背景：
+        user_prompt = f"""Simulation requirement context:
 {simulation_requirement}
 
-{f"报告上下文：{report_context[:500]}" if report_context else ""}
+{f"Report context: {report_context[:500]}" if report_context else ""}
 
-请将以下问题分解为{max_queries}个子问题：
+Please decompose the following question into {max_queries} sub-questions:
 {query}
 
-返回JSON格式的子问题列表。"""
+Return the sub-question list in JSON format."""
 
         try:
             response = self.llm.chat_json(
@@ -1127,21 +1128,21 @@ class ZepToolsService:
                 ],
                 temperature=0.3
             )
-            
+
             sub_queries = response.get("sub_queries", [])
-            # 确保是字符串列表
+            # Make sure it's a list of strings
             return [str(sq) for sq in sub_queries[:max_queries]]
-            
+
         except Exception as e:
             logger.warning(t("console.generateSubQueriesFailed", error=str(e)))
-            # 降级：返回基于原问题的变体
+            # Fallback: variants based on the original question
             return [
                 query,
-                f"{query} 的主要参与者",
-                f"{query} 的原因和影响",
-                f"{query} 的发展过程"
+                f"main participants of {query}",
+                f"causes and impacts of {query}",
+                f"how {query} unfolded"
             ][:max_queries]
-    
+
     def panorama_search(
         self,
         graph_id: str,
@@ -1150,68 +1151,68 @@ class ZepToolsService:
         limit: int = 50
     ) -> PanoramaResult:
         """
-        【PanoramaSearch - 广度搜索】
-        
-        获取全貌视图，包括所有相关内容和历史/过期信息：
-        1. 获取所有相关节点
-        2. 获取所有边（包括已过期/失效的）
-        3. 分类整理当前有效和历史信息
-        
-        这个工具适用于需要了解事件全貌、追踪演变过程的场景。
-        
+        [PanoramaSearch - breadth search]
+
+        Get the panoramic view, including all relevant content and historical/expired info:
+        1. Fetch all relevant nodes
+        2. Fetch all edges (including expired/invalidated ones)
+        3. Categorize and organize current and historical information
+
+        This tool is suited to scenarios that require a full view of an event and tracking of how it evolved.
+
         Args:
-            graph_id: 图谱ID
-            query: 搜索查询（用于相关性排序）
-            include_expired: 是否包含过期内容（默认True）
-            limit: 返回结果数量限制
-            
+            graph_id: Graph ID
+            query: Search query (used for relevance ranking)
+            include_expired: Whether to include expired content (default True)
+            limit: Limit on the number of results
+
         Returns:
-            PanoramaResult: 广度搜索结果
+            PanoramaResult: Breadth-search result
         """
         logger.info(t("console.panoramaSearchStart", query=query[:50]))
-        
+
         result = PanoramaResult(query=query)
-        
-        # 获取所有节点
+
+        # Fetch all nodes
         all_nodes = self.get_all_nodes(graph_id)
         node_map = {n.uuid: n for n in all_nodes}
         result.all_nodes = all_nodes
         result.total_nodes = len(all_nodes)
-        
-        # 获取所有边（包含时间信息）
+
+        # Fetch all edges (with temporal info)
         all_edges = self.get_all_edges(graph_id, include_temporal=True)
         result.all_edges = all_edges
         result.total_edges = len(all_edges)
-        
-        # 分类事实
+
+        # Categorize facts
         active_facts = []
         historical_facts = []
-        
+
         for edge in all_edges:
             if not edge.fact:
                 continue
-            
-            # 为事实添加实体名称
+
+            # Add entity names to the fact
             source_name = node_map.get(edge.source_node_uuid, NodeInfo('', '', [], '', {})).name or edge.source_node_uuid[:8]
             target_name = node_map.get(edge.target_node_uuid, NodeInfo('', '', [], '', {})).name or edge.target_node_uuid[:8]
-            
-            # 判断是否过期/失效
+
+            # Determine whether expired/invalidated
             is_historical = edge.is_expired or edge.is_invalid
-            
+
             if is_historical:
-                # 历史/过期事实，添加时间标记
-                valid_at = edge.valid_at or "未知"
-                invalid_at = edge.invalid_at or edge.expired_at or "未知"
+                # Historical / expired fact — annotate with time
+                valid_at = edge.valid_at or "Unknown"
+                invalid_at = edge.invalid_at or edge.expired_at or "Unknown"
                 fact_with_time = f"[{valid_at} - {invalid_at}] {edge.fact}"
                 historical_facts.append(fact_with_time)
             else:
-                # 当前有效事实
+                # Currently valid fact
                 active_facts.append(edge.fact)
-        
-        # 基于查询进行相关性排序
+
+        # Relevance-rank by the query
         query_lower = query.lower()
         keywords = [w.strip() for w in query_lower.replace(',', ' ').replace('，', ' ').split() if len(w.strip()) > 1]
-        
+
         def relevance_score(fact: str) -> int:
             fact_lower = fact.lower()
             score = 0
@@ -1221,19 +1222,19 @@ class ZepToolsService:
                 if kw in fact_lower:
                     score += 10
             return score
-        
-        # 排序并限制数量
+
+        # Sort and cap the count
         active_facts.sort(key=relevance_score, reverse=True)
         historical_facts.sort(key=relevance_score, reverse=True)
-        
+
         result.active_facts = active_facts[:limit]
         result.historical_facts = historical_facts[:limit] if include_expired else []
         result.active_count = len(active_facts)
         result.historical_count = len(historical_facts)
-        
+
         logger.info(t("console.panoramaSearchComplete", active=result.active_count, historical=result.historical_count))
         return result
-    
+
     def quick_search(
         self,
         graph_id: str,
@@ -1241,34 +1242,34 @@ class ZepToolsService:
         limit: int = 10
     ) -> SearchResult:
         """
-        【QuickSearch - 简单搜索】
-        
-        快速、轻量级的检索工具：
-        1. 直接调用Zep语义搜索
-        2. 返回最相关的结果
-        3. 适用于简单、直接的检索需求
-        
+        [QuickSearch - simple search]
+
+        A fast, lightweight retrieval tool:
+        1. Calls Zep semantic search directly
+        2. Returns the most relevant results
+        3. Suitable for simple, direct retrieval needs
+
         Args:
-            graph_id: 图谱ID
-            query: 搜索查询
-            limit: 返回结果数量
-            
+            graph_id: Graph ID
+            query: Search query
+            limit: Number of results to return
+
         Returns:
-            SearchResult: 搜索结果
+            SearchResult: Search result
         """
         logger.info(t("console.quickSearchStart", query=query[:50]))
-        
-        # 直接调用现有的search_graph方法
+
+        # Call the existing search_graph method directly
         result = self.search_graph(
             graph_id=graph_id,
             query=query,
             limit=limit,
             scope="edges"
         )
-        
+
         logger.info(t("console.quickSearchComplete", count=result.total_count))
         return result
-    
+
     def interview_agents(
         self,
         simulation_id: str,
@@ -1278,65 +1279,65 @@ class ZepToolsService:
         custom_questions: List[str] = None
     ) -> InterviewResult:
         """
-        【InterviewAgents - 深度采访】
-        
-        调用真实的OASIS采访API，采访模拟中正在运行的Agent：
-        1. 自动读取人设文件，了解所有模拟Agent
-        2. 使用LLM分析采访需求，智能选择最相关的Agent
-        3. 使用LLM生成采访问题
-        4. 调用 /api/simulation/interview/batch 接口进行真实采访（双平台同时采访）
-        5. 整合所有采访结果，生成采访报告
-        
-        【重要】此功能需要模拟环境处于运行状态（OASIS环境未关闭）
-        
-        【使用场景】
-        - 需要从不同角色视角了解事件看法
-        - 需要收集多方意见和观点
-        - 需要获取模拟Agent的真实回答（非LLM模拟）
-        
+        [InterviewAgents - in-depth interview]
+
+        Calls the real OASIS interview API to interview the agents currently running in the simulation:
+        1. Automatically reads the persona files to learn about all simulation agents
+        2. Uses the LLM to analyze the interview requirement and intelligently select the most relevant agents
+        3. Uses the LLM to generate the interview questions
+        4. Calls the /api/simulation/interview/batch endpoint for the real interview (interviewing on both platforms simultaneously)
+        5. Aggregates all interview results and produces an interview report
+
+        [Important] This feature requires the simulation to be running (the OASIS environment must not be shut down).
+
+        [Use cases]
+        - Need to understand opinions about an event from different role perspectives
+        - Need to gather opinions and views from many sides
+        - Need to obtain real answers from simulation agents (not LLM-generated)
+
         Args:
-            simulation_id: 模拟ID（用于定位人设文件和调用采访API）
-            interview_requirement: 采访需求描述（非结构化，如"了解学生对事件的看法"）
-            simulation_requirement: 模拟需求背景（可选）
-            max_agents: 最多采访的Agent数量
-            custom_questions: 自定义采访问题（可选，若不提供则自动生成）
-            
+            simulation_id: Simulation ID (used to locate persona files and call the interview API)
+            interview_requirement: Interview requirement description (unstructured, e.g., "understand students' views on the event")
+            simulation_requirement: Simulation-requirement context (optional)
+            max_agents: Maximum number of agents to interview
+            custom_questions: Custom interview questions (optional; auto-generated if not provided)
+
         Returns:
-            InterviewResult: 采访结果
+            InterviewResult: Interview result
         """
         from .simulation_runner import SimulationRunner
-        
+
         logger.info(t("console.interviewAgentsStart", requirement=interview_requirement[:50]))
-        
+
         result = InterviewResult(
             interview_topic=interview_requirement,
             interview_questions=custom_questions or []
         )
-        
-        # Step 1: 读取人设文件
+
+        # Step 1: Load persona files
         profiles = self._load_agent_profiles(simulation_id)
-        
+
         if not profiles:
             logger.warning(t("console.profilesNotFound", simId=simulation_id))
-            result.summary = "未找到可采访的Agent人设文件"
+            result.summary = "No interviewable agent persona files were found"
             return result
-        
+
         result.total_agents = len(profiles)
         logger.info(t("console.loadedProfiles", count=len(profiles)))
-        
-        # Step 2: 使用LLM选择要采访的Agent（返回agent_id列表）
+
+        # Step 2: Use the LLM to choose which agents to interview (returns an agent_id list)
         selected_agents, selected_indices, selection_reasoning = self._select_agents_for_interview(
             profiles=profiles,
             interview_requirement=interview_requirement,
             simulation_requirement=simulation_requirement,
             max_agents=max_agents
         )
-        
+
         result.selected_agents = selected_agents
         result.selection_reasoning = selection_reasoning
         logger.info(t("console.selectedAgentsForInterview", count=len(selected_agents), indices=selected_indices))
-        
-        # Step 3: 生成采访问题（如果没有提供）
+
+        # Step 3: Generate interview questions (if not provided)
         if not result.interview_questions:
             result.interview_questions = self._generate_interview_questions(
                 interview_requirement=interview_requirement,
@@ -1344,146 +1345,146 @@ class ZepToolsService:
                 selected_agents=selected_agents
             )
             logger.info(t("console.generatedInterviewQuestions", count=len(result.interview_questions)))
-        
-        # 将问题合并为一个采访prompt
+
+        # Combine the questions into a single interview prompt
         combined_prompt = "\n".join([f"{i+1}. {q}" for i, q in enumerate(result.interview_questions)])
-        
-        # 添加优化前缀，约束Agent回复格式
+
+        # Add an optimization prefix to constrain the agent's reply format
         INTERVIEW_PROMPT_PREFIX = (
-            "你正在接受一次采访。请结合你的人设、所有的过往记忆与行动，"
-            "以纯文本方式直接回答以下问题。\n"
-            "回复要求：\n"
-            "1. 直接用自然语言回答，不要调用任何工具\n"
-            "2. 不要返回JSON格式或工具调用格式\n"
-            "3. 不要使用Markdown标题（如#、##、###）\n"
-            "4. 按问题编号逐一回答，每个回答以「问题X：」开头（X为问题编号）\n"
-            "5. 每个问题的回答之间用空行分隔\n"
-            "6. 回答要有实质内容，每个问题至少回答2-3句话\n\n"
+            "You are being interviewed. Drawing on your persona, all of your past memory, and your actions, "
+            "answer the following questions directly in plain text.\n"
+            "Reply requirements:\n"
+            "1. Answer directly in natural language; do not call any tools\n"
+            "2. Do not return JSON or tool-call format\n"
+            "3. Do not use Markdown headings (such as #, ##, ###)\n"
+            "4. Answer each question in order, prefixing each answer with \"Question X:\" (where X is the question number)\n"
+            "5. Separate answers to different questions with a blank line\n"
+            "6. Each answer must contain substantive content — at least 2-3 sentences\n\n"
         )
         optimized_prompt = f"{INTERVIEW_PROMPT_PREFIX}{combined_prompt}"
-        
-        # Step 4: 调用真实的采访API（不指定platform，默认双平台同时采访）
+
+        # Step 4: Call the real interview API (no platform specified — defaults to interviewing both platforms)
         try:
-            # 构建批量采访列表（不指定platform，双平台采访）
+            # Build the batch interview request list (no platform specified — both-platform interview)
             interviews_request = []
             for agent_idx in selected_indices:
                 interviews_request.append({
                     "agent_id": agent_idx,
-                    "prompt": optimized_prompt  # 使用优化后的prompt
-                    # 不指定platform，API会在twitter和reddit两个平台都采访
+                    "prompt": optimized_prompt  # use the optimized prompt
+                    # No platform specified — the API will interview on both twitter and reddit
                 })
-            
+
             logger.info(t("console.callingBatchInterviewApi", count=len(interviews_request)))
-            
-            # 调用 SimulationRunner 的批量采访方法（不传platform，双平台采访）
+
+            # Call SimulationRunner's batch interview method (no platform — interview both platforms)
             api_result = SimulationRunner.interview_agents_batch(
                 simulation_id=simulation_id,
                 interviews=interviews_request,
-                platform=None,  # 不指定platform，双平台采访
-                timeout=180.0   # 双平台需要更长超时
+                platform=None,  # No platform specified — both platforms
+                timeout=180.0   # Both platforms need a longer timeout
             )
-            
+
             logger.info(t("console.interviewApiReturned", count=api_result.get('interviews_count', 0), success=api_result.get('success')))
-            
-            # 检查API调用是否成功
+
+            # Check whether the API call succeeded
             if not api_result.get("success", False):
-                error_msg = api_result.get("error", "未知错误")
+                error_msg = api_result.get("error", "Unknown error")
                 logger.warning(t("console.interviewApiReturnedFailure", error=error_msg))
-                result.summary = f"采访API调用失败：{error_msg}。请检查OASIS模拟环境状态。"
+                result.summary = f"Interview API call failed: {error_msg}. Please check the OASIS simulation environment status."
                 return result
-            
-            # Step 5: 解析API返回结果，构建AgentInterview对象
-            # 双平台模式返回格式: {"twitter_0": {...}, "reddit_0": {...}, "twitter_1": {...}, ...}
+
+            # Step 5: Parse the API response and build AgentInterview objects
+            # Both-platform-mode response format: {"twitter_0": {...}, "reddit_0": {...}, "twitter_1": {...}, ...}
             api_data = api_result.get("result", {})
             results_dict = api_data.get("results", {}) if isinstance(api_data, dict) else {}
-            
+
             for i, agent_idx in enumerate(selected_indices):
                 agent = selected_agents[i]
                 agent_name = agent.get("realname", agent.get("username", f"Agent_{agent_idx}"))
-                agent_role = agent.get("profession", "未知")
+                agent_role = agent.get("profession", "Unknown")
                 agent_bio = agent.get("bio", "")
-                
-                # 获取该Agent在两个平台的采访结果
+
+                # Get the interview results for this agent on both platforms
                 twitter_result = results_dict.get(f"twitter_{agent_idx}", {})
                 reddit_result = results_dict.get(f"reddit_{agent_idx}", {})
-                
+
                 twitter_response = twitter_result.get("response", "")
                 reddit_response = reddit_result.get("response", "")
 
-                # 清理可能的工具调用 JSON 包裹
+                # Strip any tool-call JSON wrapping
                 twitter_response = self._clean_tool_call_response(twitter_response)
                 reddit_response = self._clean_tool_call_response(reddit_response)
 
-                # 始终输出双平台标记
-                twitter_text = twitter_response if twitter_response else "（该平台未获得回复）"
-                reddit_text = reddit_response if reddit_response else "（该平台未获得回复）"
-                response_text = f"【Twitter平台回答】\n{twitter_text}\n\n【Reddit平台回答】\n{reddit_text}"
+                # Always render both-platform markers
+                twitter_text = twitter_response if twitter_response else "(no reply on this platform)"
+                reddit_text = reddit_response if reddit_response else "(no reply on this platform)"
+                response_text = f"[Twitter platform answer]\n{twitter_text}\n\n[Reddit platform answer]\n{reddit_text}"
 
-                # 提取关键引言（从两个平台的回答中）
+                # Extract key quotes (from the answers on both platforms)
                 import re
                 combined_responses = f"{twitter_response} {reddit_response}"
 
-                # 清理响应文本：去掉标记、编号、Markdown 等干扰
+                # Clean the response text: strip markers, numbering, Markdown, and other noise
                 clean_text = re.sub(r'#{1,6}\s+', '', combined_responses)
                 clean_text = re.sub(r'\{[^}]*tool_name[^}]*\}', '', clean_text)
                 clean_text = re.sub(r'[*_`|>~\-]{2,}', '', clean_text)
-                clean_text = re.sub(r'问题\d+[：:]\s*', '', clean_text)
+                clean_text = re.sub(r'(?:Question|问题)\d+[：:]\s*', '', clean_text)
                 clean_text = re.sub(r'【[^】]+】', '', clean_text)
 
-                # 策略1（主）: 提取完整的有实质内容的句子
-                sentences = re.split(r'[。！？]', clean_text)
+                # Strategy 1 (primary): extract complete sentences with substantive content
+                sentences = re.split(r'[。！？.!?]', clean_text)
                 meaningful = [
                     s.strip() for s in sentences
                     if 20 <= len(s.strip()) <= 150
                     and not re.match(r'^[\s\W，,；;：:、]+', s.strip())
-                    and not s.strip().startswith(('{', '问题'))
+                    and not s.strip().startswith(('{', 'Question', '问题'))
                 ]
                 meaningful.sort(key=len, reverse=True)
-                key_quotes = [s + "。" for s in meaningful[:3]]
+                key_quotes = [s + "." for s in meaningful[:3]]
 
-                # 策略2（补充）: 正确配对的中文引号「」内长文本
+                # Strategy 2 (supplementary): properly paired text inside Chinese quotation marks
                 if not key_quotes:
-                    paired = re.findall(r'\u201c([^\u201c\u201d]{15,100})\u201d', clean_text)
-                    paired += re.findall(r'\u300c([^\u300c\u300d]{15,100})\u300d', clean_text)
+                    paired = re.findall(r'“([^“”]{15,100})”', clean_text)
+                    paired += re.findall(r'「([^「」]{15,100})」', clean_text)
                     key_quotes = [q for q in paired if not re.match(r'^[，,；;：:、]', q)][:3]
-                
+
                 interview = AgentInterview(
                     agent_name=agent_name,
                     agent_role=agent_role,
-                    agent_bio=agent_bio[:1000],  # 扩大bio长度限制
+                    agent_bio=agent_bio[:1000],  # widen the bio length cap
                     question=combined_prompt,
                     response=response_text,
                     key_quotes=key_quotes[:5]
                 )
                 result.interviews.append(interview)
-            
+
             result.interviewed_count = len(result.interviews)
-            
+
         except ValueError as e:
-            # 模拟环境未运行
+            # Simulation environment not running
             logger.warning(t("console.interviewApiCallFailed", error=e))
-            result.summary = f"采访失败：{str(e)}。模拟环境可能已关闭，请确保OASIS环境正在运行。"
+            result.summary = f"Interview failed: {str(e)}. The simulation environment may have been shut down; please make sure the OASIS environment is running."
             return result
         except Exception as e:
             logger.error(t("console.interviewApiCallException", error=e))
             import traceback
             logger.error(traceback.format_exc())
-            result.summary = f"采访过程发生错误：{str(e)}"
+            result.summary = f"An error occurred during the interview: {str(e)}"
             return result
-        
-        # Step 6: 生成采访摘要
+
+        # Step 6: Generate the interview summary
         if result.interviews:
             result.summary = self._generate_interview_summary(
                 interviews=result.interviews,
                 interview_requirement=interview_requirement
             )
-        
+
         logger.info(t("console.interviewAgentsComplete", count=result.interviewed_count))
         return result
-    
+
     @staticmethod
     def _clean_tool_call_response(response: str) -> str:
-        """清理 Agent 回复中的 JSON 工具调用包裹，提取实际内容"""
+        """Strip JSON tool-call wrapping from an agent reply and extract the actual content"""
         if not response or not response.strip().startswith('{'):
             return response
         text = response.strip()
@@ -1503,19 +1504,19 @@ class ZepToolsService:
         return response
 
     def _load_agent_profiles(self, simulation_id: str) -> List[Dict[str, Any]]:
-        """加载模拟的Agent人设文件"""
+        """Load the simulation's agent persona files"""
         import os
         import csv
-        
-        # 构建人设文件路径
+
+        # Build the persona-file path
         sim_dir = os.path.join(
-            os.path.dirname(__file__), 
+            os.path.dirname(__file__),
             f'../../uploads/simulations/{simulation_id}'
         )
-        
+
         profiles = []
-        
-        # 优先尝试读取Reddit JSON格式
+
+        # Prefer the Reddit JSON format
         reddit_profile_path = os.path.join(sim_dir, "reddit_profiles.json")
         if os.path.exists(reddit_profile_path):
             try:
@@ -1525,29 +1526,29 @@ class ZepToolsService:
                 return profiles
             except Exception as e:
                 logger.warning(t("console.readRedditProfilesFailed", error=e))
-        
-        # 尝试读取Twitter CSV格式
+
+        # Try the Twitter CSV format
         twitter_profile_path = os.path.join(sim_dir, "twitter_profiles.csv")
         if os.path.exists(twitter_profile_path):
             try:
                 with open(twitter_profile_path, 'r', encoding='utf-8') as f:
                     reader = csv.DictReader(f)
                     for row in reader:
-                        # CSV格式转换为统一格式
+                        # Convert CSV format into the unified format
                         profiles.append({
                             "realname": row.get("name", ""),
                             "username": row.get("username", ""),
                             "bio": row.get("description", ""),
                             "persona": row.get("user_char", ""),
-                            "profession": "未知"
+                            "profession": "Unknown"
                         })
                 logger.info(t("console.loadedTwitterProfiles", count=len(profiles)))
                 return profiles
             except Exception as e:
                 logger.warning(t("console.readTwitterProfilesFailed", error=e))
-        
+
         return profiles
-    
+
     def _select_agents_for_interview(
         self,
         profiles: List[Dict[str, Any]],
@@ -1556,51 +1557,51 @@ class ZepToolsService:
         max_agents: int
     ) -> tuple:
         """
-        使用LLM选择要采访的Agent
-        
+        Use the LLM to choose which agents to interview
+
         Returns:
             tuple: (selected_agents, selected_indices, reasoning)
-                - selected_agents: 选中Agent的完整信息列表
-                - selected_indices: 选中Agent的索引列表（用于API调用）
-                - reasoning: 选择理由
+                - selected_agents: full info list for the chosen agents
+                - selected_indices: index list of the chosen agents (used for the API call)
+                - reasoning: rationale for the selection
         """
-        
-        # 构建Agent摘要列表
+
+        # Build the agent summary list
         agent_summaries = []
         for i, profile in enumerate(profiles):
             summary = {
                 "index": i,
                 "name": profile.get("realname", profile.get("username", f"Agent_{i}")),
-                "profession": profile.get("profession", "未知"),
+                "profession": profile.get("profession", "Unknown"),
                 "bio": profile.get("bio", "")[:200],
                 "interested_topics": profile.get("interested_topics", [])
             }
             agent_summaries.append(summary)
-        
-        system_prompt = """你是一个专业的采访策划专家。你的任务是根据采访需求，从模拟Agent列表中选择最适合采访的对象。
 
-选择标准：
-1. Agent的身份/职业与采访主题相关
-2. Agent可能持有独特或有价值的观点
-3. 选择多样化的视角（如：支持方、反对方、中立方、专业人士等）
-4. 优先选择与事件直接相关的角色
+        system_prompt = """You are a professional interview-planning expert. Your task is to choose the most suitable interviewees from the simulation agent list based on the interview requirement.
 
-返回JSON格式：
+Selection criteria:
+1. The agent's identity/profession is relevant to the interview topic
+2. The agent likely holds a unique or valuable point of view
+3. Choose a diverse range of perspectives (e.g., supporters, opponents, neutrals, professionals)
+4. Prefer roles directly involved in the event
+
+Return JSON:
 {
-    "selected_indices": [选中Agent的索引列表],
-    "reasoning": "选择理由说明"
+    "selected_indices": [list of indices of chosen agents],
+    "reasoning": "explanation of the selection"
 }"""
 
-        user_prompt = f"""采访需求：
+        user_prompt = f"""Interview requirement:
 {interview_requirement}
 
-模拟背景：
-{simulation_requirement if simulation_requirement else "未提供"}
+Simulation context:
+{simulation_requirement if simulation_requirement else "Not provided"}
 
-可选择的Agent列表（共{len(agent_summaries)}个）：
+Available agents ({len(agent_summaries)} total):
 {json.dumps(agent_summaries, ensure_ascii=False, indent=2)}
 
-请选择最多{max_agents}个最适合采访的Agent，并说明选择理由。"""
+Choose at most {max_agents} agents most suitable for the interview, and explain the reasoning."""
 
         try:
             response = self.llm.chat_json(
@@ -1610,56 +1611,56 @@ class ZepToolsService:
                 ],
                 temperature=0.3
             )
-            
+
             selected_indices = response.get("selected_indices", [])[:max_agents]
-            reasoning = response.get("reasoning", "基于相关性自动选择")
-            
-            # 获取选中的Agent完整信息
+            reasoning = response.get("reasoning", "Auto-selected based on relevance")
+
+            # Get the full info for the selected agents
             selected_agents = []
             valid_indices = []
             for idx in selected_indices:
                 if 0 <= idx < len(profiles):
                     selected_agents.append(profiles[idx])
                     valid_indices.append(idx)
-            
+
             return selected_agents, valid_indices, reasoning
-            
+
         except Exception as e:
             logger.warning(t("console.llmSelectAgentFailed", error=e))
-            # 降级：选择前N个
+            # Fallback: pick the first N
             selected = profiles[:max_agents]
             indices = list(range(min(max_agents, len(profiles))))
-            return selected, indices, "使用默认选择策略"
-    
+            return selected, indices, "Using default selection strategy"
+
     def _generate_interview_questions(
         self,
         interview_requirement: str,
         simulation_requirement: str,
         selected_agents: List[Dict[str, Any]]
     ) -> List[str]:
-        """使用LLM生成采访问题"""
-        
-        agent_roles = [a.get("profession", "未知") for a in selected_agents]
-        
-        system_prompt = """你是一个专业的记者/采访者。根据采访需求，生成3-5个深度采访问题。
+        """Use the LLM to generate interview questions"""
 
-问题要求：
-1. 开放性问题，鼓励详细回答
-2. 针对不同角色可能有不同答案
-3. 涵盖事实、观点、感受等多个维度
-4. 语言自然，像真实采访一样
-5. 每个问题控制在50字以内，简洁明了
-6. 直接提问，不要包含背景说明或前缀
+        agent_roles = [a.get("profession", "Unknown") for a in selected_agents]
 
-返回JSON格式：{"questions": ["问题1", "问题2", ...]}"""
+        system_prompt = """You are a professional journalist/interviewer. Based on the interview requirement, generate 3-5 in-depth interview questions.
 
-        user_prompt = f"""采访需求：{interview_requirement}
+Question requirements:
+1. Open-ended questions that encourage detailed answers
+2. Different roles may have different answers
+3. Cover multiple dimensions: facts, opinions, feelings, etc.
+4. Natural language, like a real interview
+5. Each question must be no more than ~50 words — concise and clear
+6. Ask the question directly; do not include background notes or prefixes
 
-模拟背景：{simulation_requirement if simulation_requirement else "未提供"}
+Return JSON: {"questions": ["question 1", "question 2", ...]}"""
 
-采访对象角色：{', '.join(agent_roles)}
+        user_prompt = f"""Interview requirement: {interview_requirement}
 
-请生成3-5个采访问题。"""
+Simulation context: {simulation_requirement if simulation_requirement else "Not provided"}
+
+Roles of interviewees: {', '.join(agent_roles)}
+
+Please generate 3-5 interview questions."""
 
         try:
             response = self.llm.chat_json(
@@ -1669,55 +1670,55 @@ class ZepToolsService:
                 ],
                 temperature=0.5
             )
-            
-            return response.get("questions", [f"关于{interview_requirement}，您有什么看法？"])
-            
+
+            return response.get("questions", [f"What are your views on {interview_requirement}?"])
+
         except Exception as e:
             logger.warning(t("console.generateInterviewQuestionsFailed", error=e))
             return [
-                f"关于{interview_requirement}，您的观点是什么？",
-                "这件事对您或您所代表的群体有什么影响？",
-                "您认为应该如何解决或改进这个问题？"
+                f"What is your view on {interview_requirement}?",
+                "What impact does this have on you or the group you represent?",
+                "How do you think this issue should be solved or improved?"
             ]
-    
+
     def _generate_interview_summary(
         self,
         interviews: List[AgentInterview],
         interview_requirement: str
     ) -> str:
-        """生成采访摘要"""
-        
+        """Generate the interview summary"""
+
         if not interviews:
-            return "未完成任何采访"
-        
-        # 收集所有采访内容
+            return "No interviews completed"
+
+        # Collect all interview content
         interview_texts = []
         for interview in interviews:
-            interview_texts.append(f"【{interview.agent_name}（{interview.agent_role}）】\n{interview.response[:500]}")
-        
-        quote_instruction = "引用受访者原话时使用中文引号「」" if get_locale() == 'zh' else 'Use quotation marks "" when quoting interviewees'
-        system_prompt = f"""你是一个专业的新闻编辑。请根据多位受访者的回答，生成一份采访摘要。
+            interview_texts.append(f"[{interview.agent_name} ({interview.agent_role})]\n{interview.response[:500]}")
 
-摘要要求：
-1. 提炼各方主要观点
-2. 指出观点的共识和分歧
-3. 突出有价值的引言
-4. 客观中立，不偏袒任何一方
-5. 控制在1000字内
+        quote_instruction = "Use Chinese quotation marks 「」 when quoting an interviewee directly" if get_locale() == 'zh' else 'Use quotation marks "" when quoting interviewees'
+        system_prompt = f"""You are a professional news editor. Based on the answers from multiple interviewees, produce an interview summary.
 
-格式约束（必须遵守）：
-- 使用纯文本段落，用空行分隔不同部分
-- 不要使用Markdown标题（如#、##、###）
-- 不要使用分割线（如---、***）
+Summary requirements:
+1. Distill the main points from each side
+2. Identify points of consensus and disagreement
+3. Highlight valuable quotations
+4. Be objective and neutral; do not favor any side
+5. Keep it under 1,000 words
+
+Format constraints (must follow):
+- Use plain-text paragraphs, separating sections with blank lines
+- Do not use Markdown headings (such as #, ##, ###)
+- Do not use horizontal rules (such as ---, ***)
 - {quote_instruction}
-- 可以使用**加粗**标记关键词，但不要使用其他Markdown语法"""
+- You may use **bold** to emphasize keywords, but do not use any other Markdown syntax"""
 
-        user_prompt = f"""采访主题：{interview_requirement}
+        user_prompt = f"""Interview topic: {interview_requirement}
 
-采访内容：
+Interview contents:
 {"".join(interview_texts)}
 
-请生成采访摘要。"""
+Please produce the interview summary."""
 
         try:
             summary = self.llm.chat(
@@ -1729,8 +1730,8 @@ class ZepToolsService:
                 max_tokens=800
             )
             return summary
-            
+
         except Exception as e:
             logger.warning(t("console.generateInterviewSummaryFailed", error=e))
-            # 降级：简单拼接
-            return f"共采访了{len(interviews)}位受访者，包括：" + "、".join([i.agent_name for i in interviews])
+            # Fallback: simple concatenation
+            return f"Interviewed {len(interviews)} respondents in total, including: " + ", ".join([i.agent_name for i in interviews])

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1,5 +1,5 @@
 """
-工具模块
+Utilities module
 """
 
 from .file_parser import FileParser
@@ -7,4 +7,3 @@ from .llm_client import LLMClient
 from .locale import t, get_locale, set_locale, get_language_instruction
 
 __all__ = ['FileParser', 'LLMClient', 't', 'get_locale', 'set_locale', 'get_language_instruction']
-

--- a/backend/app/utils/file_parser.py
+++ b/backend/app/utils/file_parser.py
@@ -1,6 +1,6 @@
 """
-文件解析工具
-支持PDF、Markdown、TXT文件的文本提取
+File parsing utilities
+Supports text extraction from PDF, Markdown, and TXT files.
 """
 
 import os
@@ -10,29 +10,29 @@ from typing import List, Optional
 
 def _read_text_with_fallback(file_path: str) -> str:
     """
-    读取文本文件，UTF-8失败时自动探测编码。
-    
-    采用多级回退策略：
-    1. 首先尝试 UTF-8 解码
-    2. 使用 charset_normalizer 检测编码
-    3. 回退到 chardet 检测编码
-    4. 最终使用 UTF-8 + errors='replace' 兜底
-    
+    Read a text file; if UTF-8 decoding fails, automatically detect the encoding.
+
+    Uses a multi-level fallback strategy:
+    1. First try decoding as UTF-8.
+    2. Detect the encoding using charset_normalizer.
+    3. Fall back to chardet for encoding detection.
+    4. As a final fallback, decode as UTF-8 with errors='replace'.
+
     Args:
-        file_path: 文件路径
-        
+        file_path: file path
+
     Returns:
-        解码后的文本内容
+        Decoded text content
     """
     data = Path(file_path).read_bytes()
-    
-    # 首先尝试 UTF-8
+
+    # First try UTF-8
     try:
         return data.decode('utf-8')
     except UnicodeDecodeError:
         pass
-    
-    # 尝试使用 charset_normalizer 检测编码
+
+    # Try detecting the encoding with charset_normalizer
     encoding = None
     try:
         from charset_normalizer import from_bytes
@@ -41,8 +41,8 @@ def _read_text_with_fallback(file_path: str) -> str:
             encoding = best.encoding
     except Exception:
         pass
-    
-    # 回退到 chardet
+
+    # Fall back to chardet
     if not encoding:
         try:
             import chardet
@@ -50,140 +50,140 @@ def _read_text_with_fallback(file_path: str) -> str:
             encoding = result.get('encoding') if result else None
         except Exception:
             pass
-    
-    # 最终兜底：使用 UTF-8 + replace
+
+    # Final fallback: UTF-8 + replace
     if not encoding:
         encoding = 'utf-8'
-    
+
     return data.decode(encoding, errors='replace')
 
 
 class FileParser:
-    """文件解析器"""
-    
+    """File parser"""
+
     SUPPORTED_EXTENSIONS = {'.pdf', '.md', '.markdown', '.txt'}
-    
+
     @classmethod
     def extract_text(cls, file_path: str) -> str:
         """
-        从文件中提取文本
-        
+        Extract text from a file.
+
         Args:
-            file_path: 文件路径
-            
+            file_path: file path
+
         Returns:
-            提取的文本内容
+            Extracted text content
         """
         path = Path(file_path)
-        
+
         if not path.exists():
-            raise FileNotFoundError(f"文件不存在: {file_path}")
-        
+            raise FileNotFoundError(f"File does not exist: {file_path}")
+
         suffix = path.suffix.lower()
-        
+
         if suffix not in cls.SUPPORTED_EXTENSIONS:
-            raise ValueError(f"不支持的文件格式: {suffix}")
-        
+            raise ValueError(f"Unsupported file format: {suffix}")
+
         if suffix == '.pdf':
             return cls._extract_from_pdf(file_path)
         elif suffix in {'.md', '.markdown'}:
             return cls._extract_from_md(file_path)
         elif suffix == '.txt':
             return cls._extract_from_txt(file_path)
-        
-        raise ValueError(f"无法处理的文件格式: {suffix}")
-    
+
+        raise ValueError(f"Unhandled file format: {suffix}")
+
     @staticmethod
     def _extract_from_pdf(file_path: str) -> str:
-        """从PDF提取文本"""
+        """Extract text from a PDF"""
         try:
             import fitz  # PyMuPDF
         except ImportError:
-            raise ImportError("需要安装PyMuPDF: pip install PyMuPDF")
-        
+            raise ImportError("PyMuPDF must be installed: pip install PyMuPDF")
+
         text_parts = []
         with fitz.open(file_path) as doc:
             for page in doc:
                 text = page.get_text()
                 if text.strip():
                     text_parts.append(text)
-        
+
         return "\n\n".join(text_parts)
-    
+
     @staticmethod
     def _extract_from_md(file_path: str) -> str:
-        """从Markdown提取文本，支持自动编码检测"""
+        """Extract text from Markdown, with automatic encoding detection"""
         return _read_text_with_fallback(file_path)
-    
+
     @staticmethod
     def _extract_from_txt(file_path: str) -> str:
-        """从TXT提取文本，支持自动编码检测"""
+        """Extract text from TXT, with automatic encoding detection"""
         return _read_text_with_fallback(file_path)
-    
+
     @classmethod
     def extract_from_multiple(cls, file_paths: List[str]) -> str:
         """
-        从多个文件提取文本并合并
-        
+        Extract text from multiple files and merge.
+
         Args:
-            file_paths: 文件路径列表
-            
+            file_paths: list of file paths
+
         Returns:
-            合并后的文本
+            Combined text
         """
         all_texts = []
-        
+
         for i, file_path in enumerate(file_paths, 1):
             try:
                 text = cls.extract_text(file_path)
                 filename = Path(file_path).name
-                all_texts.append(f"=== 文档 {i}: {filename} ===\n{text}")
+                all_texts.append(f"=== Document {i}: {filename} ===\n{text}")
             except Exception as e:
-                all_texts.append(f"=== 文档 {i}: {file_path} (提取失败: {str(e)}) ===")
-        
+                all_texts.append(f"=== Document {i}: {file_path} (extraction failed: {str(e)}) ===")
+
         return "\n\n".join(all_texts)
 
 
 def split_text_into_chunks(
-    text: str, 
-    chunk_size: int = 500, 
+    text: str,
+    chunk_size: int = 500,
     overlap: int = 50
 ) -> List[str]:
     """
-    将文本分割成小块
-    
+    Split text into smaller chunks.
+
     Args:
-        text: 原始文本
-        chunk_size: 每块的字符数
-        overlap: 重叠字符数
-        
+        text: original text
+        chunk_size: number of characters per chunk
+        overlap: number of overlapping characters
+
     Returns:
-        文本块列表
+        List of text chunks
     """
     if len(text) <= chunk_size:
         return [text] if text.strip() else []
-    
+
     chunks = []
     start = 0
-    
+
     while start < len(text):
         end = start + chunk_size
-        
-        # 尝试在句子边界处分割
+
+        # Try to split at a sentence boundary
         if end < len(text):
-            # 查找最近的句子结束符
+            # Look for the nearest sentence-ending separator (CJK punctuation kept intentionally so
+            # that Chinese-language input still splits at sentence boundaries; do not translate these).
             for sep in ['。', '！', '？', '.\n', '!\n', '?\n', '\n\n', '. ', '! ', '? ']:
                 last_sep = text[start:end].rfind(sep)
                 if last_sep != -1 and last_sep > chunk_size * 0.3:
                     end = start + last_sep + len(sep)
                     break
-        
+
         chunk = text[start:end].strip()
         if chunk:
             chunks.append(chunk)
-        
-        # 下一个块从重叠位置开始
-        start = end - overlap if end < len(text) else len(text)
-    
-    return chunks
 
+        # Next chunk starts at the overlap position
+        start = end - overlap if end < len(text) else len(text)
+
+    return chunks

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -1,6 +1,6 @@
 """
-LLM客户端封装
-统一使用OpenAI格式调用
+LLM client wrapper
+Uses the OpenAI format uniformly for invocations.
 """
 
 import json
@@ -12,8 +12,8 @@ from ..config import Config
 
 
 class LLMClient:
-    """LLM客户端"""
-    
+    """LLM client"""
+
     def __init__(
         self,
         api_key: Optional[str] = None,
@@ -23,15 +23,15 @@ class LLMClient:
         self.api_key = api_key or Config.LLM_API_KEY
         self.base_url = base_url or Config.LLM_BASE_URL
         self.model = model or Config.LLM_MODEL_NAME
-        
+
         if not self.api_key:
-            raise ValueError("LLM_API_KEY 未配置")
-        
+            raise ValueError("LLM_API_KEY is not configured")
+
         self.client = OpenAI(
             api_key=self.api_key,
             base_url=self.base_url
         )
-    
+
     def chat(
         self,
         messages: List[Dict[str, str]],
@@ -40,16 +40,16 @@ class LLMClient:
         response_format: Optional[Dict] = None
     ) -> str:
         """
-        发送聊天请求
-        
+        Send a chat request.
+
         Args:
-            messages: 消息列表
-            temperature: 温度参数
-            max_tokens: 最大token数
-            response_format: 响应格式（如JSON模式）
-            
+            messages: list of messages
+            temperature: temperature parameter
+            max_tokens: maximum number of tokens
+            response_format: response format (e.g. JSON mode)
+
         Returns:
-            模型响应文本
+            Model response text
         """
         kwargs = {
             "model": self.model,
@@ -57,16 +57,16 @@ class LLMClient:
             "temperature": temperature,
             "max_tokens": max_tokens,
         }
-        
+
         if response_format:
             kwargs["response_format"] = response_format
-        
+
         response = self.client.chat.completions.create(**kwargs)
         content = response.choices[0].message.content
-        # 部分模型（如MiniMax M2.5）会在content中包含<think>思考内容，需要移除
+        # Some models (e.g. MiniMax M2.5) include <think> reasoning content in the response; strip it.
         content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
         return content
-    
+
     def chat_json(
         self,
         messages: List[Dict[str, str]],
@@ -74,15 +74,15 @@ class LLMClient:
         max_tokens: int = 4096
     ) -> Dict[str, Any]:
         """
-        发送聊天请求并返回JSON
-        
+        Send a chat request and return JSON.
+
         Args:
-            messages: 消息列表
-            temperature: 温度参数
-            max_tokens: 最大token数
-            
+            messages: list of messages
+            temperature: temperature parameter
+            max_tokens: maximum number of tokens
+
         Returns:
-            解析后的JSON对象
+            Parsed JSON object
         """
         response = self.chat(
             messages=messages,
@@ -90,7 +90,7 @@ class LLMClient:
             max_tokens=max_tokens,
             response_format={"type": "json_object"}
         )
-        # 清理markdown代码块标记
+        # Strip markdown code-block markers
         cleaned_response = response.strip()
         cleaned_response = re.sub(r'^```(?:json)?\s*\n?', '', cleaned_response, flags=re.IGNORECASE)
         cleaned_response = re.sub(r'\n?```\s*$', '', cleaned_response)
@@ -99,5 +99,4 @@ class LLMClient:
         try:
             return json.loads(cleaned_response)
         except json.JSONDecodeError:
-            raise ValueError(f"LLM返回的JSON格式无效: {cleaned_response}")
-
+            raise ValueError(f"LLM returned invalid JSON format: {cleaned_response}")

--- a/backend/app/utils/locale.py
+++ b/backend/app/utils/locale.py
@@ -27,14 +27,14 @@ def set_locale(locale: str):
 
 def get_locale() -> str:
     if has_request_context():
-        raw = request.headers.get('Accept-Language', 'zh')
-        return raw if raw in _translations else 'zh'
-    return getattr(_thread_local, 'locale', 'zh')
+        raw = request.headers.get('Accept-Language', 'en')
+        return raw if raw in _translations else 'en'
+    return getattr(_thread_local, 'locale', 'en')
 
 
 def t(key: str, **kwargs) -> str:
     locale = get_locale()
-    messages = _translations.get(locale, _translations.get('zh', {}))
+    messages = _translations.get(locale, _translations.get('en', {}))
 
     value = messages
     for part in key.split('.'):
@@ -45,7 +45,7 @@ def t(key: str, **kwargs) -> str:
             break
 
     if value is None:
-        value = _translations.get('zh', {})
+        value = _translations.get('en', {})
         for part in key.split('.'):
             if isinstance(value, dict):
                 value = value.get(part)
@@ -65,5 +65,5 @@ def t(key: str, **kwargs) -> str:
 
 def get_language_instruction() -> str:
     locale = get_locale()
-    lang_config = _languages.get(locale, _languages.get('zh', {}))
+    lang_config = _languages.get(locale, _languages.get('en', {}))
     return lang_config.get('llmInstruction', '请使用中文回答。')

--- a/backend/app/utils/logger.py
+++ b/backend/app/utils/logger.py
@@ -1,6 +1,6 @@
 """
-日志配置模块
-提供统一的日志管理，同时输出到控制台和文件
+Logging configuration module
+Provides unified log management; outputs simultaneously to console and file.
 """
 
 import os
@@ -12,58 +12,58 @@ from logging.handlers import RotatingFileHandler
 
 def _ensure_utf8_stdout():
     """
-    确保 stdout/stderr 使用 UTF-8 编码
-    解决 Windows 控制台中文乱码问题
+    Ensure stdout/stderr use UTF-8 encoding.
+    Fixes non-ASCII output garbling on the Windows console.
     """
     if sys.platform == 'win32':
-        # Windows 下重新配置标准输出为 UTF-8
+        # On Windows, reconfigure standard output as UTF-8
         if hasattr(sys.stdout, 'reconfigure'):
             sys.stdout.reconfigure(encoding='utf-8', errors='replace')
         if hasattr(sys.stderr, 'reconfigure'):
             sys.stderr.reconfigure(encoding='utf-8', errors='replace')
 
 
-# 日志目录
+# Log directory
 LOG_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'logs')
 
 
 def setup_logger(name: str = 'mirofish', level: int = logging.DEBUG) -> logging.Logger:
     """
-    设置日志器
-    
+    Configure a logger.
+
     Args:
-        name: 日志器名称
-        level: 日志级别
-        
+        name: logger name
+        level: log level
+
     Returns:
-        配置好的日志器
+        Configured logger
     """
-    # 确保日志目录存在
+    # Make sure the log directory exists
     os.makedirs(LOG_DIR, exist_ok=True)
-    
-    # 创建日志器
+
+    # Create the logger
     logger = logging.getLogger(name)
     logger.setLevel(level)
-    
-    # 阻止日志向上传播到根 logger，避免重复输出
+
+    # Prevent log records from propagating to the root logger to avoid duplicate output
     logger.propagate = False
-    
-    # 如果已经有处理器，不重复添加
+
+    # If handlers are already attached, don't add them again
     if logger.handlers:
         return logger
-    
-    # 日志格式
+
+    # Log formatters
     detailed_formatter = logging.Formatter(
         '[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S'
     )
-    
+
     simple_formatter = logging.Formatter(
         '[%(asctime)s] %(levelname)s: %(message)s',
         datefmt='%H:%M:%S'
     )
-    
-    # 1. 文件处理器 - 详细日志（按日期命名，带轮转）
+
+    # 1. File handler - detailed logs (named by date, with rotation)
     log_filename = datetime.now().strftime('%Y-%m-%d') + '.log'
     file_handler = RotatingFileHandler(
         os.path.join(LOG_DIR, log_filename),
@@ -73,30 +73,30 @@ def setup_logger(name: str = 'mirofish', level: int = logging.DEBUG) -> logging.
     )
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(detailed_formatter)
-    
-    # 2. 控制台处理器 - 简洁日志（INFO及以上）
-    # 确保 Windows 下使用 UTF-8 编码，避免中文乱码
+
+    # 2. Console handler - concise logs (INFO and above)
+    # Make sure UTF-8 encoding is used on Windows to avoid garbled non-ASCII output.
     _ensure_utf8_stdout()
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(logging.INFO)
     console_handler.setFormatter(simple_formatter)
-    
-    # 添加处理器
+
+    # Attach handlers
     logger.addHandler(file_handler)
     logger.addHandler(console_handler)
-    
+
     return logger
 
 
 def get_logger(name: str = 'mirofish') -> logging.Logger:
     """
-    获取日志器（如果不存在则创建）
-    
+    Get a logger (creating it if it doesn't exist yet).
+
     Args:
-        name: 日志器名称
-        
+        name: logger name
+
     Returns:
-        日志器实例
+        Logger instance
     """
     logger = logging.getLogger(name)
     if not logger.handlers:
@@ -104,11 +104,11 @@ def get_logger(name: str = 'mirofish') -> logging.Logger:
     return logger
 
 
-# 创建默认日志器
+# Create the default logger
 logger = setup_logger()
 
 
-# 便捷方法
+# Convenience helpers
 def debug(msg, *args, **kwargs):
     logger.debug(msg, *args, **kwargs)
 
@@ -123,4 +123,3 @@ def error(msg, *args, **kwargs):
 
 def critical(msg, *args, **kwargs):
     logger.critical(msg, *args, **kwargs)
-

--- a/backend/app/utils/retry.py
+++ b/backend/app/utils/retry.py
@@ -1,6 +1,6 @@
 """
-API调用重试机制
-用于处理LLM等外部API调用的重试逻辑
+API call retry mechanism
+Used to handle retry logic for external API calls (such as LLMs).
 """
 
 import time
@@ -22,17 +22,17 @@ def retry_with_backoff(
     on_retry: Optional[Callable[[Exception, int], None]] = None
 ):
     """
-    带指数退避的重试装饰器
-    
+    Retry decorator with exponential backoff.
+
     Args:
-        max_retries: 最大重试次数
-        initial_delay: 初始延迟（秒）
-        max_delay: 最大延迟（秒）
-        backoff_factor: 退避因子
-        jitter: 是否添加随机抖动
-        exceptions: 需要重试的异常类型
-        on_retry: 重试时的回调函数 (exception, retry_count)
-    
+        max_retries: maximum number of retries
+        initial_delay: initial delay (seconds)
+        max_delay: maximum delay (seconds)
+        backoff_factor: backoff factor
+        jitter: whether to add random jitter
+        exceptions: exception types that should trigger a retry
+        on_retry: callback invoked on each retry (exception, retry_count)
+
     Usage:
         @retry_with_backoff(max_retries=3)
         def call_llm_api():
@@ -43,36 +43,36 @@ def retry_with_backoff(
         def wrapper(*args, **kwargs) -> Any:
             last_exception = None
             delay = initial_delay
-            
+
             for attempt in range(max_retries + 1):
                 try:
                     return func(*args, **kwargs)
-                    
+
                 except exceptions as e:
                     last_exception = e
-                    
+
                     if attempt == max_retries:
-                        logger.error(f"函数 {func.__name__} 在 {max_retries} 次重试后仍失败: {str(e)}")
+                        logger.error(f"Function {func.__name__} still failing after {max_retries} retries: {str(e)}")
                         raise
-                    
-                    # 计算延迟
+
+                    # Compute the delay
                     current_delay = min(delay, max_delay)
                     if jitter:
                         current_delay = current_delay * (0.5 + random.random())
-                    
+
                     logger.warning(
-                        f"函数 {func.__name__} 第 {attempt + 1} 次尝试失败: {str(e)}, "
-                        f"{current_delay:.1f}秒后重试..."
+                        f"Function {func.__name__} attempt {attempt + 1} failed: {str(e)}, "
+                        f"retrying in {current_delay:.1f}s..."
                     )
-                    
+
                     if on_retry:
                         on_retry(e, attempt + 1)
-                    
+
                     time.sleep(current_delay)
                     delay *= backoff_factor
-            
+
             raise last_exception
-        
+
         return wrapper
     return decorator
 
@@ -87,53 +87,53 @@ def retry_with_backoff_async(
     on_retry: Optional[Callable[[Exception, int], None]] = None
 ):
     """
-    异步版本的重试装饰器
+    Async version of the retry decorator.
     """
     import asyncio
-    
+
     def decorator(func: Callable) -> Callable:
         @functools.wraps(func)
         async def wrapper(*args, **kwargs) -> Any:
             last_exception = None
             delay = initial_delay
-            
+
             for attempt in range(max_retries + 1):
                 try:
                     return await func(*args, **kwargs)
-                    
+
                 except exceptions as e:
                     last_exception = e
-                    
+
                     if attempt == max_retries:
-                        logger.error(f"异步函数 {func.__name__} 在 {max_retries} 次重试后仍失败: {str(e)}")
+                        logger.error(f"Async function {func.__name__} still failing after {max_retries} retries: {str(e)}")
                         raise
-                    
+
                     current_delay = min(delay, max_delay)
                     if jitter:
                         current_delay = current_delay * (0.5 + random.random())
-                    
+
                     logger.warning(
-                        f"异步函数 {func.__name__} 第 {attempt + 1} 次尝试失败: {str(e)}, "
-                        f"{current_delay:.1f}秒后重试..."
+                        f"Async function {func.__name__} attempt {attempt + 1} failed: {str(e)}, "
+                        f"retrying in {current_delay:.1f}s..."
                     )
-                    
+
                     if on_retry:
                         on_retry(e, attempt + 1)
-                    
+
                     await asyncio.sleep(current_delay)
                     delay *= backoff_factor
-            
+
             raise last_exception
-        
+
         return wrapper
     return decorator
 
 
 class RetryableAPIClient:
     """
-    可重试的API客户端封装
+    Wrapper for an API client with retry support.
     """
-    
+
     def __init__(
         self,
         max_retries: int = 3,
@@ -145,7 +145,7 @@ class RetryableAPIClient:
         self.initial_delay = initial_delay
         self.max_delay = max_delay
         self.backoff_factor = backoff_factor
-    
+
     def call_with_retry(
         self,
         func: Callable,
@@ -154,44 +154,44 @@ class RetryableAPIClient:
         **kwargs
     ) -> Any:
         """
-        执行函数调用并在失败时重试
-        
+        Call a function and retry on failure.
+
         Args:
-            func: 要调用的函数
-            *args: 函数参数
-            exceptions: 需要重试的异常类型
-            **kwargs: 函数关键字参数
-            
+            func: function to call
+            *args: positional arguments
+            exceptions: exception types that should trigger a retry
+            **kwargs: keyword arguments
+
         Returns:
-            函数返回值
+            The function's return value
         """
         last_exception = None
         delay = self.initial_delay
-        
+
         for attempt in range(self.max_retries + 1):
             try:
                 return func(*args, **kwargs)
-                
+
             except exceptions as e:
                 last_exception = e
-                
+
                 if attempt == self.max_retries:
-                    logger.error(f"API调用在 {self.max_retries} 次重试后仍失败: {str(e)}")
+                    logger.error(f"API call still failing after {self.max_retries} retries: {str(e)}")
                     raise
-                
+
                 current_delay = min(delay, self.max_delay)
                 current_delay = current_delay * (0.5 + random.random())
-                
+
                 logger.warning(
-                    f"API调用第 {attempt + 1} 次尝试失败: {str(e)}, "
-                    f"{current_delay:.1f}秒后重试..."
+                    f"API call attempt {attempt + 1} failed: {str(e)}, "
+                    f"retrying in {current_delay:.1f}s..."
                 )
-                
+
                 time.sleep(current_delay)
                 delay *= self.backoff_factor
-        
+
         raise last_exception
-    
+
     def call_batch_with_retry(
         self,
         items: list,
@@ -200,20 +200,20 @@ class RetryableAPIClient:
         continue_on_failure: bool = True
     ) -> Tuple[list, list]:
         """
-        批量调用并对每个失败项单独重试
-        
+        Process items in batch, retrying each failed item individually.
+
         Args:
-            items: 要处理的项目列表
-            process_func: 处理函数，接收单个item作为参数
-            exceptions: 需要重试的异常类型
-            continue_on_failure: 单项失败后是否继续处理其他项
-            
+            items: list of items to process
+            process_func: processing function; receives a single item as its argument
+            exceptions: exception types that should trigger a retry
+            continue_on_failure: whether to continue processing other items after one fails
+
         Returns:
-            (成功结果列表, 失败项列表)
+            (list of successful results, list of failed items)
         """
         results = []
         failures = []
-        
+
         for idx, item in enumerate(items):
             try:
                 result = self.call_with_retry(
@@ -222,17 +222,16 @@ class RetryableAPIClient:
                     exceptions=exceptions
                 )
                 results.append(result)
-                
+
             except Exception as e:
-                logger.error(f"处理第 {idx + 1} 项失败: {str(e)}")
+                logger.error(f"Failed to process item {idx + 1}: {str(e)}")
                 failures.append({
                     "index": idx,
                     "item": item,
                     "error": str(e)
                 })
-                
+
                 if not continue_on_failure:
                     raise
-        
-        return results, failures
 
+        return results, failures

--- a/backend/app/utils/zep_paging.py
+++ b/backend/app/utils/zep_paging.py
@@ -1,7 +1,8 @@
-"""Zep Graph 分页读取工具。
+"""Zep Graph paged-read utilities.
 
-Zep 的 node/edge 列表接口使用 UUID cursor 分页，
-本模块封装自动翻页逻辑（含单页重试），对调用方透明地返回完整列表。
+Zep's node/edge listing endpoints use UUID cursor-based pagination.
+This module wraps the auto-pagination logic (with per-page retries) and
+transparently returns the complete list to callers.
 """
 
 from __future__ import annotations
@@ -31,7 +32,7 @@ def _fetch_page_with_retry(
     page_description: str = "page",
     **kwargs: Any,
 ) -> list[Any]:
-    """单页请求，失败时指数退避重试。仅重试网络/IO类瞬态错误。"""
+    """Fetch a single page; on failure, retry with exponential backoff. Only retries transient network/IO errors."""
     if max_retries < 1:
         raise ValueError("max_retries must be >= 1")
 
@@ -64,7 +65,7 @@ def fetch_all_nodes(
     max_retries: int = _DEFAULT_MAX_RETRIES,
     retry_delay: float = _DEFAULT_RETRY_DELAY,
 ) -> list[Any]:
-    """分页获取图谱节点，最多返回 max_items 条（默认 2000）。每页请求自带重试。"""
+    """Fetch graph nodes with pagination, returning at most max_items entries (default 2000). Each page request has its own retries."""
     all_nodes: list[Any] = []
     cursor: str | None = None
     page_num = 0
@@ -109,7 +110,7 @@ def fetch_all_edges(
     max_retries: int = _DEFAULT_MAX_RETRIES,
     retry_delay: float = _DEFAULT_RETRY_DELAY,
 ) -> list[Any]:
-    """分页获取图谱所有边，返回完整列表。每页请求自带重试。"""
+    """Fetch all graph edges with pagination, returning the complete list. Each page request has its own retries."""
     all_edges: list[Any] = []
     cursor: str | None = None
     page_num = 0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mirofish-backend"
 version = "0.1.0"
-description = "MiroFish - 简洁通用的群体智能引擎，预测万物"
+description = "MiroFish - A Simple and Universal Swarm Intelligence Engine, Predicting Anything"
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0" }
 authors = [
@@ -9,27 +9,27 @@ authors = [
 ]
 
 dependencies = [
-    # 核心框架
+    # Core framework
     "flask>=3.0.0",
     "flask-cors>=6.0.0",
-    
-    # LLM 相关
+
+    # LLM-related
     "openai>=1.0.0",
-    
+
     # Zep Cloud
     "zep-cloud==3.13.0",
-    
-    # OASIS 社交媒体模拟
+
+    # OASIS social media simulation
     "camel-oasis==0.2.5",
     "camel-ai==0.2.78",
-    
-    # 文件处理
+
+    # File processing
     "PyMuPDF>=1.24.0",
-    # 编码检测（支持非UTF-8编码的文本文件）
+    # Encoding detection (supports text files with non-UTF-8 encodings)
     "charset-normalizer>=3.0.0",
     "chardet>=5.0.0",
-    
-    # 工具库
+
+    # Utility libraries
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",
 ]

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,21 +1,21 @@
 """
-MiroFish Backend 启动入口
+MiroFish Backend startup entry point
 """
 
 import os
 import sys
 
-# 解决 Windows 控制台中文乱码问题：在所有导入之前设置 UTF-8 编码
+# Fix non-ASCII output garbling on the Windows console: set UTF-8 encoding before any imports.
 if sys.platform == 'win32':
-    # 设置环境变量确保 Python 使用 UTF-8
+    # Set the environment variable to force Python to use UTF-8.
     os.environ.setdefault('PYTHONIOENCODING', 'utf-8')
-    # 重新配置标准输出流为 UTF-8
+    # Reconfigure standard output streams as UTF-8.
     if hasattr(sys.stdout, 'reconfigure'):
         sys.stdout.reconfigure(encoding='utf-8', errors='replace')
     if hasattr(sys.stderr, 'reconfigure'):
         sys.stderr.reconfigure(encoding='utf-8', errors='replace')
 
-# 添加项目根目录到路径
+# Add the project root directory to the path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from app import create_app
@@ -23,28 +23,27 @@ from app.config import Config
 
 
 def main():
-    """主函数"""
-    # 验证配置
+    """Main function"""
+    # Validate configuration
     errors = Config.validate()
     if errors:
-        print("配置错误:")
+        print("Configuration error:")
         for err in errors:
             print(f"  - {err}")
-        print("\n请检查 .env 文件中的配置")
+        print("\nPlease check the configuration in your .env file")
         sys.exit(1)
-    
-    # 创建应用
+
+    # Create the application
     app = create_app()
-    
-    # 获取运行配置
+
+    # Get runtime configuration
     host = os.environ.get('FLASK_HOST', '0.0.0.0')
     port = int(os.environ.get('FLASK_PORT', 5001))
     debug = Config.DEBUG
-    
-    # 启动服务
+
+    # Start the service
     app.run(host=host, port=port, debug=debug, threaded=True)
 
 
 if __name__ == '__main__':
     main()
-

--- a/backend/scripts/action_logger.py
+++ b/backend/scripts/action_logger.py
@@ -1,15 +1,15 @@
 """
-动作日志记录器
-用于记录OASIS模拟中每个Agent的动作，供后端监控使用
+Action logger
+Records each Agent's actions during an OASIS simulation for backend monitoring.
 
-日志结构:
+Log structure:
     sim_xxx/
     ├── twitter/
-    │   └── actions.jsonl    # Twitter 平台动作日志
+    │   └── actions.jsonl    # Twitter platform action log
     ├── reddit/
-    │   └── actions.jsonl    # Reddit 平台动作日志
-    ├── simulation.log       # 主模拟进程日志
-    └── run_state.json       # 运行状态（API 查询用）
+    │   └── actions.jsonl    # Reddit platform action log
+    ├── simulation.log       # Main simulation process log
+    └── run_state.json       # Run state (used by API queries)
 """
 
 import json
@@ -20,26 +20,26 @@ from typing import Dict, Any, Optional
 
 
 class PlatformActionLogger:
-    """单平台动作日志记录器"""
-    
+    """Per-platform action logger"""
+
     def __init__(self, platform: str, base_dir: str):
         """
-        初始化日志记录器
-        
+        Initialize the logger.
+
         Args:
-            platform: 平台名称 (twitter/reddit)
-            base_dir: 模拟目录的基础路径
+            platform: Platform name (twitter/reddit)
+            base_dir: Base path of the simulation directory
         """
         self.platform = platform
         self.base_dir = base_dir
         self.log_dir = os.path.join(base_dir, platform)
         self.log_path = os.path.join(self.log_dir, "actions.jsonl")
         self._ensure_dir()
-    
+
     def _ensure_dir(self):
-        """确保目录存在"""
+        """Ensure the directory exists"""
         os.makedirs(self.log_dir, exist_ok=True)
-    
+
     def log_action(
         self,
         round_num: int,
@@ -50,7 +50,7 @@ class PlatformActionLogger:
         result: Optional[str] = None,
         success: bool = True
     ):
-        """记录一个动作"""
+        """Record a single action"""
         entry = {
             "round": round_num,
             "timestamp": datetime.now().isoformat(),
@@ -61,36 +61,36 @@ class PlatformActionLogger:
             "result": result,
             "success": success,
         }
-        
+
         with open(self.log_path, 'a', encoding='utf-8') as f:
             f.write(json.dumps(entry, ensure_ascii=False) + '\n')
-    
+
     def log_round_start(self, round_num: int, simulated_hour: int):
-        """记录轮次开始"""
+        """Record the start of a round"""
         entry = {
             "round": round_num,
             "timestamp": datetime.now().isoformat(),
             "event_type": "round_start",
             "simulated_hour": simulated_hour,
         }
-        
+
         with open(self.log_path, 'a', encoding='utf-8') as f:
             f.write(json.dumps(entry, ensure_ascii=False) + '\n')
-    
+
     def log_round_end(self, round_num: int, actions_count: int):
-        """记录轮次结束"""
+        """Record the end of a round"""
         entry = {
             "round": round_num,
             "timestamp": datetime.now().isoformat(),
             "event_type": "round_end",
             "actions_count": actions_count,
         }
-        
+
         with open(self.log_path, 'a', encoding='utf-8') as f:
             f.write(json.dumps(entry, ensure_ascii=False) + '\n')
-    
+
     def log_simulation_start(self, config: Dict[str, Any]):
-        """记录模拟开始"""
+        """Record the start of the simulation"""
         entry = {
             "timestamp": datetime.now().isoformat(),
             "event_type": "simulation_start",
@@ -98,12 +98,12 @@ class PlatformActionLogger:
             "total_rounds": config.get("time_config", {}).get("total_simulation_hours", 72) * 2,
             "agents_count": len(config.get("agent_configs", [])),
         }
-        
+
         with open(self.log_path, 'a', encoding='utf-8') as f:
             f.write(json.dumps(entry, ensure_ascii=False) + '\n')
-    
+
     def log_simulation_end(self, total_rounds: int, total_actions: int):
-        """记录模拟结束"""
+        """Record the end of the simulation"""
         entry = {
             "timestamp": datetime.now().isoformat(),
             "event_type": "simulation_end",
@@ -111,42 +111,42 @@ class PlatformActionLogger:
             "total_rounds": total_rounds,
             "total_actions": total_actions,
         }
-        
+
         with open(self.log_path, 'a', encoding='utf-8') as f:
             f.write(json.dumps(entry, ensure_ascii=False) + '\n')
 
 
 class SimulationLogManager:
     """
-    模拟日志管理器
-    统一管理所有日志文件，按平台分离
+    Simulation log manager.
+    Centrally manages all log files, separated by platform.
     """
-    
+
     def __init__(self, simulation_dir: str):
         """
-        初始化日志管理器
-        
+        Initialize the log manager.
+
         Args:
-            simulation_dir: 模拟目录路径
+            simulation_dir: Path to the simulation directory
         """
         self.simulation_dir = simulation_dir
         self.twitter_logger: Optional[PlatformActionLogger] = None
         self.reddit_logger: Optional[PlatformActionLogger] = None
         self._main_logger: Optional[logging.Logger] = None
-        
-        # 设置主日志
+
+        # Set up the main logger
         self._setup_main_logger()
-    
+
     def _setup_main_logger(self):
-        """设置主模拟日志"""
+        """Set up the main simulation log"""
         log_path = os.path.join(self.simulation_dir, "simulation.log")
-        
-        # 创建 logger
+
+        # Create the logger
         self._main_logger = logging.getLogger(f"simulation.{os.path.basename(self.simulation_dir)}")
         self._main_logger.setLevel(logging.INFO)
         self._main_logger.handlers.clear()
-        
-        # 文件处理器
+
+        # File handler
         file_handler = logging.FileHandler(log_path, encoding='utf-8', mode='w')
         file_handler.setLevel(logging.INFO)
         file_handler.setFormatter(logging.Formatter(
@@ -154,8 +154,8 @@ class SimulationLogManager:
             datefmt='%Y-%m-%d %H:%M:%S'
         ))
         self._main_logger.addHandler(file_handler)
-        
-        # 控制台处理器
+
+        # Console handler
         console_handler = logging.StreamHandler()
         console_handler.setLevel(logging.INFO)
         console_handler.setFormatter(logging.Formatter(
@@ -163,56 +163,56 @@ class SimulationLogManager:
             datefmt='%H:%M:%S'
         ))
         self._main_logger.addHandler(console_handler)
-        
+
         self._main_logger.propagate = False
-    
+
     def get_twitter_logger(self) -> PlatformActionLogger:
-        """获取 Twitter 平台日志记录器"""
+        """Get the Twitter platform logger"""
         if self.twitter_logger is None:
             self.twitter_logger = PlatformActionLogger("twitter", self.simulation_dir)
         return self.twitter_logger
-    
+
     def get_reddit_logger(self) -> PlatformActionLogger:
-        """获取 Reddit 平台日志记录器"""
+        """Get the Reddit platform logger"""
         if self.reddit_logger is None:
             self.reddit_logger = PlatformActionLogger("reddit", self.simulation_dir)
         return self.reddit_logger
-    
+
     def log(self, message: str, level: str = "info"):
-        """记录主日志"""
+        """Write to the main log"""
         if self._main_logger:
             getattr(self._main_logger, level.lower(), self._main_logger.info)(message)
-    
+
     def info(self, message: str):
         self.log(message, "info")
-    
+
     def warning(self, message: str):
         self.log(message, "warning")
-    
+
     def error(self, message: str):
         self.log(message, "error")
-    
+
     def debug(self, message: str):
         self.log(message, "debug")
 
 
-# ============ 兼容旧接口 ============
+# ============ Legacy interface compatibility ============
 
 class ActionLogger:
     """
-    动作日志记录器（兼容旧接口）
-    建议使用 SimulationLogManager 代替
+    Action logger (legacy interface compatibility).
+    Prefer SimulationLogManager instead.
     """
-    
+
     def __init__(self, log_path: str):
         self.log_path = log_path
         self._ensure_dir()
-    
+
     def _ensure_dir(self):
         log_dir = os.path.dirname(self.log_path)
         if log_dir:
             os.makedirs(log_dir, exist_ok=True)
-    
+
     def log_action(
         self,
         round_num: int,
@@ -235,10 +235,10 @@ class ActionLogger:
             "result": result,
             "success": success,
         }
-        
+
         with open(self.log_path, 'a', encoding='utf-8') as f:
             f.write(json.dumps(entry, ensure_ascii=False) + '\n')
-    
+
     def log_round_start(self, round_num: int, simulated_hour: int, platform: str):
         entry = {
             "round": round_num,
@@ -247,10 +247,10 @@ class ActionLogger:
             "event_type": "round_start",
             "simulated_hour": simulated_hour,
         }
-        
+
         with open(self.log_path, 'a', encoding='utf-8') as f:
             f.write(json.dumps(entry, ensure_ascii=False) + '\n')
-    
+
     def log_round_end(self, round_num: int, actions_count: int, platform: str):
         entry = {
             "round": round_num,
@@ -259,10 +259,10 @@ class ActionLogger:
             "event_type": "round_end",
             "actions_count": actions_count,
         }
-        
+
         with open(self.log_path, 'a', encoding='utf-8') as f:
             f.write(json.dumps(entry, ensure_ascii=False) + '\n')
-    
+
     def log_simulation_start(self, platform: str, config: Dict[str, Any]):
         entry = {
             "timestamp": datetime.now().isoformat(),
@@ -271,10 +271,10 @@ class ActionLogger:
             "total_rounds": config.get("time_config", {}).get("total_simulation_hours", 72) * 2,
             "agents_count": len(config.get("agent_configs", [])),
         }
-        
+
         with open(self.log_path, 'a', encoding='utf-8') as f:
             f.write(json.dumps(entry, ensure_ascii=False) + '\n')
-    
+
     def log_simulation_end(self, platform: str, total_rounds: int, total_actions: int):
         entry = {
             "timestamp": datetime.now().isoformat(),
@@ -283,23 +283,23 @@ class ActionLogger:
             "total_rounds": total_rounds,
             "total_actions": total_actions,
         }
-        
+
         with open(self.log_path, 'a', encoding='utf-8') as f:
             f.write(json.dumps(entry, ensure_ascii=False) + '\n')
 
 
-# 全局日志实例（兼容旧接口）
+# Global logger instance (legacy interface compatibility)
 _global_logger: Optional[ActionLogger] = None
 
 
 def get_logger(log_path: Optional[str] = None) -> ActionLogger:
-    """获取全局日志实例（兼容旧接口）"""
+    """Get the global logger instance (legacy interface compatibility)"""
     global _global_logger
-    
+
     if log_path:
         _global_logger = ActionLogger(log_path)
-    
+
     if _global_logger is None:
         _global_logger = ActionLogger("actions.jsonl")
-    
+
     return _global_logger

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -1,67 +1,70 @@
 """
-OASIS 双平台并行模拟预设脚本
-同时运行Twitter和Reddit模拟，读取相同的配置文件
+OASIS dual-platform parallel simulation preset script.
+Runs Twitter and Reddit simulations concurrently from the same config file.
 
-功能特性:
-- 双平台（Twitter + Reddit）并行模拟
-- 完成模拟后不立即关闭环境，进入等待命令模式
-- 支持通过IPC接收Interview命令
-- 支持单个Agent采访和批量采访
-- 支持远程关闭环境命令
+Features:
+- Dual-platform (Twitter + Reddit) parallel simulation
+- Does not immediately close the environment after the simulation completes; enters
+  command-wait mode instead.
+- Accepts Interview commands over IPC.
+- Supports single-Agent interviews and batch interviews.
+- Supports remote close-environment commands.
 
-使用方式:
+Usage:
     python run_parallel_simulation.py --config simulation_config.json
-    python run_parallel_simulation.py --config simulation_config.json --no-wait  # 完成后立即关闭
+    python run_parallel_simulation.py --config simulation_config.json --no-wait  # close immediately on completion
     python run_parallel_simulation.py --config simulation_config.json --twitter-only
     python run_parallel_simulation.py --config simulation_config.json --reddit-only
 
-日志结构:
+Log structure:
     sim_xxx/
     ├── twitter/
-    │   └── actions.jsonl    # Twitter 平台动作日志
+    │   └── actions.jsonl    # Twitter platform action log
     ├── reddit/
-    │   └── actions.jsonl    # Reddit 平台动作日志
-    ├── simulation.log       # 主模拟进程日志
-    └── run_state.json       # 运行状态（API 查询用）
+    │   └── actions.jsonl    # Reddit platform action log
+    ├── simulation.log       # Main simulation process log
+    └── run_state.json       # Run state (used by API queries)
 """
 
 # ============================================================
-# 解决 Windows 编码问题：在所有 import 之前设置 UTF-8 编码
-# 这是为了修复 OASIS 第三方库读取文件时未指定编码的问题
+# Fix Windows encoding issues: set UTF-8 encoding before any imports.
+# This works around the OASIS third-party library opening files without
+# specifying an encoding.
 # ============================================================
 import sys
 import os
 
 if sys.platform == 'win32':
-    # 设置 Python 默认 I/O 编码为 UTF-8
-    # 这会影响所有未指定编码的 open() 调用
+    # Set Python's default I/O encoding to UTF-8.
+    # This affects all open() calls that don't specify an encoding.
     os.environ.setdefault('PYTHONUTF8', '1')
     os.environ.setdefault('PYTHONIOENCODING', 'utf-8')
-    
-    # 重新配置标准输出流为 UTF-8（解决控制台中文乱码）
+
+    # Reconfigure the standard streams to UTF-8 (fixes garbled CJK output in the console)
     if hasattr(sys.stdout, 'reconfigure'):
         sys.stdout.reconfigure(encoding='utf-8', errors='replace')
     if hasattr(sys.stderr, 'reconfigure'):
         sys.stderr.reconfigure(encoding='utf-8', errors='replace')
-    
-    # 强制设置默认编码（影响 open() 函数的默认编码）
-    # 注意：这需要在 Python 启动时就设置，运行时设置可能不生效
-    # 所以我们还需要 monkey-patch 内置的 open 函数
+
+    # Force the default encoding (affects open()'s default encoding).
+    # Note: this normally needs to be set at Python startup; setting it at runtime
+    # may not take effect, so we also monkey-patch the built-in open function.
     import builtins
     _original_open = builtins.open
-    
-    def _utf8_open(file, mode='r', buffering=-1, encoding=None, errors=None, 
+
+    def _utf8_open(file, mode='r', buffering=-1, encoding=None, errors=None,
                    newline=None, closefd=True, opener=None):
         """
-        包装 open() 函数，对于文本模式默认使用 UTF-8 编码
-        这可以修复第三方库（如 OASIS）读取文件时未指定编码的问题
+        Wrap open() so that text-mode calls default to UTF-8 encoding.
+        This works around third-party libraries (such as OASIS) that read files
+        without specifying an encoding.
         """
-        # 只对文本模式（非二进制）且未指定编码的情况设置默认编码
+        # Only set the default encoding for text mode (non-binary) when no encoding was specified
         if encoding is None and 'b' not in mode:
             encoding = 'utf-8'
-        return _original_open(file, mode, buffering, encoding, errors, 
+        return _original_open(file, mode, buffering, encoding, errors,
                               newline, closefd, opener)
-    
+
     builtins.open = _utf8_open
 
 import argparse
@@ -77,78 +80,79 @@ from datetime import datetime
 from typing import Dict, Any, List, Optional, Tuple
 
 
-# 全局变量：用于信号处理
+# Global variables: used by signal handling
 _shutdown_event = None
 _cleanup_done = False
 
-# 添加 backend 目录到路径
-# 脚本固定位于 backend/scripts/ 目录
+# Add the backend directory to the path.
+# This script always lives in backend/scripts/.
 _scripts_dir = os.path.dirname(os.path.abspath(__file__))
 _backend_dir = os.path.abspath(os.path.join(_scripts_dir, '..'))
 _project_root = os.path.abspath(os.path.join(_backend_dir, '..'))
 sys.path.insert(0, _scripts_dir)
 sys.path.insert(0, _backend_dir)
 
-# 加载项目根目录的 .env 文件（包含 LLM_API_KEY 等配置）
+# Load the project root .env file (contains LLM_API_KEY and other config)
 from dotenv import load_dotenv
 _env_file = os.path.join(_project_root, '.env')
 if os.path.exists(_env_file):
     load_dotenv(_env_file)
-    print(f"已加载环境配置: {_env_file}")
+    print(f"Loaded environment config: {_env_file}")
 else:
-    # 尝试加载 backend/.env
+    # Try to load backend/.env
     _backend_env = os.path.join(_backend_dir, '.env')
     if os.path.exists(_backend_env):
         load_dotenv(_backend_env)
-        print(f"已加载环境配置: {_backend_env}")
+        print(f"Loaded environment config: {_backend_env}")
 
 
 class MaxTokensWarningFilter(logging.Filter):
-    """过滤掉 camel-ai 关于 max_tokens 的警告（我们故意不设置 max_tokens，让模型自行决定）"""
-    
+    """Filter out camel-ai's max_tokens warnings (we intentionally do not set max_tokens, letting the model decide)"""
+
     def filter(self, record):
-        # 过滤掉包含 max_tokens 警告的日志
+        # Drop log records that contain the max_tokens warning
         if "max_tokens" in record.getMessage() and "Invalid or missing" in record.getMessage():
             return False
         return True
 
 
-# 在模块加载时立即添加过滤器，确保在 camel 代码执行前生效
+# Add the filter as soon as the module loads, so it is in effect before camel code runs
 logging.getLogger().addFilter(MaxTokensWarningFilter())
 
 
 def disable_oasis_logging():
     """
-    禁用 OASIS 库的详细日志输出
-    OASIS 的日志太冗余（记录每个 agent 的观察和动作），我们使用自己的 action_logger
+    Disable OASIS library's verbose logging output.
+    OASIS logs are too noisy (recording each agent's observations and actions);
+    we use our own action_logger instead.
     """
-    # 禁用 OASIS 的所有日志器
+    # Disable all OASIS loggers
     oasis_loggers = [
         "social.agent",
-        "social.twitter", 
+        "social.twitter",
         "social.rec",
         "oasis.env",
         "table",
     ]
-    
+
     for logger_name in oasis_loggers:
         logger = logging.getLogger(logger_name)
-        logger.setLevel(logging.CRITICAL)  # 只记录严重错误
+        logger.setLevel(logging.CRITICAL)  # Only log critical errors
         logger.handlers.clear()
         logger.propagate = False
 
 
 def init_logging_for_simulation(simulation_dir: str):
     """
-    初始化模拟的日志配置
-    
+    Initialize logging configuration for the simulation.
+
     Args:
-        simulation_dir: 模拟目录路径
+        simulation_dir: simulation directory path
     """
-    # 禁用 OASIS 的详细日志
+    # Disable OASIS verbose logging
     disable_oasis_logging()
-    
-    # 清理旧的 log 目录（如果存在）
+
+    # Clean up the old log directory (if it exists)
     old_log_dir = os.path.join(simulation_dir, "log")
     if os.path.exists(old_log_dir):
         import shutil
@@ -169,12 +173,12 @@ try:
         generate_reddit_agent_graph
     )
 except ImportError as e:
-    print(f"错误: 缺少依赖 {e}")
-    print("请先安装: pip install oasis-ai camel-ai")
+    print(f"Error: missing dependency {e}")
+    print("Please install first: pip install oasis-ai camel-ai")
     sys.exit(1)
 
 
-# Twitter可用动作（不包含INTERVIEW，INTERVIEW只能通过ManualAction手动触发）
+# Twitter-available actions (does not include INTERVIEW; INTERVIEW can only be triggered manually via ManualAction)
 TWITTER_ACTIONS = [
     ActionType.CREATE_POST,
     ActionType.LIKE_POST,
@@ -184,7 +188,7 @@ TWITTER_ACTIONS = [
     ActionType.QUOTE_POST,
 ]
 
-# Reddit可用动作（不包含INTERVIEW，INTERVIEW只能通过ManualAction手动触发）
+# Reddit-available actions (does not include INTERVIEW; INTERVIEW can only be triggered manually via ManualAction)
 REDDIT_ACTIONS = [
     ActionType.LIKE_POST,
     ActionType.DISLIKE_POST,
@@ -202,13 +206,13 @@ REDDIT_ACTIONS = [
 ]
 
 
-# IPC相关常量
+# IPC-related constants
 IPC_COMMANDS_DIR = "ipc_commands"
 IPC_RESPONSES_DIR = "ipc_responses"
 ENV_STATUS_FILE = "env_status.json"
 
 class CommandType:
-    """命令类型常量"""
+    """Command type constants"""
     INTERVIEW = "interview"
     BATCH_INTERVIEW = "batch_interview"
     CLOSE_ENV = "close_env"
@@ -216,11 +220,11 @@ class CommandType:
 
 class ParallelIPCHandler:
     """
-    双平台IPC命令处理器
-    
-    管理两个平台的环境，处理Interview命令
+    Dual-platform IPC command handler.
+
+    Manages both platforms' environments and processes Interview commands.
     """
-    
+
     def __init__(
         self,
         simulation_dir: str,
@@ -234,17 +238,17 @@ class ParallelIPCHandler:
         self.twitter_agent_graph = twitter_agent_graph
         self.reddit_env = reddit_env
         self.reddit_agent_graph = reddit_agent_graph
-        
+
         self.commands_dir = os.path.join(simulation_dir, IPC_COMMANDS_DIR)
         self.responses_dir = os.path.join(simulation_dir, IPC_RESPONSES_DIR)
         self.status_file = os.path.join(simulation_dir, ENV_STATUS_FILE)
-        
-        # 确保目录存在
+
+        # Ensure directories exist
         os.makedirs(self.commands_dir, exist_ok=True)
         os.makedirs(self.responses_dir, exist_ok=True)
-    
+
     def update_status(self, status: str):
-        """更新环境状态"""
+        """Update the environment status"""
         with open(self.status_file, 'w', encoding='utf-8') as f:
             json.dump({
                 "status": status,
@@ -252,32 +256,32 @@ class ParallelIPCHandler:
                 "reddit_available": self.reddit_env is not None,
                 "timestamp": datetime.now().isoformat()
             }, f, ensure_ascii=False, indent=2)
-    
+
     def poll_command(self) -> Optional[Dict[str, Any]]:
-        """轮询获取待处理命令"""
+        """Poll for pending commands"""
         if not os.path.exists(self.commands_dir):
             return None
-        
-        # 获取命令文件（按时间排序）
+
+        # Collect command files (sorted by time)
         command_files = []
         for filename in os.listdir(self.commands_dir):
             if filename.endswith('.json'):
                 filepath = os.path.join(self.commands_dir, filename)
                 command_files.append((filepath, os.path.getmtime(filepath)))
-        
+
         command_files.sort(key=lambda x: x[1])
-        
+
         for filepath, _ in command_files:
             try:
                 with open(filepath, 'r', encoding='utf-8') as f:
                     return json.load(f)
             except (json.JSONDecodeError, OSError):
                 continue
-        
+
         return None
-    
+
     def send_response(self, command_id: str, status: str, result: Dict = None, error: str = None):
-        """发送响应"""
+        """Send a response"""
         response = {
             "command_id": command_id,
             "status": status,
@@ -285,27 +289,27 @@ class ParallelIPCHandler:
             "error": error,
             "timestamp": datetime.now().isoformat()
         }
-        
+
         response_file = os.path.join(self.responses_dir, f"{command_id}.json")
         with open(response_file, 'w', encoding='utf-8') as f:
             json.dump(response, f, ensure_ascii=False, indent=2)
-        
-        # 删除命令文件
+
+        # Delete the command file
         command_file = os.path.join(self.commands_dir, f"{command_id}.json")
         try:
             os.remove(command_file)
         except OSError:
             pass
-    
+
     def _get_env_and_graph(self, platform: str):
         """
-        获取指定平台的环境和agent_graph
-        
+        Get the env and agent_graph for the given platform.
+
         Args:
-            platform: 平台名称 ("twitter" 或 "reddit")
-            
+            platform: platform name ("twitter" or "reddit")
+
         Returns:
-            (env, agent_graph, platform_name) 或 (None, None, None)
+            (env, agent_graph, platform_name) or (None, None, None)
         """
         if platform == "twitter" and self.twitter_env:
             return self.twitter_env, self.twitter_agent_graph, "twitter"
@@ -313,19 +317,19 @@ class ParallelIPCHandler:
             return self.reddit_env, self.reddit_agent_graph, "reddit"
         else:
             return None, None, None
-    
+
     async def _interview_single_platform(self, agent_id: int, prompt: str, platform: str) -> Dict[str, Any]:
         """
-        在单个平台上执行Interview
-        
+        Run an Interview on a single platform.
+
         Returns:
-            包含结果的字典，或包含error的字典
+            A dict containing the result, or a dict containing an error.
         """
         env, agent_graph, actual_platform = self._get_env_and_graph(platform)
-        
+
         if not env or not agent_graph:
-            return {"platform": platform, "error": f"{platform}平台不可用"}
-        
+            return {"platform": platform, "error": f"{platform} platform unavailable"}
+
         try:
             agent = agent_graph.get_agent(agent_id)
             interview_action = ManualAction(
@@ -334,102 +338,102 @@ class ParallelIPCHandler:
             )
             actions = {agent: interview_action}
             await env.step(actions)
-            
+
             result = self._get_interview_result(agent_id, actual_platform)
             result["platform"] = actual_platform
             return result
-            
+
         except Exception as e:
             return {"platform": platform, "error": str(e)}
-    
+
     async def handle_interview(self, command_id: str, agent_id: int, prompt: str, platform: str = None) -> bool:
         """
-        处理单个Agent采访命令
-        
+        Handle a single-Agent interview command.
+
         Args:
-            command_id: 命令ID
+            command_id: command ID
             agent_id: Agent ID
-            prompt: 采访问题
-            platform: 指定平台（可选）
-                - "twitter": 只采访Twitter平台
-                - "reddit": 只采访Reddit平台
-                - None/不指定: 同时采访两个平台，返回整合结果
-            
+            prompt: interview prompt
+            platform: target platform (optional)
+                - "twitter": only interview on Twitter
+                - "reddit": only interview on Reddit
+                - None / unspecified: interview on both platforms and return aggregated results
+
         Returns:
-            True 表示成功，False 表示失败
+            True on success, False on failure
         """
-        # 如果指定了平台，只采访该平台
+        # If a platform is specified, only interview on that platform
         if platform in ("twitter", "reddit"):
             result = await self._interview_single_platform(agent_id, prompt, platform)
-            
+
             if "error" in result:
                 self.send_response(command_id, "failed", error=result["error"])
-                print(f"  Interview失败: agent_id={agent_id}, platform={platform}, error={result['error']}")
+                print(f"  Interview failed: agent_id={agent_id}, platform={platform}, error={result['error']}")
                 return False
             else:
                 self.send_response(command_id, "completed", result=result)
-                print(f"  Interview完成: agent_id={agent_id}, platform={platform}")
+                print(f"  Interview completed: agent_id={agent_id}, platform={platform}")
                 return True
-        
-        # 未指定平台：同时采访两个平台
+
+        # No platform specified: interview on both platforms simultaneously
         if not self.twitter_env and not self.reddit_env:
-            self.send_response(command_id, "failed", error="没有可用的模拟环境")
+            self.send_response(command_id, "failed", error="No simulation environments available")
             return False
-        
+
         results = {
             "agent_id": agent_id,
             "prompt": prompt,
             "platforms": {}
         }
         success_count = 0
-        
-        # 并行采访两个平台
+
+        # Interview both platforms in parallel
         tasks = []
         platforms_to_interview = []
-        
+
         if self.twitter_env:
             tasks.append(self._interview_single_platform(agent_id, prompt, "twitter"))
             platforms_to_interview.append("twitter")
-        
+
         if self.reddit_env:
             tasks.append(self._interview_single_platform(agent_id, prompt, "reddit"))
             platforms_to_interview.append("reddit")
-        
-        # 并行执行
+
+        # Run in parallel
         platform_results = await asyncio.gather(*tasks)
-        
+
         for platform_name, platform_result in zip(platforms_to_interview, platform_results):
             results["platforms"][platform_name] = platform_result
             if "error" not in platform_result:
                 success_count += 1
-        
+
         if success_count > 0:
             self.send_response(command_id, "completed", result=results)
-            print(f"  Interview完成: agent_id={agent_id}, 成功平台数={success_count}/{len(platforms_to_interview)}")
+            print(f"  Interview completed: agent_id={agent_id}, successful platforms={success_count}/{len(platforms_to_interview)}")
             return True
         else:
-            errors = [f"{p}: {r.get('error', '未知错误')}" for p, r in results["platforms"].items()]
+            errors = [f"{p}: {r.get('error', 'unknown error')}" for p, r in results["platforms"].items()]
             self.send_response(command_id, "failed", error="; ".join(errors))
-            print(f"  Interview失败: agent_id={agent_id}, 所有平台都失败")
+            print(f"  Interview failed: agent_id={agent_id}, all platforms failed")
             return False
-    
+
     async def handle_batch_interview(self, command_id: str, interviews: List[Dict], platform: str = None) -> bool:
         """
-        处理批量采访命令
-        
+        Handle a batch interview command.
+
         Args:
-            command_id: 命令ID
+            command_id: command ID
             interviews: [{"agent_id": int, "prompt": str, "platform": str(optional)}, ...]
-            platform: 默认平台（可被每个interview项覆盖）
-                - "twitter": 只采访Twitter平台
-                - "reddit": 只采访Reddit平台
-                - None/不指定: 每个Agent同时采访两个平台
+            platform: default platform (can be overridden per interview item)
+                - "twitter": only interview on Twitter
+                - "reddit": only interview on Reddit
+                - None / unspecified: interview each Agent on both platforms
         """
-        # 按平台分组
+        # Group by platform
         twitter_interviews = []
         reddit_interviews = []
-        both_platforms_interviews = []  # 需要同时采访两个平台的
-        
+        both_platforms_interviews = []  # Items that should be interviewed on both platforms
+
         for interview in interviews:
             item_platform = interview.get("platform", platform)
             if item_platform == "twitter":
@@ -437,19 +441,19 @@ class ParallelIPCHandler:
             elif item_platform == "reddit":
                 reddit_interviews.append(interview)
             else:
-                # 未指定平台：两个平台都采访
+                # No platform specified: interview on both platforms
                 both_platforms_interviews.append(interview)
-        
-        # 把 both_platforms_interviews 拆分到两个平台
+
+        # Distribute both_platforms_interviews to each platform
         if both_platforms_interviews:
             if self.twitter_env:
                 twitter_interviews.extend(both_platforms_interviews)
             if self.reddit_env:
                 reddit_interviews.extend(both_platforms_interviews)
-        
+
         results = {}
-        
-        # 处理Twitter平台的采访
+
+        # Process Twitter platform interviews
         if twitter_interviews and self.twitter_env:
             try:
                 twitter_actions = {}
@@ -463,20 +467,20 @@ class ParallelIPCHandler:
                             action_args={"prompt": prompt}
                         )
                     except Exception as e:
-                        print(f"  警告: 无法获取Twitter Agent {agent_id}: {e}")
-                
+                        print(f"  Warning: could not get Twitter Agent {agent_id}: {e}")
+
                 if twitter_actions:
                     await self.twitter_env.step(twitter_actions)
-                    
+
                     for interview in twitter_interviews:
                         agent_id = interview.get("agent_id")
                         result = self._get_interview_result(agent_id, "twitter")
                         result["platform"] = "twitter"
                         results[f"twitter_{agent_id}"] = result
             except Exception as e:
-                print(f"  Twitter批量Interview失败: {e}")
-        
-        # 处理Reddit平台的采访
+                print(f"  Twitter batch Interview failed: {e}")
+
+        # Process Reddit platform interviews
         if reddit_interviews and self.reddit_env:
             try:
                 reddit_actions = {}
@@ -490,48 +494,48 @@ class ParallelIPCHandler:
                             action_args={"prompt": prompt}
                         )
                     except Exception as e:
-                        print(f"  警告: 无法获取Reddit Agent {agent_id}: {e}")
-                
+                        print(f"  Warning: could not get Reddit Agent {agent_id}: {e}")
+
                 if reddit_actions:
                     await self.reddit_env.step(reddit_actions)
-                    
+
                     for interview in reddit_interviews:
                         agent_id = interview.get("agent_id")
                         result = self._get_interview_result(agent_id, "reddit")
                         result["platform"] = "reddit"
                         results[f"reddit_{agent_id}"] = result
             except Exception as e:
-                print(f"  Reddit批量Interview失败: {e}")
-        
+                print(f"  Reddit batch Interview failed: {e}")
+
         if results:
             self.send_response(command_id, "completed", result={
                 "interviews_count": len(results),
                 "results": results
             })
-            print(f"  批量Interview完成: {len(results)} 个Agent")
+            print(f"  Batch Interview completed: {len(results)} Agents")
             return True
         else:
-            self.send_response(command_id, "failed", error="没有成功的采访")
+            self.send_response(command_id, "failed", error="No successful interviews")
             return False
-    
+
     def _get_interview_result(self, agent_id: int, platform: str) -> Dict[str, Any]:
-        """从数据库获取最新的Interview结果"""
+        """Read the latest Interview result from the database"""
         db_path = os.path.join(self.simulation_dir, f"{platform}_simulation.db")
-        
+
         result = {
             "agent_id": agent_id,
             "response": None,
             "timestamp": None
         }
-        
+
         if not os.path.exists(db_path):
             return result
-        
+
         try:
             conn = sqlite3.connect(db_path)
             cursor = conn.cursor()
-            
-            # 查询最新的Interview记录
+
+            # Query the latest Interview record
             cursor.execute("""
                 SELECT user_id, info, created_at
                 FROM trace
@@ -539,7 +543,7 @@ class ParallelIPCHandler:
                 ORDER BY created_at DESC
                 LIMIT 1
             """, (ActionType.INTERVIEW.value, agent_id))
-            
+
             row = cursor.fetchone()
             if row:
                 user_id, info_json, created_at = row
@@ -549,31 +553,31 @@ class ParallelIPCHandler:
                     result["timestamp"] = created_at
                 except json.JSONDecodeError:
                     result["response"] = info_json
-            
+
             conn.close()
-            
+
         except Exception as e:
-            print(f"  读取Interview结果失败: {e}")
-        
+            print(f"  Failed to read Interview result: {e}")
+
         return result
-    
+
     async def process_commands(self) -> bool:
         """
-        处理所有待处理命令
-        
+        Process all pending commands.
+
         Returns:
-            True 表示继续运行，False 表示应该退出
+            True to continue running, False to indicate the loop should exit
         """
         command = self.poll_command()
         if not command:
             return True
-        
+
         command_id = command.get("command_id")
         command_type = command.get("command_type")
         args = command.get("args", {})
-        
-        print(f"\n收到IPC命令: {command_type}, id={command_id}")
-        
+
+        print(f"\nReceived IPC command: {command_type}, id={command_id}")
+
         if command_type == CommandType.INTERVIEW:
             await self.handle_interview(
                 command_id,
@@ -582,7 +586,7 @@ class ParallelIPCHandler:
                 args.get("platform")
             )
             return True
-            
+
         elif command_type == CommandType.BATCH_INTERVIEW:
             await self.handle_batch_interview(
                 command_id,
@@ -590,27 +594,27 @@ class ParallelIPCHandler:
                 args.get("platform")
             )
             return True
-            
+
         elif command_type == CommandType.CLOSE_ENV:
-            print("收到关闭环境命令")
-            self.send_response(command_id, "completed", result={"message": "环境即将关闭"})
+            print("Received close-environment command")
+            self.send_response(command_id, "completed", result={"message": "Environment will close shortly"})
             return False
-        
+
         else:
-            self.send_response(command_id, "failed", error=f"未知命令类型: {command_type}")
+            self.send_response(command_id, "failed", error=f"Unknown command type: {command_type}")
             return True
 
 
 def load_config(config_path: str) -> Dict[str, Any]:
-    """加载配置文件"""
+    """Load the config file"""
     with open(config_path, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 
-# 需要过滤掉的非核心动作类型（这些动作对分析价值较低）
+# Non-core action types to filter out (these have low analytical value)
 FILTERED_ACTIONS = {'refresh', 'sign_up'}
 
-# 动作类型映射表（数据库中的名称 -> 标准名称）
+# Action type mapping (DB name -> standard name)
 ACTION_TYPE_MAP = {
     'create_post': 'CREATE_POST',
     'like_post': 'LIKE_POST',
@@ -632,25 +636,25 @@ ACTION_TYPE_MAP = {
 
 def get_agent_names_from_config(config: Dict[str, Any]) -> Dict[int, str]:
     """
-    从 simulation_config 中获取 agent_id -> entity_name 的映射
-    
-    这样可以在 actions.jsonl 中显示真实的实体名称，而不是 "Agent_0" 这样的代号
-    
+    Build an agent_id -> entity_name map from simulation_config.
+
+    This makes actions.jsonl display real entity names rather than codenames like "Agent_0".
+
     Args:
-        config: simulation_config.json 的内容
-        
+        config: contents of simulation_config.json
+
     Returns:
-        agent_id -> entity_name 的映射字典
+        Dict mapping agent_id -> entity_name
     """
     agent_names = {}
     agent_configs = config.get("agent_configs", [])
-    
+
     for agent_config in agent_configs:
         agent_id = agent_config.get("agent_id")
         entity_name = agent_config.get("entity_name", f"Agent_{agent_id}")
         if agent_id is not None:
             agent_names[agent_id] = entity_name
-    
+
     return agent_names
 
 
@@ -660,52 +664,54 @@ def fetch_new_actions_from_db(
     agent_names: Dict[int, str]
 ) -> Tuple[List[Dict[str, Any]], int]:
     """
-    从数据库中获取新的动作记录，并补充完整的上下文信息
-    
+    Fetch new action records from the database and enrich them with full context.
+
     Args:
-        db_path: 数据库文件路径
-        last_rowid: 上次读取的最大 rowid 值（使用 rowid 而不是 created_at，因为不同平台的 created_at 格式不同）
-        agent_names: agent_id -> agent_name 映射
-        
+        db_path: database file path
+        last_rowid: the largest rowid read previously (we use rowid rather than created_at,
+            because the created_at format differs across platforms)
+        agent_names: agent_id -> agent_name map
+
     Returns:
         (actions_list, new_last_rowid)
-        - actions_list: 动作列表，每个元素包含 agent_id, agent_name, action_type, action_args（含上下文信息）
-        - new_last_rowid: 新的最大 rowid 值
+        - actions_list: list of actions; each entry contains agent_id, agent_name, action_type,
+          action_args (with context info)
+        - new_last_rowid: new largest rowid value
     """
     actions = []
     new_last_rowid = last_rowid
-    
+
     if not os.path.exists(db_path):
         return actions, new_last_rowid
-    
+
     try:
         conn = sqlite3.connect(db_path)
         cursor = conn.cursor()
-        
-        # 使用 rowid 来追踪已处理的记录（rowid 是 SQLite 的内置自增字段）
-        # 这样可以避免 created_at 格式差异问题（Twitter 用整数，Reddit 用日期时间字符串）
+
+        # Use rowid to track processed records (rowid is SQLite's built-in auto-increment field).
+        # This avoids created_at format differences (Twitter uses integers, Reddit uses datetime strings).
         cursor.execute("""
             SELECT rowid, user_id, action, info
             FROM trace
             WHERE rowid > ?
             ORDER BY rowid ASC
         """, (last_rowid,))
-        
+
         for rowid, user_id, action, info_json in cursor.fetchall():
-            # 更新最大 rowid
+            # Update the largest rowid
             new_last_rowid = rowid
-            
-            # 过滤非核心动作
+
+            # Filter non-core actions
             if action in FILTERED_ACTIONS:
                 continue
-            
-            # 解析动作参数
+
+            # Parse the action args
             try:
                 action_args = json.loads(info_json) if info_json else {}
             except json.JSONDecodeError:
                 action_args = {}
-            
-            # 精简 action_args，只保留关键字段（保留完整内容，不截断）
+
+            # Slim down action_args, keeping only key fields (preserve full content; do not truncate)
             simplified_args = {}
             if 'content' in action_args:
                 simplified_args['content'] = action_args['content']
@@ -725,24 +731,24 @@ def fetch_new_actions_from_db(
                 simplified_args['like_id'] = action_args['like_id']
             if 'dislike_id' in action_args:
                 simplified_args['dislike_id'] = action_args['dislike_id']
-            
-            # 转换动作类型名称
+
+            # Convert action type name
             action_type = ACTION_TYPE_MAP.get(action, action.upper())
-            
-            # 补充上下文信息（帖子内容、用户名等）
+
+            # Enrich with context (post content, user names, etc.)
             _enrich_action_context(cursor, action_type, simplified_args, agent_names)
-            
+
             actions.append({
                 'agent_id': user_id,
                 'agent_name': agent_names.get(user_id, f'Agent_{user_id}'),
                 'action_type': action_type,
                 'action_args': simplified_args,
             })
-        
+
         conn.close()
     except Exception as e:
-        print(f"读取数据库动作失败: {e}")
-    
+        print(f"Failed to read actions from database: {e}")
+
     return actions, new_last_rowid
 
 
@@ -753,16 +759,16 @@ def _enrich_action_context(
     agent_names: Dict[int, str]
 ) -> None:
     """
-    为动作补充上下文信息（帖子内容、用户名等）
-    
+    Enrich an action with context info (post content, user names, etc).
+
     Args:
-        cursor: 数据库游标
-        action_type: 动作类型
-        action_args: 动作参数（会被修改）
-        agent_names: agent_id -> agent_name 映射
+        cursor: database cursor
+        action_type: action type
+        action_args: action args (will be modified in place)
+        agent_names: agent_id -> agent_name map
     """
     try:
-        # 点赞/踩帖子：补充帖子内容和作者
+        # Like / dislike post: enrich with post content and author
         if action_type in ('LIKE_POST', 'DISLIKE_POST'):
             post_id = action_args.get('post_id')
             if post_id:
@@ -770,12 +776,12 @@ def _enrich_action_context(
                 if post_info:
                     action_args['post_content'] = post_info.get('content', '')
                     action_args['post_author_name'] = post_info.get('author_name', '')
-        
-        # 转发帖子：补充原帖内容和作者
+
+        # Repost: enrich with the original post's content and author
         elif action_type == 'REPOST':
             new_post_id = action_args.get('new_post_id')
             if new_post_id:
-                # 转发帖子的 original_post_id 指向原帖
+                # The repost's original_post_id points to the original post
                 cursor.execute("""
                     SELECT original_post_id FROM post WHERE post_id = ?
                 """, (new_post_id,))
@@ -786,19 +792,19 @@ def _enrich_action_context(
                     if original_info:
                         action_args['original_content'] = original_info.get('content', '')
                         action_args['original_author_name'] = original_info.get('author_name', '')
-        
-        # 引用帖子：补充原帖内容、作者和引用评论
+
+        # Quote post: enrich with the original post's content, author and the quote comment
         elif action_type == 'QUOTE_POST':
             quoted_id = action_args.get('quoted_id')
             new_post_id = action_args.get('new_post_id')
-            
+
             if quoted_id:
                 original_info = _get_post_info(cursor, quoted_id, agent_names)
                 if original_info:
                     action_args['original_content'] = original_info.get('content', '')
                     action_args['original_author_name'] = original_info.get('author_name', '')
-            
-            # 获取引用帖子的评论内容（quote_content）
+
+            # Get the quote post's comment content (quote_content)
             if new_post_id:
                 cursor.execute("""
                     SELECT quote_content FROM post WHERE post_id = ?
@@ -806,12 +812,12 @@ def _enrich_action_context(
                 row = cursor.fetchone()
                 if row and row[0]:
                     action_args['quote_content'] = row[0]
-        
-        # 关注用户：补充被关注用户的名称
+
+        # Follow user: enrich with the followed user's name
         elif action_type == 'FOLLOW':
             follow_id = action_args.get('follow_id')
             if follow_id:
-                # 从 follow 表获取 followee_id
+                # Get followee_id from the follow table
                 cursor.execute("""
                     SELECT followee_id FROM follow WHERE follow_id = ?
                 """, (follow_id,))
@@ -821,17 +827,17 @@ def _enrich_action_context(
                     target_name = _get_user_name(cursor, followee_id, agent_names)
                     if target_name:
                         action_args['target_user_name'] = target_name
-        
-        # 屏蔽用户：补充被屏蔽用户的名称
+
+        # Mute user: enrich with the muted user's name
         elif action_type == 'MUTE':
-            # 从 action_args 中获取 user_id 或 target_id
+            # Get user_id or target_id from action_args
             target_id = action_args.get('user_id') or action_args.get('target_id')
             if target_id:
                 target_name = _get_user_name(cursor, target_id, agent_names)
                 if target_name:
                     action_args['target_user_name'] = target_name
-        
-        # 点赞/踩评论：补充评论内容和作者
+
+        # Like / dislike comment: enrich with comment content and author
         elif action_type in ('LIKE_COMMENT', 'DISLIKE_COMMENT'):
             comment_id = action_args.get('comment_id')
             if comment_id:
@@ -839,8 +845,8 @@ def _enrich_action_context(
                 if comment_info:
                     action_args['comment_content'] = comment_info.get('content', '')
                     action_args['comment_author_name'] = comment_info.get('author_name', '')
-        
-        # 发表评论：补充所评论的帖子信息
+
+        # Create comment: enrich with the post being commented on
         elif action_type == 'CREATE_COMMENT':
             post_id = action_args.get('post_id')
             if post_id:
@@ -848,10 +854,10 @@ def _enrich_action_context(
                 if post_info:
                     action_args['post_content'] = post_info.get('content', '')
                     action_args['post_author_name'] = post_info.get('author_name', '')
-    
+
     except Exception as e:
-        # 补充上下文失败不影响主流程
-        print(f"补充动作上下文失败: {e}")
+        # Failure to enrich context must not break the main flow
+        print(f"Failed to enrich action context: {e}")
 
 
 def _get_post_info(
@@ -860,15 +866,15 @@ def _get_post_info(
     agent_names: Dict[int, str]
 ) -> Optional[Dict[str, str]]:
     """
-    获取帖子信息
-    
+    Get post info.
+
     Args:
-        cursor: 数据库游标
-        post_id: 帖子ID
-        agent_names: agent_id -> agent_name 映射
-        
+        cursor: database cursor
+        post_id: post ID
+        agent_names: agent_id -> agent_name map
+
     Returns:
-        包含 content 和 author_name 的字典，或 None
+        Dict with content and author_name, or None
     """
     try:
         cursor.execute("""
@@ -882,18 +888,18 @@ def _get_post_info(
             content = row[0] or ''
             user_id = row[1]
             agent_id = row[2]
-            
-            # 优先使用 agent_names 中的名称
+
+            # Prefer the name from agent_names
             author_name = ''
             if agent_id is not None and agent_id in agent_names:
                 author_name = agent_names[agent_id]
             elif user_id:
-                # 从 user 表获取名称
+                # Read the name from the user table
                 cursor.execute("SELECT name, user_name FROM user WHERE user_id = ?", (user_id,))
                 user_row = cursor.fetchone()
                 if user_row:
                     author_name = user_row[0] or user_row[1] or ''
-            
+
             return {'content': content, 'author_name': author_name}
     except Exception:
         pass
@@ -906,15 +912,15 @@ def _get_user_name(
     agent_names: Dict[int, str]
 ) -> Optional[str]:
     """
-    获取用户名称
-    
+    Get a user's name.
+
     Args:
-        cursor: 数据库游标
-        user_id: 用户ID
-        agent_names: agent_id -> agent_name 映射
-        
+        cursor: database cursor
+        user_id: user ID
+        agent_names: agent_id -> agent_name map
+
     Returns:
-        用户名称，或 None
+        User name, or None
     """
     try:
         cursor.execute("""
@@ -925,8 +931,8 @@ def _get_user_name(
             agent_id = row[0]
             name = row[1]
             user_name = row[2]
-            
-            # 优先使用 agent_names 中的名称
+
+            # Prefer the name from agent_names
             if agent_id is not None and agent_id in agent_names:
                 return agent_names[agent_id]
             return name or user_name or ''
@@ -941,15 +947,15 @@ def _get_comment_info(
     agent_names: Dict[int, str]
 ) -> Optional[Dict[str, str]]:
     """
-    获取评论信息
-    
+    Get comment info.
+
     Args:
-        cursor: 数据库游标
-        comment_id: 评论ID
-        agent_names: agent_id -> agent_name 映射
-        
+        cursor: database cursor
+        comment_id: comment ID
+        agent_names: agent_id -> agent_name map
+
     Returns:
-        包含 content 和 author_name 的字典，或 None
+        Dict with content and author_name, or None
     """
     try:
         cursor.execute("""
@@ -963,18 +969,18 @@ def _get_comment_info(
             content = row[0] or ''
             user_id = row[1]
             agent_id = row[2]
-            
-            # 优先使用 agent_names 中的名称
+
+            # Prefer the name from agent_names
             author_name = ''
             if agent_id is not None and agent_id in agent_names:
                 author_name = agent_names[agent_id]
             elif user_id:
-                # 从 user 表获取名称
+                # Read the name from the user table
                 cursor.execute("SELECT name, user_name FROM user WHERE user_id = ?", (user_id,))
                 user_row = cursor.fetchone()
                 if user_row:
                     author_name = user_row[0] or user_row[1] or ''
-            
+
             return {'content': content, 'author_name': author_name}
     except Exception:
         pass
@@ -983,54 +989,55 @@ def _get_comment_info(
 
 def create_model(config: Dict[str, Any], use_boost: bool = False):
     """
-    创建LLM模型
-    
-    支持双 LLM 配置，用于并行模拟时提速：
-    - 通用配置：LLM_API_KEY, LLM_BASE_URL, LLM_MODEL_NAME
-    - 加速配置（可选）：LLM_BOOST_API_KEY, LLM_BOOST_BASE_URL, LLM_BOOST_MODEL_NAME
-    
-    如果配置了加速 LLM，并行模拟时可以让不同平台使用不同的 API 服务商，提高并发能力。
-    
+    Create the LLM model.
+
+    Supports a dual LLM configuration to speed up parallel simulations:
+    - Standard config: LLM_API_KEY, LLM_BASE_URL, LLM_MODEL_NAME
+    - Boost config (optional): LLM_BOOST_API_KEY, LLM_BOOST_BASE_URL, LLM_BOOST_MODEL_NAME
+
+    When the boost LLM is configured, parallel simulations can route different platforms
+    to different API providers, increasing concurrent throughput.
+
     Args:
-        config: 模拟配置字典
-        use_boost: 是否使用加速 LLM 配置（如果可用）
+        config: simulation config dict
+        use_boost: whether to use the boost LLM config (if available)
     """
-    # 检查是否有加速配置
+    # Check whether a boost config exists
     boost_api_key = os.environ.get("LLM_BOOST_API_KEY", "")
     boost_base_url = os.environ.get("LLM_BOOST_BASE_URL", "")
     boost_model = os.environ.get("LLM_BOOST_MODEL_NAME", "")
     has_boost_config = bool(boost_api_key)
-    
-    # 根据参数和配置情况选择使用哪个 LLM
+
+    # Choose which LLM to use based on the flag and the available configs
     if use_boost and has_boost_config:
-        # 使用加速配置
+        # Use the boost config
         llm_api_key = boost_api_key
         llm_base_url = boost_base_url
         llm_model = boost_model or os.environ.get("LLM_MODEL_NAME", "")
-        config_label = "[加速LLM]"
+        config_label = "[Boost LLM]"
     else:
-        # 使用通用配置
+        # Use the standard config
         llm_api_key = os.environ.get("LLM_API_KEY", "")
         llm_base_url = os.environ.get("LLM_BASE_URL", "")
         llm_model = os.environ.get("LLM_MODEL_NAME", "")
-        config_label = "[通用LLM]"
-    
-    # 如果 .env 中没有模型名，则使用 config 作为备用
+        config_label = "[Standard LLM]"
+
+    # If .env did not provide a model name, fall back to the config
     if not llm_model:
         llm_model = config.get("llm_model", "gpt-4o-mini")
-    
-    # 设置 camel-ai 所需的环境变量
+
+    # Set the environment variables required by camel-ai
     if llm_api_key:
         os.environ["OPENAI_API_KEY"] = llm_api_key
-    
+
     if not os.environ.get("OPENAI_API_KEY"):
-        raise ValueError("缺少 API Key 配置，请在项目根目录 .env 文件中设置 LLM_API_KEY")
-    
+        raise ValueError("Missing API Key configuration; please set LLM_API_KEY in the project root .env file")
+
     if llm_base_url:
         os.environ["OPENAI_API_BASE_URL"] = llm_base_url
-    
-    print(f"{config_label} model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else '默认'}...")
-    
+
+    print(f"{config_label} model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else 'default'}...")
+
     return ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
         model_type=llm_model,
@@ -1043,42 +1050,42 @@ def get_active_agents_for_round(
     current_hour: int,
     round_num: int
 ) -> List:
-    """根据时间和配置决定本轮激活哪些Agent"""
+    """Decide which Agents to activate this round based on time and config"""
     time_config = config.get("time_config", {})
     agent_configs = config.get("agent_configs", [])
-    
+
     base_min = time_config.get("agents_per_hour_min", 5)
     base_max = time_config.get("agents_per_hour_max", 20)
-    
+
     peak_hours = time_config.get("peak_hours", [9, 10, 11, 14, 15, 20, 21, 22])
     off_peak_hours = time_config.get("off_peak_hours", [0, 1, 2, 3, 4, 5])
-    
+
     if current_hour in peak_hours:
         multiplier = time_config.get("peak_activity_multiplier", 1.5)
     elif current_hour in off_peak_hours:
         multiplier = time_config.get("off_peak_activity_multiplier", 0.3)
     else:
         multiplier = 1.0
-    
+
     target_count = int(random.uniform(base_min, base_max) * multiplier)
-    
+
     candidates = []
     for cfg in agent_configs:
         agent_id = cfg.get("agent_id", 0)
         active_hours = cfg.get("active_hours", list(range(8, 23)))
         activity_level = cfg.get("activity_level", 0.5)
-        
+
         if current_hour not in active_hours:
             continue
-        
+
         if random.random() < activity_level:
             candidates.append(agent_id)
-    
+
     selected_ids = random.sample(
-        candidates, 
+        candidates,
         min(target_count, len(candidates))
     ) if candidates else []
-    
+
     active_agents = []
     for agent_id in selected_ids:
         try:
@@ -1086,12 +1093,12 @@ def get_active_agents_for_round(
             active_agents.append((agent_id, agent))
         except Exception:
             pass
-    
+
     return active_agents
 
 
 class PlatformSimulation:
-    """平台模拟结果容器"""
+    """Container for platform simulation results"""
     def __init__(self):
         self.env = None
         self.agent_graph = None
@@ -1099,83 +1106,83 @@ class PlatformSimulation:
 
 
 async def run_twitter_simulation(
-    config: Dict[str, Any], 
+    config: Dict[str, Any],
     simulation_dir: str,
     action_logger: Optional[PlatformActionLogger] = None,
     main_logger: Optional[SimulationLogManager] = None,
     max_rounds: Optional[int] = None
 ) -> PlatformSimulation:
-    """运行Twitter模拟
-    
+    """Run the Twitter simulation
+
     Args:
-        config: 模拟配置
-        simulation_dir: 模拟目录
-        action_logger: 动作日志记录器
-        main_logger: 主日志管理器
-        max_rounds: 最大模拟轮数（可选，用于截断过长的模拟）
-        
+        config: simulation config
+        simulation_dir: simulation directory
+        action_logger: action logger
+        main_logger: main log manager
+        max_rounds: maximum simulation rounds (optional, used to truncate overly long runs)
+
     Returns:
-        PlatformSimulation: 包含env和agent_graph的结果对象
+        PlatformSimulation: result object containing env and agent_graph
     """
     result = PlatformSimulation()
-    
+
     def log_info(msg):
         if main_logger:
             main_logger.info(f"[Twitter] {msg}")
         print(f"[Twitter] {msg}")
-    
-    log_info("初始化...")
-    
-    # Twitter 使用通用 LLM 配置
+
+    log_info("Initializing...")
+
+    # Twitter uses the standard LLM config
     model = create_model(config, use_boost=False)
-    
-    # OASIS Twitter使用CSV格式
+
+    # OASIS Twitter uses CSV format
     profile_path = os.path.join(simulation_dir, "twitter_profiles.csv")
     if not os.path.exists(profile_path):
-        log_info(f"错误: Profile文件不存在: {profile_path}")
+        log_info(f"Error: profile file does not exist: {profile_path}")
         return result
-    
+
     result.agent_graph = await generate_twitter_agent_graph(
         profile_path=profile_path,
         model=model,
         available_actions=TWITTER_ACTIONS,
     )
-    
-    # 从配置文件获取 Agent 真实名称映射（使用 entity_name 而非默认的 Agent_X）
+
+    # Build agent_id -> real name map from the config (uses entity_name instead of the default Agent_X)
     agent_names = get_agent_names_from_config(config)
-    # 如果配置中没有某个 agent，则使用 OASIS 的默认名称
+    # If the config doesn't include a given agent, fall back to OASIS's default name
     for agent_id, agent in result.agent_graph.get_agents():
         if agent_id not in agent_names:
             agent_names[agent_id] = getattr(agent, 'name', f'Agent_{agent_id}')
-    
+
     db_path = os.path.join(simulation_dir, "twitter_simulation.db")
     if os.path.exists(db_path):
         os.remove(db_path)
-    
+
     result.env = oasis.make(
         agent_graph=result.agent_graph,
         platform=oasis.DefaultPlatformType.TWITTER,
         database_path=db_path,
-        semaphore=30,  # 限制最大并发 LLM 请求数，防止 API 过载
+        semaphore=30,  # Cap concurrent LLM requests to avoid overloading the API
     )
-    
+
     await result.env.reset()
-    log_info("环境已启动")
-    
+    log_info("Environment started")
+
     if action_logger:
         action_logger.log_simulation_start(config)
-    
+
     total_actions = 0
-    last_rowid = 0  # 跟踪数据库中最后处理的行号（使用 rowid 避免 created_at 格式差异）
-    
-    # 执行初始事件
+    last_rowid = 0  # Track the last processed row in the database (use rowid to avoid created_at format differences)
+
+    # Run initial events
     event_config = config.get("event_config", {})
     initial_posts = event_config.get("initial_posts", [])
-    
-    # 记录 round 0 开始（初始事件阶段）
+
+    # Record start of round 0 (initial-events phase)
     if action_logger:
         action_logger.log_round_start(0, 0)  # round 0, simulated_hour 0
-    
+
     initial_action_count = 0
     if initial_posts:
         initial_actions = {}
@@ -1188,7 +1195,7 @@ async def run_twitter_simulation(
                     action_type=ActionType.CREATE_POST,
                     action_args={"content": content}
                 )
-                
+
                 if action_logger:
                     action_logger.log_action(
                         round_num=0,
@@ -1201,63 +1208,63 @@ async def run_twitter_simulation(
                     initial_action_count += 1
             except Exception:
                 pass
-        
+
         if initial_actions:
             await result.env.step(initial_actions)
-            log_info(f"已发布 {len(initial_actions)} 条初始帖子")
-    
-    # 记录 round 0 结束
+            log_info(f"Published {len(initial_actions)} initial posts")
+
+    # Record end of round 0
     if action_logger:
         action_logger.log_round_end(0, initial_action_count)
-    
-    # 主模拟循环
+
+    # Main simulation loop
     time_config = config.get("time_config", {})
     total_hours = time_config.get("total_simulation_hours", 72)
     minutes_per_round = time_config.get("minutes_per_round", 30)
     total_rounds = (total_hours * 60) // minutes_per_round
-    
-    # 如果指定了最大轮数，则截断
+
+    # If max_rounds specified, truncate
     if max_rounds is not None and max_rounds > 0:
         original_rounds = total_rounds
         total_rounds = min(total_rounds, max_rounds)
         if total_rounds < original_rounds:
-            log_info(f"轮数已截断: {original_rounds} -> {total_rounds} (max_rounds={max_rounds})")
-    
+            log_info(f"Round count truncated: {original_rounds} -> {total_rounds} (max_rounds={max_rounds})")
+
     start_time = datetime.now()
-    
+
     for round_num in range(total_rounds):
-        # 检查是否收到退出信号
+        # Check for shutdown signal
         if _shutdown_event and _shutdown_event.is_set():
             if main_logger:
-                main_logger.info(f"收到退出信号，在第 {round_num + 1} 轮停止模拟")
+                main_logger.info(f"Received shutdown signal; stopping simulation at round {round_num + 1}")
             break
-        
+
         simulated_minutes = round_num * minutes_per_round
         simulated_hour = (simulated_minutes // 60) % 24
         simulated_day = simulated_minutes // (60 * 24) + 1
-        
+
         active_agents = get_active_agents_for_round(
             result.env, config, simulated_hour, round_num
         )
-        
-        # 无论是否有活跃agent，都记录round开始
+
+        # Record round start regardless of whether there are active agents
         if action_logger:
             action_logger.log_round_start(round_num + 1, simulated_hour)
-        
+
         if not active_agents:
-            # 没有活跃agent时也记录round结束（actions_count=0）
+            # When there are no active agents, still record round end (actions_count=0)
             if action_logger:
                 action_logger.log_round_end(round_num + 1, 0)
             continue
-        
+
         actions = {agent: LLMAction() for _, agent in active_agents}
         await result.env.step(actions)
-        
-        # 从数据库获取实际执行的动作并记录
+
+        # Read the actions actually executed from the database and record them
         actual_actions, last_rowid = fetch_new_actions_from_db(
             db_path, last_rowid, agent_names
         )
-        
+
         round_action_count = 0
         for action_data in actual_actions:
             if action_logger:
@@ -1270,103 +1277,103 @@ async def run_twitter_simulation(
                 )
                 total_actions += 1
                 round_action_count += 1
-        
+
         if action_logger:
             action_logger.log_round_end(round_num + 1, round_action_count)
-        
+
         if (round_num + 1) % 20 == 0:
             progress = (round_num + 1) / total_rounds * 100
             log_info(f"Day {simulated_day}, {simulated_hour:02d}:00 - Round {round_num + 1}/{total_rounds} ({progress:.1f}%)")
-    
-    # 注意：不关闭环境，保留给Interview使用
-    
+
+    # Note: do not close the environment; keep it alive for Interview use
+
     if action_logger:
         action_logger.log_simulation_end(total_rounds, total_actions)
-    
+
     result.total_actions = total_actions
     elapsed = (datetime.now() - start_time).total_seconds()
-    log_info(f"模拟循环完成! 耗时: {elapsed:.1f}秒, 总动作: {total_actions}")
-    
+    log_info(f"Simulation loop complete! Elapsed: {elapsed:.1f}s, total actions: {total_actions}")
+
     return result
 
 
 async def run_reddit_simulation(
-    config: Dict[str, Any], 
+    config: Dict[str, Any],
     simulation_dir: str,
     action_logger: Optional[PlatformActionLogger] = None,
     main_logger: Optional[SimulationLogManager] = None,
     max_rounds: Optional[int] = None
 ) -> PlatformSimulation:
-    """运行Reddit模拟
-    
+    """Run the Reddit simulation
+
     Args:
-        config: 模拟配置
-        simulation_dir: 模拟目录
-        action_logger: 动作日志记录器
-        main_logger: 主日志管理器
-        max_rounds: 最大模拟轮数（可选，用于截断过长的模拟）
-        
+        config: simulation config
+        simulation_dir: simulation directory
+        action_logger: action logger
+        main_logger: main log manager
+        max_rounds: maximum simulation rounds (optional, used to truncate overly long runs)
+
     Returns:
-        PlatformSimulation: 包含env和agent_graph的结果对象
+        PlatformSimulation: result object containing env and agent_graph
     """
     result = PlatformSimulation()
-    
+
     def log_info(msg):
         if main_logger:
             main_logger.info(f"[Reddit] {msg}")
         print(f"[Reddit] {msg}")
-    
-    log_info("初始化...")
-    
-    # Reddit 使用加速 LLM 配置（如果有的话，否则回退到通用配置）
+
+    log_info("Initializing...")
+
+    # Reddit uses the boost LLM config (if available; otherwise falls back to the standard config)
     model = create_model(config, use_boost=True)
-    
+
     profile_path = os.path.join(simulation_dir, "reddit_profiles.json")
     if not os.path.exists(profile_path):
-        log_info(f"错误: Profile文件不存在: {profile_path}")
+        log_info(f"Error: profile file does not exist: {profile_path}")
         return result
-    
+
     result.agent_graph = await generate_reddit_agent_graph(
         profile_path=profile_path,
         model=model,
         available_actions=REDDIT_ACTIONS,
     )
-    
-    # 从配置文件获取 Agent 真实名称映射（使用 entity_name 而非默认的 Agent_X）
+
+    # Build agent_id -> real name map from the config (uses entity_name instead of the default Agent_X)
     agent_names = get_agent_names_from_config(config)
-    # 如果配置中没有某个 agent，则使用 OASIS 的默认名称
+    # If the config doesn't include a given agent, fall back to OASIS's default name
     for agent_id, agent in result.agent_graph.get_agents():
         if agent_id not in agent_names:
             agent_names[agent_id] = getattr(agent, 'name', f'Agent_{agent_id}')
-    
+
     db_path = os.path.join(simulation_dir, "reddit_simulation.db")
     if os.path.exists(db_path):
         os.remove(db_path)
-    
+
     result.env = oasis.make(
         agent_graph=result.agent_graph,
         platform=oasis.DefaultPlatformType.REDDIT,
         database_path=db_path,
-        semaphore=30,  # 限制最大并发 LLM 请求数，防止 API 过载
+        semaphore=30,  # Cap concurrent LLM requests to avoid overloading the API
     )
-    
+
     await result.env.reset()
-    log_info("环境已启动")
-    
+    log_info("Environment started")
+
     if action_logger:
         action_logger.log_simulation_start(config)
-    
+
     total_actions = 0
-    last_rowid = 0  # 跟踪数据库中最后处理的行号（使用 rowid 避免 created_at 格式差异）
-    
-    # 执行初始事件
+    last_rowid = 0  # Track the last processed row in the database (use rowid to avoid created_at format differences)
+
+    # Run initial events
     event_config = config.get("event_config", {})
     initial_posts = event_config.get("initial_posts", [])
-    
-    # 记录 round 0 开始（初始事件阶段）
+
+    # Record start of round 0 (initial-events phase)
     if action_logger:
         action_logger.log_round_start(0, 0)  # round 0, simulated_hour 0
-    
+
     initial_action_count = 0
     if initial_posts:
         initial_actions = {}
@@ -1387,7 +1394,7 @@ async def run_reddit_simulation(
                         action_type=ActionType.CREATE_POST,
                         action_args={"content": content}
                     )
-                
+
                 if action_logger:
                     action_logger.log_action(
                         round_num=0,
@@ -1400,63 +1407,63 @@ async def run_reddit_simulation(
                     initial_action_count += 1
             except Exception:
                 pass
-        
+
         if initial_actions:
             await result.env.step(initial_actions)
-            log_info(f"已发布 {len(initial_actions)} 条初始帖子")
-    
-    # 记录 round 0 结束
+            log_info(f"Published {len(initial_actions)} initial posts")
+
+    # Record end of round 0
     if action_logger:
         action_logger.log_round_end(0, initial_action_count)
-    
-    # 主模拟循环
+
+    # Main simulation loop
     time_config = config.get("time_config", {})
     total_hours = time_config.get("total_simulation_hours", 72)
     minutes_per_round = time_config.get("minutes_per_round", 30)
     total_rounds = (total_hours * 60) // minutes_per_round
-    
-    # 如果指定了最大轮数，则截断
+
+    # If max_rounds specified, truncate
     if max_rounds is not None and max_rounds > 0:
         original_rounds = total_rounds
         total_rounds = min(total_rounds, max_rounds)
         if total_rounds < original_rounds:
-            log_info(f"轮数已截断: {original_rounds} -> {total_rounds} (max_rounds={max_rounds})")
-    
+            log_info(f"Round count truncated: {original_rounds} -> {total_rounds} (max_rounds={max_rounds})")
+
     start_time = datetime.now()
-    
+
     for round_num in range(total_rounds):
-        # 检查是否收到退出信号
+        # Check for shutdown signal
         if _shutdown_event and _shutdown_event.is_set():
             if main_logger:
-                main_logger.info(f"收到退出信号，在第 {round_num + 1} 轮停止模拟")
+                main_logger.info(f"Received shutdown signal; stopping simulation at round {round_num + 1}")
             break
-        
+
         simulated_minutes = round_num * minutes_per_round
         simulated_hour = (simulated_minutes // 60) % 24
         simulated_day = simulated_minutes // (60 * 24) + 1
-        
+
         active_agents = get_active_agents_for_round(
             result.env, config, simulated_hour, round_num
         )
-        
-        # 无论是否有活跃agent，都记录round开始
+
+        # Record round start regardless of whether there are active agents
         if action_logger:
             action_logger.log_round_start(round_num + 1, simulated_hour)
-        
+
         if not active_agents:
-            # 没有活跃agent时也记录round结束（actions_count=0）
+            # When there are no active agents, still record round end (actions_count=0)
             if action_logger:
                 action_logger.log_round_end(round_num + 1, 0)
             continue
-        
+
         actions = {agent: LLMAction() for _, agent in active_agents}
         await result.env.step(actions)
-        
-        # 从数据库获取实际执行的动作并记录
+
+        # Read the actions actually executed from the database and record them
         actual_actions, last_rowid = fetch_new_actions_from_db(
             db_path, last_rowid, agent_names
         )
-        
+
         round_action_count = 0
         for action_data in actual_actions:
             if action_logger:
@@ -1469,138 +1476,138 @@ async def run_reddit_simulation(
                 )
                 total_actions += 1
                 round_action_count += 1
-        
+
         if action_logger:
             action_logger.log_round_end(round_num + 1, round_action_count)
-        
+
         if (round_num + 1) % 20 == 0:
             progress = (round_num + 1) / total_rounds * 100
             log_info(f"Day {simulated_day}, {simulated_hour:02d}:00 - Round {round_num + 1}/{total_rounds} ({progress:.1f}%)")
-    
-    # 注意：不关闭环境，保留给Interview使用
-    
+
+    # Note: do not close the environment; keep it alive for Interview use
+
     if action_logger:
         action_logger.log_simulation_end(total_rounds, total_actions)
-    
+
     result.total_actions = total_actions
     elapsed = (datetime.now() - start_time).total_seconds()
-    log_info(f"模拟循环完成! 耗时: {elapsed:.1f}秒, 总动作: {total_actions}")
-    
+    log_info(f"Simulation loop complete! Elapsed: {elapsed:.1f}s, total actions: {total_actions}")
+
     return result
 
 
 async def main():
-    parser = argparse.ArgumentParser(description='OASIS双平台并行模拟')
+    parser = argparse.ArgumentParser(description='OASIS dual-platform parallel simulation')
     parser.add_argument(
-        '--config', 
-        type=str, 
+        '--config',
+        type=str,
         required=True,
-        help='配置文件路径 (simulation_config.json)'
+        help='Path to config file (simulation_config.json)'
     )
     parser.add_argument(
         '--twitter-only',
         action='store_true',
-        help='只运行Twitter模拟'
+        help='Run only the Twitter simulation'
     )
     parser.add_argument(
         '--reddit-only',
         action='store_true',
-        help='只运行Reddit模拟'
+        help='Run only the Reddit simulation'
     )
     parser.add_argument(
         '--max-rounds',
         type=int,
         default=None,
-        help='最大模拟轮数（可选，用于截断过长的模拟）'
+        help='Maximum simulation rounds (optional, used to truncate overly long runs)'
     )
     parser.add_argument(
         '--no-wait',
         action='store_true',
         default=False,
-        help='模拟完成后立即关闭环境，不进入等待命令模式'
+        help='Close the environment immediately after simulation; do not enter command-wait mode'
     )
-    
+
     args = parser.parse_args()
-    
-    # 在 main 函数开始时创建 shutdown 事件，确保整个程序都能响应退出信号
+
+    # Create the shutdown event at the start of main so the entire program can respond to shutdown signals
     global _shutdown_event
     _shutdown_event = asyncio.Event()
-    
+
     if not os.path.exists(args.config):
-        print(f"错误: 配置文件不存在: {args.config}")
+        print(f"Error: config file does not exist: {args.config}")
         sys.exit(1)
-    
+
     config = load_config(args.config)
     simulation_dir = os.path.dirname(args.config) or "."
     wait_for_commands = not args.no_wait
-    
-    # 初始化日志配置（禁用 OASIS 日志，清理旧文件）
+
+    # Initialize logging (disable OASIS logs, clean up old files)
     init_logging_for_simulation(simulation_dir)
-    
-    # 创建日志管理器
+
+    # Create the log manager
     log_manager = SimulationLogManager(simulation_dir)
     twitter_logger = log_manager.get_twitter_logger()
     reddit_logger = log_manager.get_reddit_logger()
-    
+
     log_manager.info("=" * 60)
-    log_manager.info("OASIS 双平台并行模拟")
-    log_manager.info(f"配置文件: {args.config}")
-    log_manager.info(f"模拟ID: {config.get('simulation_id', 'unknown')}")
-    log_manager.info(f"等待命令模式: {'启用' if wait_for_commands else '禁用'}")
+    log_manager.info("OASIS dual-platform parallel simulation")
+    log_manager.info(f"Config file: {args.config}")
+    log_manager.info(f"Simulation ID: {config.get('simulation_id', 'unknown')}")
+    log_manager.info(f"Command-wait mode: {'enabled' if wait_for_commands else 'disabled'}")
     log_manager.info("=" * 60)
-    
+
     time_config = config.get("time_config", {})
     total_hours = time_config.get('total_simulation_hours', 72)
     minutes_per_round = time_config.get('minutes_per_round', 30)
     config_total_rounds = (total_hours * 60) // minutes_per_round
-    
-    log_manager.info(f"模拟参数:")
-    log_manager.info(f"  - 总模拟时长: {total_hours}小时")
-    log_manager.info(f"  - 每轮时间: {minutes_per_round}分钟")
-    log_manager.info(f"  - 配置总轮数: {config_total_rounds}")
+
+    log_manager.info(f"Simulation parameters:")
+    log_manager.info(f"  - Total simulated duration: {total_hours} hours")
+    log_manager.info(f"  - Time per round: {minutes_per_round} minutes")
+    log_manager.info(f"  - Configured total rounds: {config_total_rounds}")
     if args.max_rounds:
-        log_manager.info(f"  - 最大轮数限制: {args.max_rounds}")
+        log_manager.info(f"  - Max-rounds limit: {args.max_rounds}")
         if args.max_rounds < config_total_rounds:
-            log_manager.info(f"  - 实际执行轮数: {args.max_rounds} (已截断)")
-    log_manager.info(f"  - Agent数量: {len(config.get('agent_configs', []))}")
-    
-    log_manager.info("日志结构:")
-    log_manager.info(f"  - 主日志: simulation.log")
-    log_manager.info(f"  - Twitter动作: twitter/actions.jsonl")
-    log_manager.info(f"  - Reddit动作: reddit/actions.jsonl")
+            log_manager.info(f"  - Actual rounds to run: {args.max_rounds} (truncated)")
+    log_manager.info(f"  - Agent count: {len(config.get('agent_configs', []))}")
+
+    log_manager.info("Log structure:")
+    log_manager.info(f"  - Main log: simulation.log")
+    log_manager.info(f"  - Twitter actions: twitter/actions.jsonl")
+    log_manager.info(f"  - Reddit actions: reddit/actions.jsonl")
     log_manager.info("=" * 60)
-    
+
     start_time = datetime.now()
-    
-    # 存储两个平台的模拟结果
+
+    # Hold both platforms' simulation results
     twitter_result: Optional[PlatformSimulation] = None
     reddit_result: Optional[PlatformSimulation] = None
-    
+
     if args.twitter_only:
         twitter_result = await run_twitter_simulation(config, simulation_dir, twitter_logger, log_manager, args.max_rounds)
     elif args.reddit_only:
         reddit_result = await run_reddit_simulation(config, simulation_dir, reddit_logger, log_manager, args.max_rounds)
     else:
-        # 并行运行（每个平台使用独立的日志记录器）
+        # Run in parallel (each platform uses its own logger)
         results = await asyncio.gather(
             run_twitter_simulation(config, simulation_dir, twitter_logger, log_manager, args.max_rounds),
             run_reddit_simulation(config, simulation_dir, reddit_logger, log_manager, args.max_rounds),
         )
         twitter_result, reddit_result = results
-    
+
     total_elapsed = (datetime.now() - start_time).total_seconds()
     log_manager.info("=" * 60)
-    log_manager.info(f"模拟循环完成! 总耗时: {total_elapsed:.1f}秒")
-    
-    # 是否进入等待命令模式
+    log_manager.info(f"Simulation loop complete! Total elapsed: {total_elapsed:.1f}s")
+
+    # Whether to enter command-wait mode
     if wait_for_commands:
         log_manager.info("")
         log_manager.info("=" * 60)
-        log_manager.info("进入等待命令模式 - 环境保持运行")
-        log_manager.info("支持的命令: interview, batch_interview, close_env")
+        log_manager.info("Entering command-wait mode - environment stays running")
+        log_manager.info("Supported commands: interview, batch_interview, close_env")
         log_manager.info("=" * 60)
-        
-        # 创建IPC处理器
+
+        # Create the IPC handler
         ipc_handler = ParallelIPCHandler(
             simulation_dir=simulation_dir,
             twitter_env=twitter_result.env if twitter_result else None,
@@ -1609,41 +1616,41 @@ async def main():
             reddit_agent_graph=reddit_result.agent_graph if reddit_result else None
         )
         ipc_handler.update_status("alive")
-        
-        # 等待命令循环（使用全局 _shutdown_event）
+
+        # Command-wait loop (uses the global _shutdown_event)
         try:
             while not _shutdown_event.is_set():
                 should_continue = await ipc_handler.process_commands()
                 if not should_continue:
                     break
-                # 使用 wait_for 替代 sleep，这样可以响应 shutdown_event
+                # Use wait_for instead of sleep so we can react to shutdown_event
                 try:
                     await asyncio.wait_for(_shutdown_event.wait(), timeout=0.5)
-                    break  # 收到退出信号
+                    break  # received shutdown signal
                 except asyncio.TimeoutError:
-                    pass  # 超时继续循环
+                    pass  # timed out, continue the loop
         except KeyboardInterrupt:
-            print("\n收到中断信号")
+            print("\nReceived interrupt signal")
         except asyncio.CancelledError:
-            print("\n任务被取消")
+            print("\nTask was cancelled")
         except Exception as e:
-            print(f"\n命令处理出错: {e}")
-        
-        log_manager.info("\n关闭环境...")
+            print(f"\nCommand processing error: {e}")
+
+        log_manager.info("\nClosing environment...")
         ipc_handler.update_status("stopped")
-    
-    # 关闭环境
+
+    # Close the environment
     if twitter_result and twitter_result.env:
         await twitter_result.env.close()
-        log_manager.info("[Twitter] 环境已关闭")
-    
+        log_manager.info("[Twitter] Environment closed")
+
     if reddit_result and reddit_result.env:
         await reddit_result.env.close()
-        log_manager.info("[Reddit] 环境已关闭")
-    
+        log_manager.info("[Reddit] Environment closed")
+
     log_manager.info("=" * 60)
-    log_manager.info(f"全部完成!")
-    log_manager.info(f"日志文件:")
+    log_manager.info(f"All done!")
+    log_manager.info(f"Log files:")
     log_manager.info(f"  - {os.path.join(simulation_dir, 'simulation.log')}")
     log_manager.info(f"  - {os.path.join(simulation_dir, 'twitter', 'actions.jsonl')}")
     log_manager.info(f"  - {os.path.join(simulation_dir, 'reddit', 'actions.jsonl')}")
@@ -1652,31 +1659,31 @@ async def main():
 
 def setup_signal_handlers(loop=None):
     """
-    设置信号处理器，确保收到 SIGTERM/SIGINT 时能够正确退出
-    
-    持久化模拟场景：模拟完成后不退出，等待 interview 命令
-    当收到终止信号时，需要：
-    1. 通知 asyncio 循环退出等待
-    2. 让程序有机会正常清理资源（关闭数据库、环境等）
-    3. 然后才退出
+    Set up signal handlers so SIGTERM/SIGINT cause an orderly shutdown.
+
+    Persistent simulation scenario: after the simulation completes the process does not
+    exit, but waits for interview commands. When a termination signal arrives, we need to:
+    1. Notify the asyncio loop to stop waiting
+    2. Give the program a chance to clean up resources (close database, environment, etc.)
+    3. Then exit
     """
     def signal_handler(signum, frame):
         global _cleanup_done
         sig_name = "SIGTERM" if signum == signal.SIGTERM else "SIGINT"
-        print(f"\n收到 {sig_name} 信号，正在退出...")
-        
+        print(f"\nReceived {sig_name} signal, shutting down...")
+
         if not _cleanup_done:
             _cleanup_done = True
-            # 设置事件通知 asyncio 循环退出（让循环有机会清理资源）
+            # Set the event to notify the asyncio loop to exit (so it can clean up resources)
             if _shutdown_event:
                 _shutdown_event.set()
-        
-        # 不要直接 sys.exit()，让 asyncio 循环正常退出并清理资源
-        # 如果是重复收到信号，才强制退出
+
+        # Do not call sys.exit() directly; let the asyncio loop exit normally and clean up resources.
+        # Only force-exit if the signal repeats.
         else:
-            print("强制退出...")
+            print("Forcing exit...")
             sys.exit(1)
-    
+
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
 
@@ -1686,14 +1693,14 @@ if __name__ == "__main__":
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
-        print("\n程序被中断")
+        print("\nProgram interrupted")
     except SystemExit:
         pass
     finally:
-        # 清理 multiprocessing 资源跟踪器（防止退出时的警告）
+        # Clean up the multiprocessing resource tracker (avoids warnings on exit)
         try:
             from multiprocessing import resource_tracker
             resource_tracker._resource_tracker._stop()
         except Exception:
             pass
-        print("模拟进程已退出")
+        print("Simulation process exited")

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -1,16 +1,17 @@
 """
-OASIS Reddit模拟预设脚本
-此脚本读取配置文件中的参数来执行模拟，实现全程自动化
+OASIS Reddit simulation preset script.
+This script reads parameters from a config file and runs a fully-automated simulation.
 
-功能特性:
-- 完成模拟后不立即关闭环境，进入等待命令模式
-- 支持通过IPC接收Interview命令
-- 支持单个Agent采访和批量采访
-- 支持远程关闭环境命令
+Features:
+- Does not immediately close the environment after the simulation completes; enters
+  command-wait mode instead.
+- Accepts Interview commands over IPC.
+- Supports single-Agent interviews and batch interviews.
+- Supports remote close-environment commands.
 
-使用方式:
+Usage:
     python run_reddit_simulation.py --config /path/to/simulation_config.json
-    python run_reddit_simulation.py --config /path/to/simulation_config.json --no-wait  # 完成后立即关闭
+    python run_reddit_simulation.py --config /path/to/simulation_config.json --no-wait  # close immediately on completion
 """
 
 import argparse
@@ -25,18 +26,18 @@ import sqlite3
 from datetime import datetime
 from typing import Dict, Any, List, Optional
 
-# 全局变量：用于信号处理
+# Global variable: used by the signal handler
 _shutdown_event = None
 _cleanup_done = False
 
-# 添加项目路径
+# Add project paths
 _scripts_dir = os.path.dirname(os.path.abspath(__file__))
 _backend_dir = os.path.abspath(os.path.join(_scripts_dir, '..'))
 _project_root = os.path.abspath(os.path.join(_backend_dir, '..'))
 sys.path.insert(0, _scripts_dir)
 sys.path.insert(0, _backend_dir)
 
-# 加载项目根目录的 .env 文件（包含 LLM_API_KEY 等配置）
+# Load the project root .env file (contains LLM_API_KEY and other config)
 from dotenv import load_dotenv
 _env_file = os.path.join(_project_root, '.env')
 if os.path.exists(_env_file):
@@ -51,41 +52,41 @@ import re
 
 
 class UnicodeFormatter(logging.Formatter):
-    """自定义格式化器，将 Unicode 转义序列转换为可读字符"""
-    
+    """Custom formatter that converts Unicode escape sequences into readable characters"""
+
     UNICODE_ESCAPE_PATTERN = re.compile(r'\\u([0-9a-fA-F]{4})')
-    
+
     def format(self, record):
         result = super().format(record)
-        
+
         def replace_unicode(match):
             try:
                 return chr(int(match.group(1), 16))
             except (ValueError, OverflowError):
                 return match.group(0)
-        
+
         return self.UNICODE_ESCAPE_PATTERN.sub(replace_unicode, result)
 
 
 class MaxTokensWarningFilter(logging.Filter):
-    """过滤掉 camel-ai 关于 max_tokens 的警告（我们故意不设置 max_tokens，让模型自行决定）"""
-    
+    """Filter out camel-ai's max_tokens warnings (we intentionally do not set max_tokens, letting the model decide)"""
+
     def filter(self, record):
-        # 过滤掉包含 max_tokens 警告的日志
+        # Drop log records that contain the max_tokens warning
         if "max_tokens" in record.getMessage() and "Invalid or missing" in record.getMessage():
             return False
         return True
 
 
-# 在模块加载时立即添加过滤器，确保在 camel 代码执行前生效
+# Add the filter as soon as the module loads, so it is in effect before camel code runs
 logging.getLogger().addFilter(MaxTokensWarningFilter())
 
 
 def setup_oasis_logging(log_dir: str):
-    """配置 OASIS 的日志，使用固定名称的日志文件"""
+    """Configure OASIS logging using fixed log file names"""
     os.makedirs(log_dir, exist_ok=True)
-    
-    # 清理旧的日志文件
+
+    # Clean up old log files
     for f in os.listdir(log_dir):
         old_log = os.path.join(log_dir, f)
         if os.path.isfile(old_log) and f.endswith('.log'):
@@ -93,9 +94,9 @@ def setup_oasis_logging(log_dir: str):
                 os.remove(old_log)
             except OSError:
                 pass
-    
+
     formatter = UnicodeFormatter("%(levelname)s - %(asctime)s - %(name)s - %(message)s")
-    
+
     loggers_config = {
         "social.agent": os.path.join(log_dir, "social.agent.log"),
         "social.twitter": os.path.join(log_dir, "social.twitter.log"),
@@ -103,7 +104,7 @@ def setup_oasis_logging(log_dir: str):
         "oasis.env": os.path.join(log_dir, "oasis.env.log"),
         "table": os.path.join(log_dir, "table.log"),
     }
-    
+
     for logger_name, log_file in loggers_config.items():
         logger = logging.getLogger(logger_name)
         logger.setLevel(logging.DEBUG)
@@ -126,26 +127,26 @@ try:
         generate_reddit_agent_graph
     )
 except ImportError as e:
-    print(f"错误: 缺少依赖 {e}")
-    print("请先安装: pip install oasis-ai camel-ai")
+    print(f"Error: missing dependency {e}")
+    print("Please install first: pip install oasis-ai camel-ai")
     sys.exit(1)
 
 
-# IPC相关常量
+# IPC-related constants
 IPC_COMMANDS_DIR = "ipc_commands"
 IPC_RESPONSES_DIR = "ipc_responses"
 ENV_STATUS_FILE = "env_status.json"
 
 class CommandType:
-    """命令类型常量"""
+    """Command type constants"""
     INTERVIEW = "interview"
     BATCH_INTERVIEW = "batch_interview"
     CLOSE_ENV = "close_env"
 
 
 class IPCHandler:
-    """IPC命令处理器"""
-    
+    """IPC command handler"""
+
     def __init__(self, simulation_dir: str, env, agent_graph):
         self.simulation_dir = simulation_dir
         self.env = env
@@ -154,44 +155,44 @@ class IPCHandler:
         self.responses_dir = os.path.join(simulation_dir, IPC_RESPONSES_DIR)
         self.status_file = os.path.join(simulation_dir, ENV_STATUS_FILE)
         self._running = True
-        
-        # 确保目录存在
+
+        # Ensure directories exist
         os.makedirs(self.commands_dir, exist_ok=True)
         os.makedirs(self.responses_dir, exist_ok=True)
-    
+
     def update_status(self, status: str):
-        """更新环境状态"""
+        """Update the environment status"""
         with open(self.status_file, 'w', encoding='utf-8') as f:
             json.dump({
                 "status": status,
                 "timestamp": datetime.now().isoformat()
             }, f, ensure_ascii=False, indent=2)
-    
+
     def poll_command(self) -> Optional[Dict[str, Any]]:
-        """轮询获取待处理命令"""
+        """Poll for pending commands"""
         if not os.path.exists(self.commands_dir):
             return None
-        
-        # 获取命令文件（按时间排序）
+
+        # Collect command files (sorted by time)
         command_files = []
         for filename in os.listdir(self.commands_dir):
             if filename.endswith('.json'):
                 filepath = os.path.join(self.commands_dir, filename)
                 command_files.append((filepath, os.path.getmtime(filepath)))
-        
+
         command_files.sort(key=lambda x: x[1])
-        
+
         for filepath, _ in command_files:
             try:
                 with open(filepath, 'r', encoding='utf-8') as f:
                     return json.load(f)
             except (json.JSONDecodeError, OSError):
                 continue
-        
+
         return None
-    
+
     def send_response(self, command_id: str, status: str, result: Dict = None, error: str = None):
-        """发送响应"""
+        """Send a response"""
         response = {
             "command_id": command_id,
             "status": status,
@@ -199,68 +200,68 @@ class IPCHandler:
             "error": error,
             "timestamp": datetime.now().isoformat()
         }
-        
+
         response_file = os.path.join(self.responses_dir, f"{command_id}.json")
         with open(response_file, 'w', encoding='utf-8') as f:
             json.dump(response, f, ensure_ascii=False, indent=2)
-        
-        # 删除命令文件
+
+        # Delete the command file
         command_file = os.path.join(self.commands_dir, f"{command_id}.json")
         try:
             os.remove(command_file)
         except OSError:
             pass
-    
+
     async def handle_interview(self, command_id: str, agent_id: int, prompt: str) -> bool:
         """
-        处理单个Agent采访命令
-        
+        Handle a single-Agent interview command.
+
         Returns:
-            True 表示成功，False 表示失败
+            True on success, False on failure
         """
         try:
-            # 获取Agent
+            # Get the Agent
             agent = self.agent_graph.get_agent(agent_id)
-            
-            # 创建Interview动作
+
+            # Create the Interview action
             interview_action = ManualAction(
                 action_type=ActionType.INTERVIEW,
                 action_args={"prompt": prompt}
             )
-            
-            # 执行Interview
+
+            # Execute the Interview
             actions = {agent: interview_action}
             await self.env.step(actions)
-            
-            # 从数据库获取结果
+
+            # Read the result from the database
             result = self._get_interview_result(agent_id)
-            
+
             self.send_response(command_id, "completed", result=result)
-            print(f"  Interview完成: agent_id={agent_id}")
+            print(f"  Interview completed: agent_id={agent_id}")
             return True
-            
+
         except Exception as e:
             error_msg = str(e)
-            print(f"  Interview失败: agent_id={agent_id}, error={error_msg}")
+            print(f"  Interview failed: agent_id={agent_id}, error={error_msg}")
             self.send_response(command_id, "failed", error=error_msg)
             return False
-    
+
     async def handle_batch_interview(self, command_id: str, interviews: List[Dict]) -> bool:
         """
-        处理批量采访命令
-        
+        Handle a batch interview command.
+
         Args:
             interviews: [{"agent_id": int, "prompt": str}, ...]
         """
         try:
-            # 构建动作字典
+            # Build the action dictionary
             actions = {}
-            agent_prompts = {}  # 记录每个agent的prompt
-            
+            agent_prompts = {}  # Track each agent's prompt
+
             for interview in interviews:
                 agent_id = interview.get("agent_id")
                 prompt = interview.get("prompt", "")
-                
+
                 try:
                     agent = self.agent_graph.get_agent(agent_id)
                     actions[agent] = ManualAction(
@@ -269,52 +270,52 @@ class IPCHandler:
                     )
                     agent_prompts[agent_id] = prompt
                 except Exception as e:
-                    print(f"  警告: 无法获取Agent {agent_id}: {e}")
-            
+                    print(f"  Warning: could not get Agent {agent_id}: {e}")
+
             if not actions:
-                self.send_response(command_id, "failed", error="没有有效的Agent")
+                self.send_response(command_id, "failed", error="No valid Agents")
                 return False
-            
-            # 执行批量Interview
+
+            # Execute the batch Interview
             await self.env.step(actions)
-            
-            # 获取所有结果
+
+            # Collect all results
             results = {}
             for agent_id in agent_prompts.keys():
                 result = self._get_interview_result(agent_id)
                 results[agent_id] = result
-            
+
             self.send_response(command_id, "completed", result={
                 "interviews_count": len(results),
                 "results": results
             })
-            print(f"  批量Interview完成: {len(results)} 个Agent")
+            print(f"  Batch Interview completed: {len(results)} Agents")
             return True
-            
+
         except Exception as e:
             error_msg = str(e)
-            print(f"  批量Interview失败: {error_msg}")
+            print(f"  Batch Interview failed: {error_msg}")
             self.send_response(command_id, "failed", error=error_msg)
             return False
-    
+
     def _get_interview_result(self, agent_id: int) -> Dict[str, Any]:
-        """从数据库获取最新的Interview结果"""
+        """Read the latest Interview result from the database"""
         db_path = os.path.join(self.simulation_dir, "reddit_simulation.db")
-        
+
         result = {
             "agent_id": agent_id,
             "response": None,
             "timestamp": None
         }
-        
+
         if not os.path.exists(db_path):
             return result
-        
+
         try:
             conn = sqlite3.connect(db_path)
             cursor = conn.cursor()
-            
-            # 查询最新的Interview记录
+
+            # Query the latest Interview record
             cursor.execute("""
                 SELECT user_id, info, created_at
                 FROM trace
@@ -322,7 +323,7 @@ class IPCHandler:
                 ORDER BY created_at DESC
                 LIMIT 1
             """, (ActionType.INTERVIEW.value, agent_id))
-            
+
             row = cursor.fetchone()
             if row:
                 user_id, info_json, created_at = row
@@ -332,31 +333,31 @@ class IPCHandler:
                     result["timestamp"] = created_at
                 except json.JSONDecodeError:
                     result["response"] = info_json
-            
+
             conn.close()
-            
+
         except Exception as e:
-            print(f"  读取Interview结果失败: {e}")
-        
+            print(f"  Failed to read Interview result: {e}")
+
         return result
-    
+
     async def process_commands(self) -> bool:
         """
-        处理所有待处理命令
-        
+        Process all pending commands.
+
         Returns:
-            True 表示继续运行，False 表示应该退出
+            True to continue running, False to indicate the loop should exit
         """
         command = self.poll_command()
         if not command:
             return True
-        
+
         command_id = command.get("command_id")
         command_type = command.get("command_type")
         args = command.get("args", {})
-        
-        print(f"\n收到IPC命令: {command_type}, id={command_id}")
-        
+
+        print(f"\nReceived IPC command: {command_type}, id={command_id}")
+
         if command_type == CommandType.INTERVIEW:
             await self.handle_interview(
                 command_id,
@@ -364,28 +365,28 @@ class IPCHandler:
                 args.get("prompt", "")
             )
             return True
-            
+
         elif command_type == CommandType.BATCH_INTERVIEW:
             await self.handle_batch_interview(
                 command_id,
                 args.get("interviews", [])
             )
             return True
-            
+
         elif command_type == CommandType.CLOSE_ENV:
-            print("收到关闭环境命令")
-            self.send_response(command_id, "completed", result={"message": "环境即将关闭"})
+            print("Received close-environment command")
+            self.send_response(command_id, "completed", result={"message": "Environment will close shortly"})
             return False
-        
+
         else:
-            self.send_response(command_id, "failed", error=f"未知命令类型: {command_type}")
+            self.send_response(command_id, "failed", error=f"Unknown command type: {command_type}")
             return True
 
 
 class RedditSimulationRunner:
-    """Reddit模拟运行器"""
-    
-    # Reddit可用动作（不包含INTERVIEW，INTERVIEW只能通过ManualAction手动触发）
+    """Reddit simulation runner"""
+
+    # Reddit-available actions (does not include INTERVIEW; INTERVIEW can only be triggered manually via ManualAction)
     AVAILABLE_ACTIONS = [
         ActionType.LIKE_POST,
         ActionType.DISLIKE_POST,
@@ -401,14 +402,14 @@ class RedditSimulationRunner:
         ActionType.FOLLOW,
         ActionType.MUTE,
     ]
-    
+
     def __init__(self, config_path: str, wait_for_commands: bool = True):
         """
-        初始化模拟运行器
-        
+        Initialize the simulation runner.
+
         Args:
-            config_path: 配置文件路径 (simulation_config.json)
-            wait_for_commands: 模拟完成后是否等待命令（默认True）
+            config_path: Path to the config file (simulation_config.json)
+            wait_for_commands: Whether to wait for commands after simulation completes (default True)
         """
         self.config_path = config_path
         self.config = self._load_config()
@@ -417,99 +418,99 @@ class RedditSimulationRunner:
         self.env = None
         self.agent_graph = None
         self.ipc_handler = None
-        
+
     def _load_config(self) -> Dict[str, Any]:
-        """加载配置文件"""
+        """Load the config file"""
         with open(self.config_path, 'r', encoding='utf-8') as f:
             return json.load(f)
-    
+
     def _get_profile_path(self) -> str:
-        """获取Profile文件路径"""
+        """Get the profile file path"""
         return os.path.join(self.simulation_dir, "reddit_profiles.json")
-    
+
     def _get_db_path(self) -> str:
-        """获取数据库路径"""
+        """Get the database path"""
         return os.path.join(self.simulation_dir, "reddit_simulation.db")
-    
+
     def _create_model(self):
         """
-        创建LLM模型
-        
-        统一使用项目根目录 .env 文件中的配置（优先级最高）：
-        - LLM_API_KEY: API密钥
-        - LLM_BASE_URL: API基础URL
-        - LLM_MODEL_NAME: 模型名称
+        Create the LLM model.
+
+        Always uses configuration from the project root .env file (highest priority):
+        - LLM_API_KEY: API key
+        - LLM_BASE_URL: API base URL
+        - LLM_MODEL_NAME: model name
         """
-        # 优先从 .env 读取配置
+        # Read configuration from .env first
         llm_api_key = os.environ.get("LLM_API_KEY", "")
         llm_base_url = os.environ.get("LLM_BASE_URL", "")
         llm_model = os.environ.get("LLM_MODEL_NAME", "")
-        
-        # 如果 .env 中没有，则使用 config 作为备用
+
+        # If not present in .env, fall back to the config
         if not llm_model:
             llm_model = self.config.get("llm_model", "gpt-4o-mini")
-        
-        # 设置 camel-ai 所需的环境变量
+
+        # Set the environment variables required by camel-ai
         if llm_api_key:
             os.environ["OPENAI_API_KEY"] = llm_api_key
-        
+
         if not os.environ.get("OPENAI_API_KEY"):
-            raise ValueError("缺少 API Key 配置，请在项目根目录 .env 文件中设置 LLM_API_KEY")
-        
+            raise ValueError("Missing API Key configuration; please set LLM_API_KEY in the project root .env file")
+
         if llm_base_url:
             os.environ["OPENAI_API_BASE_URL"] = llm_base_url
-        
-        print(f"LLM配置: model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else '默认'}...")
-        
+
+        print(f"LLM config: model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else 'default'}...")
+
         return ModelFactory.create(
             model_platform=ModelPlatformType.OPENAI,
             model_type=llm_model,
         )
-    
+
     def _get_active_agents_for_round(
-        self, 
-        env, 
+        self,
+        env,
         current_hour: int,
         round_num: int
     ) -> List:
         """
-        根据时间和配置决定本轮激活哪些Agent
+        Decide which Agents to activate this round based on time and config.
         """
         time_config = self.config.get("time_config", {})
         agent_configs = self.config.get("agent_configs", [])
-        
+
         base_min = time_config.get("agents_per_hour_min", 5)
         base_max = time_config.get("agents_per_hour_max", 20)
-        
+
         peak_hours = time_config.get("peak_hours", [9, 10, 11, 14, 15, 20, 21, 22])
         off_peak_hours = time_config.get("off_peak_hours", [0, 1, 2, 3, 4, 5])
-        
+
         if current_hour in peak_hours:
             multiplier = time_config.get("peak_activity_multiplier", 1.5)
         elif current_hour in off_peak_hours:
             multiplier = time_config.get("off_peak_activity_multiplier", 0.3)
         else:
             multiplier = 1.0
-        
+
         target_count = int(random.uniform(base_min, base_max) * multiplier)
-        
+
         candidates = []
         for cfg in agent_configs:
             agent_id = cfg.get("agent_id", 0)
             active_hours = cfg.get("active_hours", list(range(8, 23)))
             activity_level = cfg.get("activity_level", 0.5)
-            
+
             if current_hour not in active_hours:
                 continue
-            
+
             if random.random() < activity_level:
                 candidates.append(agent_id)
-        
+
         selected_ids = random.sample(
-            candidates, 
+            candidates,
             min(target_count, len(candidates))
         ) if candidates else []
-        
+
         active_agents = []
         for agent_id in selected_ids:
             try:
@@ -517,83 +518,83 @@ class RedditSimulationRunner:
                 active_agents.append((agent_id, agent))
             except Exception:
                 pass
-        
+
         return active_agents
-    
+
     async def run(self, max_rounds: int = None):
-        """运行Reddit模拟
-        
+        """Run the Reddit simulation
+
         Args:
-            max_rounds: 最大模拟轮数（可选，用于截断过长的模拟）
+            max_rounds: maximum number of simulation rounds (optional, used to truncate overly long runs)
         """
         print("=" * 60)
-        print("OASIS Reddit模拟")
-        print(f"配置文件: {self.config_path}")
-        print(f"模拟ID: {self.config.get('simulation_id', 'unknown')}")
-        print(f"等待命令模式: {'启用' if self.wait_for_commands else '禁用'}")
+        print("OASIS Reddit simulation")
+        print(f"Config file: {self.config_path}")
+        print(f"Simulation ID: {self.config.get('simulation_id', 'unknown')}")
+        print(f"Command-wait mode: {'enabled' if self.wait_for_commands else 'disabled'}")
         print("=" * 60)
-        
+
         time_config = self.config.get("time_config", {})
         total_hours = time_config.get("total_simulation_hours", 72)
         minutes_per_round = time_config.get("minutes_per_round", 30)
         total_rounds = (total_hours * 60) // minutes_per_round
-        
-        # 如果指定了最大轮数，则截断
+
+        # If max_rounds specified, truncate
         if max_rounds is not None and max_rounds > 0:
             original_rounds = total_rounds
             total_rounds = min(total_rounds, max_rounds)
             if total_rounds < original_rounds:
-                print(f"\n轮数已截断: {original_rounds} -> {total_rounds} (max_rounds={max_rounds})")
-        
-        print(f"\n模拟参数:")
-        print(f"  - 总模拟时长: {total_hours}小时")
-        print(f"  - 每轮时间: {minutes_per_round}分钟")
-        print(f"  - 总轮数: {total_rounds}")
+                print(f"\nRound count truncated: {original_rounds} -> {total_rounds} (max_rounds={max_rounds})")
+
+        print(f"\nSimulation parameters:")
+        print(f"  - Total simulated duration: {total_hours} hours")
+        print(f"  - Time per round: {minutes_per_round} minutes")
+        print(f"  - Total rounds: {total_rounds}")
         if max_rounds:
-            print(f"  - 最大轮数限制: {max_rounds}")
-        print(f"  - Agent数量: {len(self.config.get('agent_configs', []))}")
-        
-        print("\n初始化LLM模型...")
+            print(f"  - Max-rounds limit: {max_rounds}")
+        print(f"  - Agent count: {len(self.config.get('agent_configs', []))}")
+
+        print("\nInitializing LLM model...")
         model = self._create_model()
-        
-        print("加载Agent Profile...")
+
+        print("Loading Agent profiles...")
         profile_path = self._get_profile_path()
         if not os.path.exists(profile_path):
-            print(f"错误: Profile文件不存在: {profile_path}")
+            print(f"Error: profile file does not exist: {profile_path}")
             return
-        
+
         self.agent_graph = await generate_reddit_agent_graph(
             profile_path=profile_path,
             model=model,
             available_actions=self.AVAILABLE_ACTIONS,
         )
-        
+
         db_path = self._get_db_path()
         if os.path.exists(db_path):
             os.remove(db_path)
-            print(f"已删除旧数据库: {db_path}")
-        
-        print("创建OASIS环境...")
+            print(f"Deleted old database: {db_path}")
+
+        print("Creating OASIS environment...")
         self.env = oasis.make(
             agent_graph=self.agent_graph,
             platform=oasis.DefaultPlatformType.REDDIT,
             database_path=db_path,
-            semaphore=30,  # 限制最大并发 LLM 请求数，防止 API 过载
+            semaphore=30,  # Cap concurrent LLM requests to avoid overloading the API
         )
-        
+
         await self.env.reset()
-        print("环境初始化完成\n")
-        
-        # 初始化IPC处理器
+        print("Environment initialized\n")
+
+        # Initialize the IPC handler
         self.ipc_handler = IPCHandler(self.simulation_dir, self.env, self.agent_graph)
         self.ipc_handler.update_status("running")
-        
-        # 执行初始事件
+
+        # Run initial events
         event_config = self.config.get("event_config", {})
         initial_posts = event_config.get("initial_posts", [])
-        
+
         if initial_posts:
-            print(f"执行初始事件 ({len(initial_posts)}条初始帖子)...")
+            print(f"Running initial events ({len(initial_posts)} initial posts)...")
             initial_actions = {}
             for post in initial_posts:
                 agent_id = post.get("poster_agent_id", 0)
@@ -613,35 +614,35 @@ class RedditSimulationRunner:
                             action_args={"content": content}
                         )
                 except Exception as e:
-                    print(f"  警告: 无法为Agent {agent_id}创建初始帖子: {e}")
-            
+                    print(f"  Warning: could not create initial post for Agent {agent_id}: {e}")
+
             if initial_actions:
                 await self.env.step(initial_actions)
-                print(f"  已发布 {len(initial_actions)} 条初始帖子")
-        
-        # 主模拟循环
-        print("\n开始模拟循环...")
+                print(f"  Published {len(initial_actions)} initial posts")
+
+        # Main simulation loop
+        print("\nStarting simulation loop...")
         start_time = datetime.now()
-        
+
         for round_num in range(total_rounds):
             simulated_minutes = round_num * minutes_per_round
             simulated_hour = (simulated_minutes // 60) % 24
             simulated_day = simulated_minutes // (60 * 24) + 1
-            
+
             active_agents = self._get_active_agents_for_round(
                 self.env, simulated_hour, round_num
             )
-            
+
             if not active_agents:
                 continue
-            
+
             actions = {
                 agent: LLMAction()
                 for _, agent in active_agents
             }
-            
+
             await self.env.step(actions)
-            
+
             if (round_num + 1) % 10 == 0 or round_num == 0:
                 elapsed = (datetime.now() - start_time).total_seconds()
                 progress = (round_num + 1) / total_rounds * 100
@@ -649,22 +650,22 @@ class RedditSimulationRunner:
                       f"Round {round_num + 1}/{total_rounds} ({progress:.1f}%) "
                       f"- {len(active_agents)} agents active "
                       f"- elapsed: {elapsed:.1f}s")
-        
+
         total_elapsed = (datetime.now() - start_time).total_seconds()
-        print(f"\n模拟循环完成!")
-        print(f"  - 总耗时: {total_elapsed:.1f}秒")
-        print(f"  - 数据库: {db_path}")
-        
-        # 是否进入等待命令模式
+        print(f"\nSimulation loop complete!")
+        print(f"  - Total elapsed: {total_elapsed:.1f}s")
+        print(f"  - Database: {db_path}")
+
+        # Whether to enter command-wait mode
         if self.wait_for_commands:
             print("\n" + "=" * 60)
-            print("进入等待命令模式 - 环境保持运行")
-            print("支持的命令: interview, batch_interview, close_env")
+            print("Entering command-wait mode - environment stays running")
+            print("Supported commands: interview, batch_interview, close_env")
             print("=" * 60)
-            
+
             self.ipc_handler.update_status("alive")
-            
-            # 等待命令循环（使用全局 _shutdown_event）
+
+            # Command-wait loop (uses the global _shutdown_event)
             try:
                 while not _shutdown_event.is_set():
                     should_continue = await self.ipc_handler.process_commands()
@@ -672,61 +673,61 @@ class RedditSimulationRunner:
                         break
                     try:
                         await asyncio.wait_for(_shutdown_event.wait(), timeout=0.5)
-                        break  # 收到退出信号
+                        break  # received shutdown signal
                     except asyncio.TimeoutError:
                         pass
             except KeyboardInterrupt:
-                print("\n收到中断信号")
+                print("\nReceived interrupt signal")
             except asyncio.CancelledError:
-                print("\n任务被取消")
+                print("\nTask was cancelled")
             except Exception as e:
-                print(f"\n命令处理出错: {e}")
-            
-            print("\n关闭环境...")
-        
-        # 关闭环境
+                print(f"\nCommand processing error: {e}")
+
+            print("\nClosing environment...")
+
+        # Close the environment
         self.ipc_handler.update_status("stopped")
         await self.env.close()
-        
-        print("环境已关闭")
+
+        print("Environment closed")
         print("=" * 60)
 
 
 async def main():
-    parser = argparse.ArgumentParser(description='OASIS Reddit模拟')
+    parser = argparse.ArgumentParser(description='OASIS Reddit simulation')
     parser.add_argument(
-        '--config', 
-        type=str, 
+        '--config',
+        type=str,
         required=True,
-        help='配置文件路径 (simulation_config.json)'
+        help='Path to config file (simulation_config.json)'
     )
     parser.add_argument(
         '--max-rounds',
         type=int,
         default=None,
-        help='最大模拟轮数（可选，用于截断过长的模拟）'
+        help='Maximum simulation rounds (optional, used to truncate overly long runs)'
     )
     parser.add_argument(
         '--no-wait',
         action='store_true',
         default=False,
-        help='模拟完成后立即关闭环境，不进入等待命令模式'
+        help='Close the environment immediately after simulation; do not enter command-wait mode'
     )
-    
+
     args = parser.parse_args()
-    
-    # 在 main 函数开始时创建 shutdown 事件
+
+    # Create the shutdown event at the start of main
     global _shutdown_event
     _shutdown_event = asyncio.Event()
-    
+
     if not os.path.exists(args.config):
-        print(f"错误: 配置文件不存在: {args.config}")
+        print(f"Error: config file does not exist: {args.config}")
         sys.exit(1)
-    
-    # 初始化日志配置（使用固定文件名，清理旧日志）
+
+    # Initialize logging (use fixed file names, clean up old logs)
     simulation_dir = os.path.dirname(args.config) or "."
     setup_oasis_logging(os.path.join(simulation_dir, "log"))
-    
+
     runner = RedditSimulationRunner(
         config_path=args.config,
         wait_for_commands=not args.no_wait
@@ -736,22 +737,22 @@ async def main():
 
 def setup_signal_handlers():
     """
-    设置信号处理器，确保收到 SIGTERM/SIGINT 时能够正确退出
-    让程序有机会正常清理资源（关闭数据库、环境等）
+    Set up signal handlers so SIGTERM/SIGINT cause an orderly shutdown.
+    Gives the program a chance to clean up resources (close database, environment, etc).
     """
     def signal_handler(signum, frame):
         global _cleanup_done
         sig_name = "SIGTERM" if signum == signal.SIGTERM else "SIGINT"
-        print(f"\n收到 {sig_name} 信号，正在退出...")
+        print(f"\nReceived {sig_name} signal, shutting down...")
         if not _cleanup_done:
             _cleanup_done = True
             if _shutdown_event:
                 _shutdown_event.set()
         else:
-            # 重复收到信号才强制退出
-            print("强制退出...")
+            # Force-exit only if signal repeats
+            print("Forcing exit...")
             sys.exit(1)
-    
+
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
 
@@ -761,9 +762,8 @@ if __name__ == "__main__":
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
-        print("\n程序被中断")
+        print("\nProgram interrupted")
     except SystemExit:
         pass
     finally:
-        print("模拟进程已退出")
-
+        print("Simulation process exited")

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -1,16 +1,17 @@
 """
-OASIS Twitter模拟预设脚本
-此脚本读取配置文件中的参数来执行模拟，实现全程自动化
+OASIS Twitter simulation preset script.
+This script reads parameters from a config file and runs a fully-automated simulation.
 
-功能特性:
-- 完成模拟后不立即关闭环境，进入等待命令模式
-- 支持通过IPC接收Interview命令
-- 支持单个Agent采访和批量采访
-- 支持远程关闭环境命令
+Features:
+- Does not immediately close the environment after the simulation completes; enters
+  command-wait mode instead.
+- Accepts Interview commands over IPC.
+- Supports single-Agent interviews and batch interviews.
+- Supports remote close-environment commands.
 
-使用方式:
+Usage:
     python run_twitter_simulation.py --config /path/to/simulation_config.json
-    python run_twitter_simulation.py --config /path/to/simulation_config.json --no-wait  # 完成后立即关闭
+    python run_twitter_simulation.py --config /path/to/simulation_config.json --no-wait  # close immediately on completion
 """
 
 import argparse
@@ -25,18 +26,18 @@ import sqlite3
 from datetime import datetime
 from typing import Dict, Any, List, Optional
 
-# 全局变量：用于信号处理
+# Global variable: used by the signal handler
 _shutdown_event = None
 _cleanup_done = False
 
-# 添加项目路径
+# Add project paths
 _scripts_dir = os.path.dirname(os.path.abspath(__file__))
 _backend_dir = os.path.abspath(os.path.join(_scripts_dir, '..'))
 _project_root = os.path.abspath(os.path.join(_backend_dir, '..'))
 sys.path.insert(0, _scripts_dir)
 sys.path.insert(0, _backend_dir)
 
-# 加载项目根目录的 .env 文件（包含 LLM_API_KEY 等配置）
+# Load the project root .env file (contains LLM_API_KEY and other config)
 from dotenv import load_dotenv
 _env_file = os.path.join(_project_root, '.env')
 if os.path.exists(_env_file):
@@ -51,41 +52,41 @@ import re
 
 
 class UnicodeFormatter(logging.Formatter):
-    """自定义格式化器，将 Unicode 转义序列转换为可读字符"""
-    
+    """Custom formatter that converts Unicode escape sequences into readable characters"""
+
     UNICODE_ESCAPE_PATTERN = re.compile(r'\\u([0-9a-fA-F]{4})')
-    
+
     def format(self, record):
         result = super().format(record)
-        
+
         def replace_unicode(match):
             try:
                 return chr(int(match.group(1), 16))
             except (ValueError, OverflowError):
                 return match.group(0)
-        
+
         return self.UNICODE_ESCAPE_PATTERN.sub(replace_unicode, result)
 
 
 class MaxTokensWarningFilter(logging.Filter):
-    """过滤掉 camel-ai 关于 max_tokens 的警告（我们故意不设置 max_tokens，让模型自行决定）"""
-    
+    """Filter out camel-ai's max_tokens warnings (we intentionally do not set max_tokens, letting the model decide)"""
+
     def filter(self, record):
-        # 过滤掉包含 max_tokens 警告的日志
+        # Drop log records that contain the max_tokens warning
         if "max_tokens" in record.getMessage() and "Invalid or missing" in record.getMessage():
             return False
         return True
 
 
-# 在模块加载时立即添加过滤器，确保在 camel 代码执行前生效
+# Add the filter as soon as the module loads, so it is in effect before camel code runs
 logging.getLogger().addFilter(MaxTokensWarningFilter())
 
 
 def setup_oasis_logging(log_dir: str):
-    """配置 OASIS 的日志，使用固定名称的日志文件"""
+    """Configure OASIS logging using fixed log file names"""
     os.makedirs(log_dir, exist_ok=True)
-    
-    # 清理旧的日志文件
+
+    # Clean up old log files
     for f in os.listdir(log_dir):
         old_log = os.path.join(log_dir, f)
         if os.path.isfile(old_log) and f.endswith('.log'):
@@ -93,9 +94,9 @@ def setup_oasis_logging(log_dir: str):
                 os.remove(old_log)
             except OSError:
                 pass
-    
+
     formatter = UnicodeFormatter("%(levelname)s - %(asctime)s - %(name)s - %(message)s")
-    
+
     loggers_config = {
         "social.agent": os.path.join(log_dir, "social.agent.log"),
         "social.twitter": os.path.join(log_dir, "social.twitter.log"),
@@ -103,7 +104,7 @@ def setup_oasis_logging(log_dir: str):
         "oasis.env": os.path.join(log_dir, "oasis.env.log"),
         "table": os.path.join(log_dir, "table.log"),
     }
-    
+
     for logger_name, log_file in loggers_config.items():
         logger = logging.getLogger(logger_name)
         logger.setLevel(logging.DEBUG)
@@ -126,26 +127,26 @@ try:
         generate_twitter_agent_graph
     )
 except ImportError as e:
-    print(f"错误: 缺少依赖 {e}")
-    print("请先安装: pip install oasis-ai camel-ai")
+    print(f"Error: missing dependency {e}")
+    print("Please install first: pip install oasis-ai camel-ai")
     sys.exit(1)
 
 
-# IPC相关常量
+# IPC-related constants
 IPC_COMMANDS_DIR = "ipc_commands"
 IPC_RESPONSES_DIR = "ipc_responses"
 ENV_STATUS_FILE = "env_status.json"
 
 class CommandType:
-    """命令类型常量"""
+    """Command type constants"""
     INTERVIEW = "interview"
     BATCH_INTERVIEW = "batch_interview"
     CLOSE_ENV = "close_env"
 
 
 class IPCHandler:
-    """IPC命令处理器"""
-    
+    """IPC command handler"""
+
     def __init__(self, simulation_dir: str, env, agent_graph):
         self.simulation_dir = simulation_dir
         self.env = env
@@ -154,44 +155,44 @@ class IPCHandler:
         self.responses_dir = os.path.join(simulation_dir, IPC_RESPONSES_DIR)
         self.status_file = os.path.join(simulation_dir, ENV_STATUS_FILE)
         self._running = True
-        
-        # 确保目录存在
+
+        # Ensure directories exist
         os.makedirs(self.commands_dir, exist_ok=True)
         os.makedirs(self.responses_dir, exist_ok=True)
-    
+
     def update_status(self, status: str):
-        """更新环境状态"""
+        """Update the environment status"""
         with open(self.status_file, 'w', encoding='utf-8') as f:
             json.dump({
                 "status": status,
                 "timestamp": datetime.now().isoformat()
             }, f, ensure_ascii=False, indent=2)
-    
+
     def poll_command(self) -> Optional[Dict[str, Any]]:
-        """轮询获取待处理命令"""
+        """Poll for pending commands"""
         if not os.path.exists(self.commands_dir):
             return None
-        
-        # 获取命令文件（按时间排序）
+
+        # Collect command files (sorted by time)
         command_files = []
         for filename in os.listdir(self.commands_dir):
             if filename.endswith('.json'):
                 filepath = os.path.join(self.commands_dir, filename)
                 command_files.append((filepath, os.path.getmtime(filepath)))
-        
+
         command_files.sort(key=lambda x: x[1])
-        
+
         for filepath, _ in command_files:
             try:
                 with open(filepath, 'r', encoding='utf-8') as f:
                     return json.load(f)
             except (json.JSONDecodeError, OSError):
                 continue
-        
+
         return None
-    
+
     def send_response(self, command_id: str, status: str, result: Dict = None, error: str = None):
-        """发送响应"""
+        """Send a response"""
         response = {
             "command_id": command_id,
             "status": status,
@@ -199,68 +200,68 @@ class IPCHandler:
             "error": error,
             "timestamp": datetime.now().isoformat()
         }
-        
+
         response_file = os.path.join(self.responses_dir, f"{command_id}.json")
         with open(response_file, 'w', encoding='utf-8') as f:
             json.dump(response, f, ensure_ascii=False, indent=2)
-        
-        # 删除命令文件
+
+        # Delete the command file
         command_file = os.path.join(self.commands_dir, f"{command_id}.json")
         try:
             os.remove(command_file)
         except OSError:
             pass
-    
+
     async def handle_interview(self, command_id: str, agent_id: int, prompt: str) -> bool:
         """
-        处理单个Agent采访命令
-        
+        Handle a single-Agent interview command.
+
         Returns:
-            True 表示成功，False 表示失败
+            True on success, False on failure
         """
         try:
-            # 获取Agent
+            # Get the Agent
             agent = self.agent_graph.get_agent(agent_id)
-            
-            # 创建Interview动作
+
+            # Create the Interview action
             interview_action = ManualAction(
                 action_type=ActionType.INTERVIEW,
                 action_args={"prompt": prompt}
             )
-            
-            # 执行Interview
+
+            # Execute the Interview
             actions = {agent: interview_action}
             await self.env.step(actions)
-            
-            # 从数据库获取结果
+
+            # Read the result from the database
             result = self._get_interview_result(agent_id)
-            
+
             self.send_response(command_id, "completed", result=result)
-            print(f"  Interview完成: agent_id={agent_id}")
+            print(f"  Interview completed: agent_id={agent_id}")
             return True
-            
+
         except Exception as e:
             error_msg = str(e)
-            print(f"  Interview失败: agent_id={agent_id}, error={error_msg}")
+            print(f"  Interview failed: agent_id={agent_id}, error={error_msg}")
             self.send_response(command_id, "failed", error=error_msg)
             return False
-    
+
     async def handle_batch_interview(self, command_id: str, interviews: List[Dict]) -> bool:
         """
-        处理批量采访命令
-        
+        Handle a batch interview command.
+
         Args:
             interviews: [{"agent_id": int, "prompt": str}, ...]
         """
         try:
-            # 构建动作字典
+            # Build the action dictionary
             actions = {}
-            agent_prompts = {}  # 记录每个agent的prompt
-            
+            agent_prompts = {}  # Track each agent's prompt
+
             for interview in interviews:
                 agent_id = interview.get("agent_id")
                 prompt = interview.get("prompt", "")
-                
+
                 try:
                     agent = self.agent_graph.get_agent(agent_id)
                     actions[agent] = ManualAction(
@@ -269,52 +270,52 @@ class IPCHandler:
                     )
                     agent_prompts[agent_id] = prompt
                 except Exception as e:
-                    print(f"  警告: 无法获取Agent {agent_id}: {e}")
-            
+                    print(f"  Warning: could not get Agent {agent_id}: {e}")
+
             if not actions:
-                self.send_response(command_id, "failed", error="没有有效的Agent")
+                self.send_response(command_id, "failed", error="No valid Agents")
                 return False
-            
-            # 执行批量Interview
+
+            # Execute the batch Interview
             await self.env.step(actions)
-            
-            # 获取所有结果
+
+            # Collect all results
             results = {}
             for agent_id in agent_prompts.keys():
                 result = self._get_interview_result(agent_id)
                 results[agent_id] = result
-            
+
             self.send_response(command_id, "completed", result={
                 "interviews_count": len(results),
                 "results": results
             })
-            print(f"  批量Interview完成: {len(results)} 个Agent")
+            print(f"  Batch Interview completed: {len(results)} Agents")
             return True
-            
+
         except Exception as e:
             error_msg = str(e)
-            print(f"  批量Interview失败: {error_msg}")
+            print(f"  Batch Interview failed: {error_msg}")
             self.send_response(command_id, "failed", error=error_msg)
             return False
-    
+
     def _get_interview_result(self, agent_id: int) -> Dict[str, Any]:
-        """从数据库获取最新的Interview结果"""
+        """Read the latest Interview result from the database"""
         db_path = os.path.join(self.simulation_dir, "twitter_simulation.db")
-        
+
         result = {
             "agent_id": agent_id,
             "response": None,
             "timestamp": None
         }
-        
+
         if not os.path.exists(db_path):
             return result
-        
+
         try:
             conn = sqlite3.connect(db_path)
             cursor = conn.cursor()
-            
-            # 查询最新的Interview记录
+
+            # Query the latest Interview record
             cursor.execute("""
                 SELECT user_id, info, created_at
                 FROM trace
@@ -322,7 +323,7 @@ class IPCHandler:
                 ORDER BY created_at DESC
                 LIMIT 1
             """, (ActionType.INTERVIEW.value, agent_id))
-            
+
             row = cursor.fetchone()
             if row:
                 user_id, info_json, created_at = row
@@ -332,31 +333,31 @@ class IPCHandler:
                     result["timestamp"] = created_at
                 except json.JSONDecodeError:
                     result["response"] = info_json
-            
+
             conn.close()
-            
+
         except Exception as e:
-            print(f"  读取Interview结果失败: {e}")
-        
+            print(f"  Failed to read Interview result: {e}")
+
         return result
-    
+
     async def process_commands(self) -> bool:
         """
-        处理所有待处理命令
-        
+        Process all pending commands.
+
         Returns:
-            True 表示继续运行，False 表示应该退出
+            True to continue running, False to indicate the loop should exit
         """
         command = self.poll_command()
         if not command:
             return True
-        
+
         command_id = command.get("command_id")
         command_type = command.get("command_type")
         args = command.get("args", {})
-        
-        print(f"\n收到IPC命令: {command_type}, id={command_id}")
-        
+
+        print(f"\nReceived IPC command: {command_type}, id={command_id}")
+
         if command_type == CommandType.INTERVIEW:
             await self.handle_interview(
                 command_id,
@@ -364,28 +365,28 @@ class IPCHandler:
                 args.get("prompt", "")
             )
             return True
-            
+
         elif command_type == CommandType.BATCH_INTERVIEW:
             await self.handle_batch_interview(
                 command_id,
                 args.get("interviews", [])
             )
             return True
-            
+
         elif command_type == CommandType.CLOSE_ENV:
-            print("收到关闭环境命令")
-            self.send_response(command_id, "completed", result={"message": "环境即将关闭"})
+            print("Received close-environment command")
+            self.send_response(command_id, "completed", result={"message": "Environment will close shortly"})
             return False
-        
+
         else:
-            self.send_response(command_id, "failed", error=f"未知命令类型: {command_type}")
+            self.send_response(command_id, "failed", error=f"Unknown command type: {command_type}")
             return True
 
 
 class TwitterSimulationRunner:
-    """Twitter模拟运行器"""
-    
-    # Twitter可用动作（不包含INTERVIEW，INTERVIEW只能通过ManualAction手动触发）
+    """Twitter simulation runner"""
+
+    # Twitter-available actions (does not include INTERVIEW; INTERVIEW can only be triggered manually via ManualAction)
     AVAILABLE_ACTIONS = [
         ActionType.CREATE_POST,
         ActionType.LIKE_POST,
@@ -394,14 +395,14 @@ class TwitterSimulationRunner:
         ActionType.DO_NOTHING,
         ActionType.QUOTE_POST,
     ]
-    
+
     def __init__(self, config_path: str, wait_for_commands: bool = True):
         """
-        初始化模拟运行器
-        
+        Initialize the simulation runner.
+
         Args:
-            config_path: 配置文件路径 (simulation_config.json)
-            wait_for_commands: 模拟完成后是否等待命令（默认True）
+            config_path: Path to the config file (simulation_config.json)
+            wait_for_commands: Whether to wait for commands after simulation completes (default True)
         """
         self.config_path = config_path
         self.config = self._load_config()
@@ -410,114 +411,114 @@ class TwitterSimulationRunner:
         self.env = None
         self.agent_graph = None
         self.ipc_handler = None
-        
+
     def _load_config(self) -> Dict[str, Any]:
-        """加载配置文件"""
+        """Load the config file"""
         with open(self.config_path, 'r', encoding='utf-8') as f:
             return json.load(f)
-    
+
     def _get_profile_path(self) -> str:
-        """获取Profile文件路径（OASIS Twitter使用CSV格式）"""
+        """Get the profile file path (OASIS Twitter uses CSV)"""
         return os.path.join(self.simulation_dir, "twitter_profiles.csv")
-    
+
     def _get_db_path(self) -> str:
-        """获取数据库路径"""
+        """Get the database path"""
         return os.path.join(self.simulation_dir, "twitter_simulation.db")
-    
+
     def _create_model(self):
         """
-        创建LLM模型
-        
-        统一使用项目根目录 .env 文件中的配置（优先级最高）：
-        - LLM_API_KEY: API密钥
-        - LLM_BASE_URL: API基础URL
-        - LLM_MODEL_NAME: 模型名称
+        Create the LLM model.
+
+        Always uses configuration from the project root .env file (highest priority):
+        - LLM_API_KEY: API key
+        - LLM_BASE_URL: API base URL
+        - LLM_MODEL_NAME: model name
         """
-        # 优先从 .env 读取配置
+        # Read configuration from .env first
         llm_api_key = os.environ.get("LLM_API_KEY", "")
         llm_base_url = os.environ.get("LLM_BASE_URL", "")
         llm_model = os.environ.get("LLM_MODEL_NAME", "")
-        
-        # 如果 .env 中没有，则使用 config 作为备用
+
+        # If not present in .env, fall back to the config
         if not llm_model:
             llm_model = self.config.get("llm_model", "gpt-4o-mini")
-        
-        # 设置 camel-ai 所需的环境变量
+
+        # Set the environment variables required by camel-ai
         if llm_api_key:
             os.environ["OPENAI_API_KEY"] = llm_api_key
-        
+
         if not os.environ.get("OPENAI_API_KEY"):
-            raise ValueError("缺少 API Key 配置，请在项目根目录 .env 文件中设置 LLM_API_KEY")
-        
+            raise ValueError("Missing API Key configuration; please set LLM_API_KEY in the project root .env file")
+
         if llm_base_url:
             os.environ["OPENAI_API_BASE_URL"] = llm_base_url
-        
-        print(f"LLM配置: model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else '默认'}...")
-        
+
+        print(f"LLM config: model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else 'default'}...")
+
         return ModelFactory.create(
             model_platform=ModelPlatformType.OPENAI,
             model_type=llm_model,
         )
-    
+
     def _get_active_agents_for_round(
-        self, 
-        env, 
+        self,
+        env,
         current_hour: int,
         round_num: int
     ) -> List:
         """
-        根据时间和配置决定本轮激活哪些Agent
-        
+        Decide which Agents to activate this round based on time and config.
+
         Args:
-            env: OASIS环境
-            current_hour: 当前模拟小时（0-23）
-            round_num: 当前轮数
-            
+            env: OASIS environment
+            current_hour: current simulated hour (0-23)
+            round_num: current round number
+
         Returns:
-            激活的Agent列表
+            List of activated Agents
         """
         time_config = self.config.get("time_config", {})
         agent_configs = self.config.get("agent_configs", [])
-        
-        # 基础激活数量
+
+        # Base activation count
         base_min = time_config.get("agents_per_hour_min", 5)
         base_max = time_config.get("agents_per_hour_max", 20)
-        
-        # 根据时段调整
+
+        # Adjust based on time-of-day band
         peak_hours = time_config.get("peak_hours", [9, 10, 11, 14, 15, 20, 21, 22])
         off_peak_hours = time_config.get("off_peak_hours", [0, 1, 2, 3, 4, 5])
-        
+
         if current_hour in peak_hours:
             multiplier = time_config.get("peak_activity_multiplier", 1.5)
         elif current_hour in off_peak_hours:
             multiplier = time_config.get("off_peak_activity_multiplier", 0.3)
         else:
             multiplier = 1.0
-        
+
         target_count = int(random.uniform(base_min, base_max) * multiplier)
-        
-        # 根据每个Agent的配置计算激活概率
+
+        # Compute activation probability based on each Agent's config
         candidates = []
         for cfg in agent_configs:
             agent_id = cfg.get("agent_id", 0)
             active_hours = cfg.get("active_hours", list(range(8, 23)))
             activity_level = cfg.get("activity_level", 0.5)
-            
-            # 检查是否在活跃时间
+
+            # Check whether currently within active hours
             if current_hour not in active_hours:
                 continue
-            
-            # 根据活跃度计算概率
+
+            # Roll probability based on activity level
             if random.random() < activity_level:
                 candidates.append(agent_id)
-        
-        # 随机选择
+
+        # Random selection
         selected_ids = random.sample(
-            candidates, 
+            candidates,
             min(target_count, len(candidates))
         ) if candidates else []
-        
-        # 转换为Agent对象
+
+        # Resolve into Agent objects
         active_agents = []
         for agent_id in selected_ids:
             try:
@@ -525,90 +526,90 @@ class TwitterSimulationRunner:
                 active_agents.append((agent_id, agent))
             except Exception:
                 pass
-        
+
         return active_agents
-    
+
     async def run(self, max_rounds: int = None):
-        """运行Twitter模拟
-        
+        """Run the Twitter simulation
+
         Args:
-            max_rounds: 最大模拟轮数（可选，用于截断过长的模拟）
+            max_rounds: maximum number of simulation rounds (optional, used to truncate overly long runs)
         """
         print("=" * 60)
-        print("OASIS Twitter模拟")
-        print(f"配置文件: {self.config_path}")
-        print(f"模拟ID: {self.config.get('simulation_id', 'unknown')}")
-        print(f"等待命令模式: {'启用' if self.wait_for_commands else '禁用'}")
+        print("OASIS Twitter simulation")
+        print(f"Config file: {self.config_path}")
+        print(f"Simulation ID: {self.config.get('simulation_id', 'unknown')}")
+        print(f"Command-wait mode: {'enabled' if self.wait_for_commands else 'disabled'}")
         print("=" * 60)
-        
-        # 加载时间配置
+
+        # Load time config
         time_config = self.config.get("time_config", {})
         total_hours = time_config.get("total_simulation_hours", 72)
         minutes_per_round = time_config.get("minutes_per_round", 30)
-        
-        # 计算总轮数
+
+        # Compute total round count
         total_rounds = (total_hours * 60) // minutes_per_round
-        
-        # 如果指定了最大轮数，则截断
+
+        # If max_rounds specified, truncate
         if max_rounds is not None and max_rounds > 0:
             original_rounds = total_rounds
             total_rounds = min(total_rounds, max_rounds)
             if total_rounds < original_rounds:
-                print(f"\n轮数已截断: {original_rounds} -> {total_rounds} (max_rounds={max_rounds})")
-        
-        print(f"\n模拟参数:")
-        print(f"  - 总模拟时长: {total_hours}小时")
-        print(f"  - 每轮时间: {minutes_per_round}分钟")
-        print(f"  - 总轮数: {total_rounds}")
+                print(f"\nRound count truncated: {original_rounds} -> {total_rounds} (max_rounds={max_rounds})")
+
+        print(f"\nSimulation parameters:")
+        print(f"  - Total simulated duration: {total_hours} hours")
+        print(f"  - Time per round: {minutes_per_round} minutes")
+        print(f"  - Total rounds: {total_rounds}")
         if max_rounds:
-            print(f"  - 最大轮数限制: {max_rounds}")
-        print(f"  - Agent数量: {len(self.config.get('agent_configs', []))}")
-        
-        # 创建模型
-        print("\n初始化LLM模型...")
+            print(f"  - Max-rounds limit: {max_rounds}")
+        print(f"  - Agent count: {len(self.config.get('agent_configs', []))}")
+
+        # Create the model
+        print("\nInitializing LLM model...")
         model = self._create_model()
-        
-        # 加载Agent图
-        print("加载Agent Profile...")
+
+        # Load the Agent graph
+        print("Loading Agent profiles...")
         profile_path = self._get_profile_path()
         if not os.path.exists(profile_path):
-            print(f"错误: Profile文件不存在: {profile_path}")
+            print(f"Error: profile file does not exist: {profile_path}")
             return
-        
+
         self.agent_graph = await generate_twitter_agent_graph(
             profile_path=profile_path,
             model=model,
             available_actions=self.AVAILABLE_ACTIONS,
         )
-        
-        # 数据库路径
+
+        # Database path
         db_path = self._get_db_path()
         if os.path.exists(db_path):
             os.remove(db_path)
-            print(f"已删除旧数据库: {db_path}")
-        
-        # 创建环境
-        print("创建OASIS环境...")
+            print(f"Deleted old database: {db_path}")
+
+        # Create the environment
+        print("Creating OASIS environment...")
         self.env = oasis.make(
             agent_graph=self.agent_graph,
             platform=oasis.DefaultPlatformType.TWITTER,
             database_path=db_path,
-            semaphore=30,  # 限制最大并发 LLM 请求数，防止 API 过载
+            semaphore=30,  # Cap concurrent LLM requests to avoid overloading the API
         )
-        
+
         await self.env.reset()
-        print("环境初始化完成\n")
-        
-        # 初始化IPC处理器
+        print("Environment initialized\n")
+
+        # Initialize the IPC handler
         self.ipc_handler = IPCHandler(self.simulation_dir, self.env, self.agent_graph)
         self.ipc_handler.update_status("running")
-        
-        # 执行初始事件
+
+        # Run initial events
         event_config = self.config.get("event_config", {})
         initial_posts = event_config.get("initial_posts", [])
-        
+
         if initial_posts:
-            print(f"执行初始事件 ({len(initial_posts)}条初始帖子)...")
+            print(f"Running initial events ({len(initial_posts)} initial posts)...")
             initial_actions = {}
             for post in initial_posts:
                 agent_id = post.get("poster_agent_id", 0)
@@ -620,40 +621,40 @@ class TwitterSimulationRunner:
                         action_args={"content": content}
                     )
                 except Exception as e:
-                    print(f"  警告: 无法为Agent {agent_id}创建初始帖子: {e}")
-            
+                    print(f"  Warning: could not create initial post for Agent {agent_id}: {e}")
+
             if initial_actions:
                 await self.env.step(initial_actions)
-                print(f"  已发布 {len(initial_actions)} 条初始帖子")
-        
-        # 主模拟循环
-        print("\n开始模拟循环...")
+                print(f"  Published {len(initial_actions)} initial posts")
+
+        # Main simulation loop
+        print("\nStarting simulation loop...")
         start_time = datetime.now()
-        
+
         for round_num in range(total_rounds):
-            # 计算当前模拟时间
+            # Compute the current simulated time
             simulated_minutes = round_num * minutes_per_round
             simulated_hour = (simulated_minutes // 60) % 24
             simulated_day = simulated_minutes // (60 * 24) + 1
-            
-            # 获取本轮激活的Agent
+
+            # Get the Agents activated this round
             active_agents = self._get_active_agents_for_round(
                 self.env, simulated_hour, round_num
             )
-            
+
             if not active_agents:
                 continue
-            
-            # 构建动作
+
+            # Build actions
             actions = {
                 agent: LLMAction()
                 for _, agent in active_agents
             }
-            
-            # 执行动作
+
+            # Execute actions
             await self.env.step(actions)
-            
-            # 打印进度
+
+            # Print progress
             if (round_num + 1) % 10 == 0 or round_num == 0:
                 elapsed = (datetime.now() - start_time).total_seconds()
                 progress = (round_num + 1) / total_rounds * 100
@@ -661,22 +662,22 @@ class TwitterSimulationRunner:
                       f"Round {round_num + 1}/{total_rounds} ({progress:.1f}%) "
                       f"- {len(active_agents)} agents active "
                       f"- elapsed: {elapsed:.1f}s")
-        
+
         total_elapsed = (datetime.now() - start_time).total_seconds()
-        print(f"\n模拟循环完成!")
-        print(f"  - 总耗时: {total_elapsed:.1f}秒")
-        print(f"  - 数据库: {db_path}")
-        
-        # 是否进入等待命令模式
+        print(f"\nSimulation loop complete!")
+        print(f"  - Total elapsed: {total_elapsed:.1f}s")
+        print(f"  - Database: {db_path}")
+
+        # Whether to enter command-wait mode
         if self.wait_for_commands:
             print("\n" + "=" * 60)
-            print("进入等待命令模式 - 环境保持运行")
-            print("支持的命令: interview, batch_interview, close_env")
+            print("Entering command-wait mode - environment stays running")
+            print("Supported commands: interview, batch_interview, close_env")
             print("=" * 60)
-            
+
             self.ipc_handler.update_status("alive")
-            
-            # 等待命令循环（使用全局 _shutdown_event）
+
+            # Command-wait loop (uses the global _shutdown_event)
             try:
                 while not _shutdown_event.is_set():
                     should_continue = await self.ipc_handler.process_commands()
@@ -684,61 +685,61 @@ class TwitterSimulationRunner:
                         break
                     try:
                         await asyncio.wait_for(_shutdown_event.wait(), timeout=0.5)
-                        break  # 收到退出信号
+                        break  # received shutdown signal
                     except asyncio.TimeoutError:
                         pass
             except KeyboardInterrupt:
-                print("\n收到中断信号")
+                print("\nReceived interrupt signal")
             except asyncio.CancelledError:
-                print("\n任务被取消")
+                print("\nTask was cancelled")
             except Exception as e:
-                print(f"\n命令处理出错: {e}")
-            
-            print("\n关闭环境...")
-        
-        # 关闭环境
+                print(f"\nCommand processing error: {e}")
+
+            print("\nClosing environment...")
+
+        # Close the environment
         self.ipc_handler.update_status("stopped")
         await self.env.close()
-        
-        print("环境已关闭")
+
+        print("Environment closed")
         print("=" * 60)
 
 
 async def main():
-    parser = argparse.ArgumentParser(description='OASIS Twitter模拟')
+    parser = argparse.ArgumentParser(description='OASIS Twitter simulation')
     parser.add_argument(
-        '--config', 
-        type=str, 
+        '--config',
+        type=str,
         required=True,
-        help='配置文件路径 (simulation_config.json)'
+        help='Path to config file (simulation_config.json)'
     )
     parser.add_argument(
         '--max-rounds',
         type=int,
         default=None,
-        help='最大模拟轮数（可选，用于截断过长的模拟）'
+        help='Maximum simulation rounds (optional, used to truncate overly long runs)'
     )
     parser.add_argument(
         '--no-wait',
         action='store_true',
         default=False,
-        help='模拟完成后立即关闭环境，不进入等待命令模式'
+        help='Close the environment immediately after simulation; do not enter command-wait mode'
     )
-    
+
     args = parser.parse_args()
-    
-    # 在 main 函数开始时创建 shutdown 事件
+
+    # Create the shutdown event at the start of main
     global _shutdown_event
     _shutdown_event = asyncio.Event()
-    
+
     if not os.path.exists(args.config):
-        print(f"错误: 配置文件不存在: {args.config}")
+        print(f"Error: config file does not exist: {args.config}")
         sys.exit(1)
-    
-    # 初始化日志配置（使用固定文件名，清理旧日志）
+
+    # Initialize logging (use fixed file names, clean up old logs)
     simulation_dir = os.path.dirname(args.config) or "."
     setup_oasis_logging(os.path.join(simulation_dir, "log"))
-    
+
     runner = TwitterSimulationRunner(
         config_path=args.config,
         wait_for_commands=not args.no_wait
@@ -748,22 +749,22 @@ async def main():
 
 def setup_signal_handlers():
     """
-    设置信号处理器，确保收到 SIGTERM/SIGINT 时能够正确退出
-    让程序有机会正常清理资源（关闭数据库、环境等）
+    Set up signal handlers so SIGTERM/SIGINT cause an orderly shutdown.
+    Gives the program a chance to clean up resources (close database, environment, etc).
     """
     def signal_handler(signum, frame):
         global _cleanup_done
         sig_name = "SIGTERM" if signum == signal.SIGTERM else "SIGINT"
-        print(f"\n收到 {sig_name} 信号，正在退出...")
+        print(f"\nReceived {sig_name} signal, shutting down...")
         if not _cleanup_done:
             _cleanup_done = True
             if _shutdown_event:
                 _shutdown_event.set()
         else:
-            # 重复收到信号才强制退出
-            print("强制退出...")
+            # Force-exit only if signal repeats
+            print("Forcing exit...")
             sys.exit(1)
-    
+
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
 
@@ -773,8 +774,8 @@ if __name__ == "__main__":
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
-        print("\n程序被中断")
+        print("\nProgram interrupted")
     except SystemExit:
         pass
     finally:
-        print("模拟进程已退出")
+        print("Simulation process exited")

--- a/backend/scripts/test_profile_format.py
+++ b/backend/scripts/test_profile_format.py
@@ -1,8 +1,8 @@
 """
-测试Profile格式生成是否符合OASIS要求
-验证：
-1. Twitter Profile生成CSV格式
-2. Reddit Profile生成JSON详细格式
+Test whether generated Profile formats meet OASIS requirements.
+Validates:
+1. Twitter Profile is generated in CSV format
+2. Reddit Profile is generated in detailed JSON format
 """
 
 import os
@@ -11,19 +11,19 @@ import json
 import csv
 import tempfile
 
-# 添加项目路径
+# Add project path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app.services.oasis_profile_generator import OasisProfileGenerator, OasisAgentProfile
 
 
 def test_profile_formats():
-    """测试Profile格式"""
+    """Test profile formats"""
     print("=" * 60)
-    print("OASIS Profile格式测试")
+    print("OASIS Profile format test")
     print("=" * 60)
-    
-    # 创建测试Profile数据
+
+    # Build test profile data
     test_profiles = [
         OasisAgentProfile(
             user_id=0,
@@ -60,87 +60,87 @@ def test_profile_formats():
             source_entity_type="University",
         ),
     ]
-    
+
     generator = OasisProfileGenerator.__new__(OasisProfileGenerator)
-    
-    # 使用临时目录
+
+    # Use a temporary directory
     with tempfile.TemporaryDirectory() as temp_dir:
         twitter_path = os.path.join(temp_dir, "twitter_profiles.csv")
         reddit_path = os.path.join(temp_dir, "reddit_profiles.json")
-        
-        # 测试Twitter CSV格式
-        print("\n1. 测试Twitter Profile (CSV格式)")
+
+        # Test Twitter CSV format
+        print("\n1. Test Twitter Profile (CSV format)")
         print("-" * 40)
         generator._save_twitter_csv(test_profiles, twitter_path)
-        
-        # 读取并验证CSV
+
+        # Read and validate the CSV
         with open(twitter_path, 'r', encoding='utf-8') as f:
             reader = csv.DictReader(f)
             rows = list(reader)
-            
-        print(f"   文件: {twitter_path}")
-        print(f"   行数: {len(rows)}")
-        print(f"   表头: {list(rows[0].keys())}")
-        print(f"\n   示例数据 (第1行):")
+
+        print(f"   File: {twitter_path}")
+        print(f"   Row count: {len(rows)}")
+        print(f"   Header: {list(rows[0].keys())}")
+        print(f"\n   Sample data (row 1):")
         for key, value in rows[0].items():
             print(f"     {key}: {value}")
-        
-        # 验证必需字段
-        required_twitter_fields = ['user_id', 'user_name', 'name', 'bio', 
+
+        # Validate required fields
+        required_twitter_fields = ['user_id', 'user_name', 'name', 'bio',
                                    'friend_count', 'follower_count', 'statuses_count', 'created_at']
         missing = set(required_twitter_fields) - set(rows[0].keys())
         if missing:
-            print(f"\n   [错误] 缺少字段: {missing}")
+            print(f"\n   [ERROR] Missing fields: {missing}")
         else:
-            print(f"\n   [通过] 所有必需字段都存在")
-        
-        # 测试Reddit JSON格式
-        print("\n2. 测试Reddit Profile (JSON详细格式)")
+            print(f"\n   [PASS] All required fields are present")
+
+        # Test Reddit JSON format
+        print("\n2. Test Reddit Profile (detailed JSON format)")
         print("-" * 40)
         generator._save_reddit_json(test_profiles, reddit_path)
-        
-        # 读取并验证JSON
+
+        # Read and validate the JSON
         with open(reddit_path, 'r', encoding='utf-8') as f:
             reddit_data = json.load(f)
-        
-        print(f"   文件: {reddit_path}")
-        print(f"   条目数: {len(reddit_data)}")
-        print(f"   字段: {list(reddit_data[0].keys())}")
-        print(f"\n   示例数据 (第1条):")
+
+        print(f"   File: {reddit_path}")
+        print(f"   Entry count: {len(reddit_data)}")
+        print(f"   Fields: {list(reddit_data[0].keys())}")
+        print(f"\n   Sample data (entry 1):")
         print(json.dumps(reddit_data[0], ensure_ascii=False, indent=4))
-        
-        # 验证详细格式字段
+
+        # Validate detailed format fields
         required_reddit_fields = ['realname', 'username', 'bio', 'persona']
         optional_reddit_fields = ['age', 'gender', 'mbti', 'country', 'profession', 'interested_topics']
-        
+
         missing = set(required_reddit_fields) - set(reddit_data[0].keys())
         if missing:
-            print(f"\n   [错误] 缺少必需字段: {missing}")
+            print(f"\n   [ERROR] Missing required fields: {missing}")
         else:
-            print(f"\n   [通过] 所有必需字段都存在")
-        
+            print(f"\n   [PASS] All required fields are present")
+
         present_optional = set(optional_reddit_fields) & set(reddit_data[0].keys())
-        print(f"   [信息] 可选字段: {present_optional}")
-    
+        print(f"   [INFO] Optional fields: {present_optional}")
+
     print("\n" + "=" * 60)
-    print("测试完成!")
+    print("Test complete!")
     print("=" * 60)
 
 
 def show_expected_formats():
-    """显示OASIS期望的格式"""
+    """Show the formats that OASIS expects"""
     print("\n" + "=" * 60)
-    print("OASIS 期望的Profile格式参考")
+    print("OASIS expected Profile format reference")
     print("=" * 60)
-    
-    print("\n1. Twitter Profile (CSV格式)")
+
+    print("\n1. Twitter Profile (CSV format)")
     print("-" * 40)
     twitter_example = """user_id,user_name,name,bio,friend_count,follower_count,statuses_count,created_at
 0,user0,User Zero,I am user zero with interests in technology.,100,150,500,2023-01-01
 1,user1,User One,Tech enthusiast and coffee lover.,200,250,1000,2023-01-02"""
     print(twitter_example)
-    
-    print("\n2. Reddit Profile (JSON详细格式)")
+
+    print("\n2. Reddit Profile (detailed JSON format)")
     print("-" * 40)
     reddit_example = [
         {
@@ -162,5 +162,3 @@ def show_expected_formats():
 if __name__ == "__main__":
     test_profile_formats()
     show_expected_formats()
-
-

--- a/backend/tests/test_prompts_no_cjk.py
+++ b/backend/tests/test_prompts_no_cjk.py
@@ -1,0 +1,82 @@
+"""Guards against Chinese (CJK) text re-entering the source tree.
+
+The MiroFish LLM previously reasoned in Chinese because Chinese strings
+appeared in prompts, system messages, and tool descriptions sent to the
+model. We translated everything to English; this test makes sure CJK
+characters do not regress.
+
+Allowlist: a small set of files / lines is permitted to retain CJK on
+purpose (e.g. legacy gender normalization keys, CN-language-aware regex
+filters in zep_tools, locale routing). See ALLOWED_CJK below.
+"""
+
+import re
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]  # MiroFish/
+
+# Match CJK Unified Ideographs only (NOT punctuation U+3000–U+303F or full-width
+# punctuation U+FF00–U+FFEF — those are runtime data, e.g. sentence-boundary
+# splitters in file_parser.py).
+CJK_RE = re.compile(r"[一-鿿]")
+
+# Files allowed to contain CJK chars. Use posix-relative paths from MiroFish/.
+# Keep this list TIGHT — every entry needs a justification comment.
+ALLOWED_CJK_FILES = {
+    # Locale source-of-truth: Chinese translations live here on purpose.
+    "locales/zh.json",
+    "locales/languages.json",
+    # README in Chinese is intentional.
+    "README-ZH.md",
+    # locale.py routes between en/zh translations; comments may reference CJK.
+    "backend/app/utils/locale.py",
+    # Runtime data, not prompts:
+    # - oasis_profile_generator: gender-normalization dict keys ("男"/"女"/...) for
+    #   legacy LLM output coming back in Chinese.
+    # - zep_tools: regex filters that strip Chinese question prefixes ("问题1") from
+    #   agent output.
+    "backend/app/services/oasis_profile_generator.py",
+    "backend/app/services/zep_tools.py",
+}
+
+# Scan only source dirs, not vendored / build artifacts.
+SCAN_DIRS = ["backend/app", "backend/scripts", "frontend/src"]
+SCAN_EXTS = {".py", ".vue", ".js", ".ts", ".tsx", ".jsx", ".md", ".json", ".toml"}
+
+def iter_source_files():
+    for d in SCAN_DIRS:
+        base = ROOT / d
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.suffix not in SCAN_EXTS:
+                continue
+            rel = path.relative_to(ROOT).as_posix()
+            if rel in ALLOWED_CJK_FILES:
+                continue
+            yield path, rel
+
+def test_no_cjk_in_source():
+    offenders: list[tuple[str, int, str]] = []
+    for path, rel in iter_source_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if CJK_RE.search(line):
+                offenders.append((rel, lineno, line.strip()[:120]))
+    if offenders:
+        msg = "Chinese (CJK) characters found in source files. Translate to English or add to ALLOWED_CJK_FILES with justification:\n"
+        for rel, lineno, snippet in offenders[:30]:
+            msg += f"  {rel}:{lineno}: {snippet}\n"
+        if len(offenders) > 30:
+            msg += f"  ... and {len(offenders) - 30} more\n"
+        raise AssertionError(msg)
+
+def test_locale_files_kept_in_chinese():
+    """Negative test — make sure we did NOT accidentally strip CJK from locale files."""
+    zh = (ROOT / "locales/zh.json").read_text(encoding="utf-8")
+    assert CJK_RE.search(zh), "locales/zh.json should contain Chinese translations"

--- a/backend/tests/test_real_llm_english_output.py
+++ b/backend/tests/test_real_llm_english_output.py
@@ -1,0 +1,150 @@
+"""Real-LLM end-to-end test: confirm the model produces English-only output.
+
+Calls the real ontology generator against a fixture document and asserts the
+returned ontology contains zero CJK ideographs in entity/relation type names,
+attribute names, or descriptions. This is the regression test for the
+"MiroFish reasons in Chinese" production bug — if a future prompt edit reverts
+or weakens the English directive, this test catches it before deploy.
+
+Configuration via environment (same vars MiroFish uses at runtime):
+  LLM_API_KEY      — required; test skips if unset
+  LLM_BASE_URL     — defaults to https://api.openai.com/v1
+  LLM_MODEL_NAME   — defaults to gpt-4o-mini
+
+In CI, point these at the production Gemini config to exercise the real
+production pipeline:
+  LLM_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/
+  LLM_MODEL_NAME=models/gemini-3-flash-preview
+  LLM_API_KEY=<gemini-key>
+
+Locally, OPENAI_API_KEY + the gpt-4o-mini default is sufficient for sanity.
+"""
+
+import os
+import re
+import sys
+import pathlib
+
+import pytest
+
+# Make `import app...` work without installing the package.
+ROOT = pathlib.Path(__file__).resolve().parents[2]  # MiroFish/
+BACKEND = ROOT / "backend"
+sys.path.insert(0, str(BACKEND))
+
+CJK_RE = re.compile(r"[一-鿿]")
+
+
+# A fixture seed document. Deliberately mixes Western and Asian context so an
+# under-prompted model has every excuse to emit Chinese — and the test catches
+# the regression if it does.
+SEED_DOCUMENT = """
+Acme Therapeutics, a clinical-stage biotech, is preparing to launch a Phase III
+trial for ATX-219, an oral small-molecule inhibitor of MYC for relapsed
+multiple myeloma. The chief medical officer, Dr. Elena Park, has flagged
+competitive pressure from Genentech's MYC-degrader program (RG-7842) and from
+Daiichi Sankyo's bispecific antibody DS-9070. Investor sentiment on social
+media (X, LinkedIn, biotech subreddits) has shifted neutral after the recent
+ASH abstract; key opinion leaders Dr. Akira Tanaka (Memorial Sloan Kettering)
+and Dr. Wei Chen (Peking Union Medical College) have publicly endorsed the
+mechanism. The company expects an FDA Type-B meeting in Q3, with European
+EMA scientific advice pending. Patient advocacy group MMRF is monitoring
+the trial design closely.
+""".strip()
+
+SIMULATION_REQUIREMENT = (
+    "Predict how key opinion leaders, investors, and patient advocacy groups "
+    "will react to a Phase III readout for ATX-219, including likely social "
+    "media discourse and competitive responses from rival programs."
+)
+
+
+@pytest.fixture(scope="module")
+def llm_available() -> bool:
+    return bool(os.environ.get("LLM_API_KEY"))
+
+
+@pytest.mark.skipif(
+    not os.environ.get("LLM_API_KEY"),
+    reason="LLM_API_KEY not set — skipping real-LLM e2e test",
+)
+def test_ontology_output_is_english_only():
+    """Real LLM call. Asserts the produced ontology contains no CJK chars."""
+    from app.services.ontology_generator import OntologyGenerator
+
+    generator = OntologyGenerator()
+    ontology = generator.generate(
+        document_texts=[SEED_DOCUMENT],
+        simulation_requirement=SIMULATION_REQUIREMENT,
+    )
+
+    assert "entity_types" in ontology, f"missing entity_types in: {ontology}"
+    assert "edge_types" in ontology, f"missing edge_types in: {ontology}"
+    assert len(ontology["entity_types"]) > 0, "ontology has zero entity types"
+    assert len(ontology["edge_types"]) > 0, "ontology has zero edge types"
+
+    offenders = []
+
+    def scan(label: str, value):
+        if isinstance(value, str) and CJK_RE.search(value):
+            offenders.append(f"{label}: {value!r}")
+        elif isinstance(value, dict):
+            for k, v in value.items():
+                scan(f"{label}.{k}", v)
+        elif isinstance(value, list):
+            for i, v in enumerate(value):
+                scan(f"{label}[{i}]", v)
+
+    # Type names + attribute names are the load-bearing fields. Descriptions
+    # may legitimately reference Chinese names if the seed document mentions
+    # Chinese institutions (e.g. "Peking Union Medical College"), so we scan
+    # only structural fields where Chinese signals an LLM-language regression.
+    for et in ontology.get("entity_types", []):
+        scan("entity_types.name", et.get("name"))
+        for attr in et.get("attributes", []) or []:
+            scan("entity_types.attributes.name", attr.get("name"))
+    for rt in ontology.get("edge_types", []):
+        scan("edge_types.name", rt.get("name"))
+        for attr in rt.get("attributes", []) or []:
+            scan("edge_types.attributes.name", attr.get("name"))
+
+    assert not offenders, (
+        "LLM emitted CJK characters in structural ontology fields. "
+        "This is the production bug the prompts were supposed to prevent.\n"
+        + "\n".join(f"  - {o}" for o in offenders)
+        + f"\n\nRaw ontology:\n{ontology}"
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("LLM_API_KEY"),
+    reason="LLM_API_KEY not set — skipping real-LLM e2e test",
+)
+def test_llm_client_direct_english_response():
+    """Sanity test: a bare LLM call with the system prompt routes English."""
+    from app.utils.llm_client import LLMClient
+
+    client = LLMClient()
+    response = client.chat(
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You are a helpful assistant. You MUST respond in English "
+                    "regardless of the language of the question."
+                ),
+            },
+            {
+                "role": "user",
+                "content": "用中文回答：什么是机器学习？",
+            },
+        ],
+        temperature=0.0,
+        max_tokens=256,
+    )
+    assert response, "empty response from LLM"
+    cjk_chars = CJK_RE.findall(response)
+    assert not cjk_chars, (
+        f"LLM responded in Chinese despite English-only system prompt. "
+        f"Found {len(cjk_chars)} CJK chars. Response: {response!r}"
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,22 @@
 services:
-  mirofish:
-    image: ghcr.io/666ghj/mirofish:latest
-    # 加速镜像（如拉取缓慢可替换上方地址）
-    # image: ghcr.nju.edu.cn/666ghj/mirofish:latest
-    container_name: mirofish
+  mirofish-backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: mirofish-backend-dev
     env_file:
       - .env
     ports:
-      - "3000:3000"
       - "5001:5001"
-    restart: unless-stopped
+    # Override the default CMD (which starts both frontend+backend) to run
+    # only the Flask backend on port 5001 for the mTORch PoC integration.
+    command: ["uv", "run", "--project", "backend", "python", "backend/run.py"]
     volumes:
       - ./backend/uploads:/app/backend/uploads
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:5001/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 40s

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,15 +1,15 @@
 <!doctype html>
-<html lang="zh">
+<html lang="en">
   <head>
-    <script>document.documentElement.lang = localStorage.getItem('locale') || 'zh'</script>
+    <script>document.documentElement.lang = localStorage.getItem('locale') || 'en'</script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@100..800&family=Noto+Sans+SC:wght@300;400;500;700;800;900&family=Space+Grotesk:wght@300..700&display=swap" rel="stylesheet">
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="MiroFish - 社交媒体舆论模拟系统" />
-    <title>MiroFish - 预测万物</title>
+    <meta name="description" content="MiroFish" />
+    <title>MiroFish</title>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,11 +3,11 @@
 </template>
 
 <script setup>
-// 使用 Vue Router 来管理页面
+// Use Vue Router to manage pages
 </script>
 
 <style>
-/* 全局样式重置 */
+/* Global style reset */
 * {
   margin: 0;
   padding: 0;
@@ -22,7 +22,7 @@
   background-color: #ffffff;
 }
 
-/* 滚动条样式 */
+/* Scrollbar styles */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
@@ -40,7 +40,7 @@
   background: #333333;
 }
 
-/* 全局按钮样式 */
+/* Global button styles */
 button {
   font-family: inherit;
 }

--- a/frontend/src/api/graph.js
+++ b/frontend/src/api/graph.js
@@ -1,12 +1,12 @@
 import service, { requestWithRetry } from './index'
 
 /**
- * 生成本体（上传文档和模拟需求）
- * @param {Object} data - 包含files, simulation_requirement, project_name等
+ * Generate ontology (upload documents and simulation requirements)
+ * @param {Object} data - includes files, simulation_requirement, project_name, etc.
  * @returns {Promise}
  */
 export function generateOntology(formData) {
-  return requestWithRetry(() => 
+  return requestWithRetry(() =>
     service({
       url: '/api/graph/ontology/generate',
       method: 'post',
@@ -19,8 +19,8 @@ export function generateOntology(formData) {
 }
 
 /**
- * 构建图谱
- * @param {Object} data - 包含project_id, graph_name等
+ * Build graph
+ * @param {Object} data - includes project_id, graph_name, etc.
  * @returns {Promise}
  */
 export function buildGraph(data) {
@@ -34,8 +34,8 @@ export function buildGraph(data) {
 }
 
 /**
- * 查询任务状态
- * @param {String} taskId - 任务ID
+ * Query task status
+ * @param {String} taskId - task ID
  * @returns {Promise}
  */
 export function getTaskStatus(taskId) {
@@ -46,8 +46,8 @@ export function getTaskStatus(taskId) {
 }
 
 /**
- * 获取图谱数据
- * @param {String} graphId - 图谱ID
+ * Get graph data
+ * @param {String} graphId - graph ID
  * @returns {Promise}
  */
 export function getGraphData(graphId) {
@@ -58,8 +58,8 @@ export function getGraphData(graphId) {
 }
 
 /**
- * 获取项目信息
- * @param {String} projectId - 项目ID
+ * Get project info
+ * @param {String} projectId - project ID
  * @returns {Promise}
  */
 export function getProject(projectId) {

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -3,17 +3,24 @@ import i18n from '../i18n'
 
 // 创建axios实例
 const service = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5001',
+  baseURL: import.meta.env.VITE_BASE_PATH || 'http://localhost:5001',
   timeout: 300000, // 5分钟超时（本体生成可能需要较长时间）
   headers: {
     'Content-Type': 'application/json'
   }
 })
 
+// API key for production deployments (optional, for dev mode leave unset)
+const apiKey = import.meta.env.VITE_MIROFISH_API_KEY || ''
+
 // 请求拦截器
 service.interceptors.request.use(
   config => {
     config.headers['Accept-Language'] = i18n.global.locale.value
+    // Add X-API-Key header if configured (for production deployments)
+    if (apiKey) {
+      config.headers['X-API-Key'] = apiKey
+    }
     return config
   },
   error => {

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,10 +1,10 @@
 import axios from 'axios'
 import i18n from '../i18n'
 
-// 创建axios实例
+// Create axios instance
 const service = axios.create({
   baseURL: import.meta.env.VITE_BASE_PATH || 'http://localhost:5001',
-  timeout: 300000, // 5分钟超时（本体生成可能需要较长时间）
+  timeout: 300000, // 5-minute timeout (ontology generation may take a while)
   headers: {
     'Content-Type': 'application/json'
   }
@@ -13,7 +13,7 @@ const service = axios.create({
 // API key for production deployments (optional, for dev mode leave unset)
 const apiKey = import.meta.env.VITE_MIROFISH_API_KEY || ''
 
-// 请求拦截器
+// Request interceptor
 service.interceptors.request.use(
   config => {
     config.headers['Accept-Language'] = i18n.global.locale.value
@@ -29,44 +29,44 @@ service.interceptors.request.use(
   }
 )
 
-// 响应拦截器（容错重试机制）
+// Response interceptor (with retry/fault-tolerance handling)
 service.interceptors.response.use(
   response => {
     const res = response.data
-    
-    // 如果返回的状态码不是success，则抛出错误
+
+    // If the returned status is not success, throw an error
     if (!res.success && res.success !== undefined) {
       console.error('API Error:', res.error || res.message || 'Unknown error')
       return Promise.reject(new Error(res.error || res.message || 'Error'))
     }
-    
+
     return res
   },
   error => {
     console.error('Response error:', error)
-    
-    // 处理超时
+
+    // Handle timeout
     if (error.code === 'ECONNABORTED' && error.message.includes('timeout')) {
       console.error('Request timeout')
     }
-    
-    // 处理网络错误
+
+    // Handle network errors
     if (error.message === 'Network Error') {
       console.error('Network error - please check your connection')
     }
-    
+
     return Promise.reject(error)
   }
 )
 
-// 带重试的请求函数
+// Request function with retry
 export const requestWithRetry = async (requestFn, maxRetries = 3, delay = 1000) => {
   for (let i = 0; i < maxRetries; i++) {
     try {
       return await requestFn()
     } catch (error) {
       if (i === maxRetries - 1) throw error
-      
+
       console.warn(`Request failed, retrying (${i + 1}/${maxRetries})...`)
       await new Promise(resolve => setTimeout(resolve, delay * Math.pow(2, i)))
     }

--- a/frontend/src/api/report.js
+++ b/frontend/src/api/report.js
@@ -1,7 +1,7 @@
 import service, { requestWithRetry } from './index'
 
 /**
- * 开始报告生成
+ * Start report generation
  * @param {Object} data - { simulation_id, force_regenerate? }
  */
 export const generateReport = (data) => {
@@ -9,7 +9,7 @@ export const generateReport = (data) => {
 }
 
 /**
- * 获取报告生成状态
+ * Get report generation status
  * @param {string} reportId
  */
 export const getReportStatus = (reportId) => {
@@ -17,25 +17,25 @@ export const getReportStatus = (reportId) => {
 }
 
 /**
- * 获取 Agent 日志（增量）
+ * Get Agent log (incremental)
  * @param {string} reportId
- * @param {number} fromLine - 从第几行开始获取
+ * @param {number} fromLine - line number to start fetching from
  */
 export const getAgentLog = (reportId, fromLine = 0) => {
   return service.get(`/api/report/${reportId}/agent-log`, { params: { from_line: fromLine } })
 }
 
 /**
- * 获取控制台日志（增量）
+ * Get console log (incremental)
  * @param {string} reportId
- * @param {number} fromLine - 从第几行开始获取
+ * @param {number} fromLine - line number to start fetching from
  */
 export const getConsoleLog = (reportId, fromLine = 0) => {
   return service.get(`/api/report/${reportId}/console-log`, { params: { from_line: fromLine } })
 }
 
 /**
- * 获取报告详情
+ * Get report details
  * @param {string} reportId
  */
 export const getReport = (reportId) => {
@@ -43,7 +43,7 @@ export const getReport = (reportId) => {
 }
 
 /**
- * 与 Report Agent 对话
+ * Chat with the Report Agent
  * @param {Object} data - { simulation_id, message, chat_history? }
  */
 export const chatWithReport = (data) => {

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -1,7 +1,7 @@
 import service, { requestWithRetry } from './index'
 
 /**
- * 创建模拟
+ * Create a simulation
  * @param {Object} data - { project_id, graph_id?, enable_twitter?, enable_reddit? }
  */
 export const createSimulation = (data) => {
@@ -9,7 +9,7 @@ export const createSimulation = (data) => {
 }
 
 /**
- * 准备模拟环境（异步任务）
+ * Prepare simulation environment (async task)
  * @param {Object} data - { simulation_id, entity_types?, use_llm_for_profiles?, parallel_profile_count?, force_regenerate? }
  */
 export const prepareSimulation = (data) => {
@@ -17,7 +17,7 @@ export const prepareSimulation = (data) => {
 }
 
 /**
- * 查询准备任务进度
+ * Query preparation task progress
  * @param {Object} data - { task_id?, simulation_id? }
  */
 export const getPrepareStatus = (data) => {
@@ -25,7 +25,7 @@ export const getPrepareStatus = (data) => {
 }
 
 /**
- * 获取模拟状态
+ * Get simulation status
  * @param {string} simulationId
  */
 export const getSimulation = (simulationId) => {
@@ -33,7 +33,7 @@ export const getSimulation = (simulationId) => {
 }
 
 /**
- * 获取模拟的 Agent Profiles
+ * Get the simulation's Agent Profiles
  * @param {string} simulationId
  * @param {string} platform - 'reddit' | 'twitter'
  */
@@ -42,7 +42,7 @@ export const getSimulationProfiles = (simulationId, platform = 'reddit') => {
 }
 
 /**
- * 实时获取生成中的 Agent Profiles
+ * Real-time fetch of Agent Profiles being generated
  * @param {string} simulationId
  * @param {string} platform - 'reddit' | 'twitter'
  */
@@ -51,7 +51,7 @@ export const getSimulationProfilesRealtime = (simulationId, platform = 'reddit')
 }
 
 /**
- * 获取模拟配置
+ * Get simulation configuration
  * @param {string} simulationId
  */
 export const getSimulationConfig = (simulationId) => {
@@ -59,17 +59,17 @@ export const getSimulationConfig = (simulationId) => {
 }
 
 /**
- * 实时获取生成中的模拟配置
+ * Real-time fetch of simulation configuration being generated
  * @param {string} simulationId
- * @returns {Promise} 返回配置信息，包含元数据和配置内容
+ * @returns {Promise} returns config info, including metadata and config content
  */
 export const getSimulationConfigRealtime = (simulationId) => {
   return service.get(`/api/simulation/${simulationId}/config/realtime`)
 }
 
 /**
- * 列出所有模拟
- * @param {string} projectId - 可选，按项目ID过滤
+ * List all simulations
+ * @param {string} projectId - optional, filter by project ID
  */
 export const listSimulations = (projectId) => {
   const params = projectId ? { project_id: projectId } : {}
@@ -77,7 +77,7 @@ export const listSimulations = (projectId) => {
 }
 
 /**
- * 启动模拟
+ * Start simulation
  * @param {Object} data - { simulation_id, platform?, max_rounds?, enable_graph_memory_update? }
  */
 export const startSimulation = (data) => {
@@ -85,7 +85,7 @@ export const startSimulation = (data) => {
 }
 
 /**
- * 停止模拟
+ * Stop simulation
  * @param {Object} data - { simulation_id }
  */
 export const stopSimulation = (data) => {
@@ -93,7 +93,7 @@ export const stopSimulation = (data) => {
 }
 
 /**
- * 获取模拟运行实时状态
+ * Get real-time simulation run status
  * @param {string} simulationId
  */
 export const getRunStatus = (simulationId) => {
@@ -101,7 +101,7 @@ export const getRunStatus = (simulationId) => {
 }
 
 /**
- * 获取模拟运行详细状态（包含最近动作）
+ * Get detailed simulation run status (including recent actions)
  * @param {string} simulationId
  */
 export const getRunStatusDetail = (simulationId) => {
@@ -109,11 +109,11 @@ export const getRunStatusDetail = (simulationId) => {
 }
 
 /**
- * 获取模拟中的帖子
+ * Get posts within the simulation
  * @param {string} simulationId
  * @param {string} platform - 'reddit' | 'twitter'
- * @param {number} limit - 返回数量
- * @param {number} offset - 偏移量
+ * @param {number} limit - number of items to return
+ * @param {number} offset - offset
  */
 export const getSimulationPosts = (simulationId, platform = 'reddit', limit = 50, offset = 0) => {
   return service.get(`/api/simulation/${simulationId}/posts`, {
@@ -122,10 +122,10 @@ export const getSimulationPosts = (simulationId, platform = 'reddit', limit = 50
 }
 
 /**
- * 获取模拟时间线（按轮次汇总）
+ * Get simulation timeline (aggregated by round)
  * @param {string} simulationId
- * @param {number} startRound - 起始轮次
- * @param {number} endRound - 结束轮次
+ * @param {number} startRound - start round
+ * @param {number} endRound - end round
  */
 export const getSimulationTimeline = (simulationId, startRound = 0, endRound = null) => {
   const params = { start_round: startRound }
@@ -136,7 +136,7 @@ export const getSimulationTimeline = (simulationId, startRound = 0, endRound = n
 }
 
 /**
- * 获取Agent统计信息
+ * Get Agent statistics
  * @param {string} simulationId
  */
 export const getAgentStats = (simulationId) => {
@@ -144,7 +144,7 @@ export const getAgentStats = (simulationId) => {
 }
 
 /**
- * 获取模拟动作历史
+ * Get simulation action history
  * @param {string} simulationId
  * @param {Object} params - { limit, offset, platform, agent_id, round_num }
  */
@@ -153,7 +153,7 @@ export const getSimulationActions = (simulationId, params = {}) => {
 }
 
 /**
- * 关闭模拟环境（优雅退出）
+ * Close simulation environment (graceful exit)
  * @param {Object} data - { simulation_id, timeout? }
  */
 export const closeSimulationEnv = (data) => {
@@ -161,7 +161,7 @@ export const closeSimulationEnv = (data) => {
 }
 
 /**
- * 获取模拟环境状态
+ * Get simulation environment status
  * @param {Object} data - { simulation_id }
  */
 export const getEnvStatus = (data) => {
@@ -169,7 +169,7 @@ export const getEnvStatus = (data) => {
 }
 
 /**
- * 批量采访 Agent
+ * Batch interview Agents
  * @param {Object} data - { simulation_id, interviews: [{ agent_id, prompt }] }
  */
 export const interviewAgents = (data) => {
@@ -177,9 +177,9 @@ export const interviewAgents = (data) => {
 }
 
 /**
- * 获取历史模拟列表（带项目详情）
- * 用于首页历史项目展示
- * @param {number} limit - 返回数量限制
+ * Get historical simulation list (with project details)
+ * Used for the home page historical projects display
+ * @param {number} limit - max number of items to return
  */
 export const getSimulationHistory = (limit = 20) => {
   return service.get('/api/simulation/history', { params: { limit } })

--- a/frontend/src/components/GraphPanel.vue
+++ b/frontend/src/components/GraphPanel.vue
@@ -2,7 +2,7 @@
   <div class="graph-panel">
     <div class="panel-header">
       <span class="panel-title">{{ $t('graph.panelTitle') }}</span>
-      <!-- 顶部工具栏 (Internal Top Right) -->
+      <!-- Top toolbar (internal top-right) -->
       <div class="header-tools">
         <button class="tool-btn" @click="$emit('refresh')" :disabled="loading" :title="$t('graph.refreshGraph')">
           <span class="icon-refresh" :class="{ 'spinning': loading }">↻</span>
@@ -15,11 +15,11 @@
     </div>
     
     <div class="graph-container" ref="graphContainer">
-      <!-- 图谱可视化 -->
+      <!-- Graph visualization -->
       <div v-if="graphData" class="graph-view">
         <svg ref="graphSvg" class="graph-svg"></svg>
         
-        <!-- 构建中/模拟中提示 -->
+        <!-- Building / simulating hint -->
         <div v-if="currentPhase === 1 || isSimulating" class="graph-building-hint">
           <div class="memory-icon-wrapper">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="memory-icon">
@@ -30,7 +30,7 @@
           {{ isSimulating ? $t('graph.graphMemoryRealtime') : $t('graph.realtimeUpdating') }}
         </div>
         
-        <!-- 模拟结束后的提示 -->
+        <!-- Post-simulation hint -->
         <div v-if="showSimulationFinishedHint" class="graph-building-hint finished-hint">
           <div class="hint-icon-wrapper">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="hint-icon">
@@ -48,7 +48,7 @@
           </button>
         </div>
         
-        <!-- 节点/边详情面板 -->
+        <!-- Node/edge detail panel -->
         <div v-if="selectedItem" class="detail-panel">
           <div class="detail-panel-header">
             <span class="detail-title">{{ selectedItem.type === 'node' ? $t('graph.nodeDetails') : $t('graph.relationship') }}</span>
@@ -58,7 +58,7 @@
             <button class="detail-close" @click="closeDetailPanel">×</button>
           </div>
           
-          <!-- 节点详情 -->
+          <!-- Node details -->
           <div v-if="selectedItem.type === 'node'" class="detail-content">
             <div class="detail-row">
               <span class="detail-label">Name:</span>
@@ -101,9 +101,9 @@
             </div>
           </div>
           
-          <!-- 边详情 -->
+          <!-- Edge details -->
           <div v-else class="detail-content">
-            <!-- 自环组详情 -->
+            <!-- Self-loop group details -->
             <template v-if="selectedItem.data.isSelfLoopGroup">
               <div class="edge-relation-header self-loop-header">
                 {{ selectedItem.data.source_name }} - Self Relations
@@ -154,7 +154,7 @@
               </div>
             </template>
             
-            <!-- 普通边详情 -->
+            <!-- Regular edge details -->
             <template v-else>
               <div class="edge-relation-header">
                 {{ selectedItem.data.source_name }} → {{ selectedItem.data.name || 'RELATED_TO' }} → {{ selectedItem.data.target_name }}
@@ -200,20 +200,20 @@
         </div>
       </div>
       
-      <!-- 加载状态 -->
+      <!-- Loading state -->
       <div v-else-if="loading" class="graph-state">
         <div class="loading-spinner"></div>
         <p>{{ $t('graph.graphDataLoading') }}</p>
       </div>
       
-      <!-- 等待/空状态 -->
+      <!-- Waiting / empty state -->
       <div v-else class="graph-state">
         <div class="empty-icon">❖</div>
         <p class="empty-text">{{ $t('graph.waitingOntology') }}</p>
       </div>
     </div>
 
-    <!-- 底部图例 (Bottom Left) -->
+    <!-- Bottom legend (bottom-left) -->
     <div v-if="graphData && entityTypes.length" class="graph-legend">
       <span class="legend-title">Entity Types</span>
       <div class="legend-items">
@@ -224,7 +224,7 @@
       </div>
     </div>
     
-    <!-- 显示边标签开关 -->
+    <!-- Edge labels toggle -->
     <div v-if="graphData" class="edge-labels-toggle">
       <label class="toggle-switch">
         <input type="checkbox" v-model="showEdgeLabels" />
@@ -251,26 +251,26 @@ const emit = defineEmits(['refresh', 'toggle-maximize'])
 const graphContainer = ref(null)
 const graphSvg = ref(null)
 const selectedItem = ref(null)
-const showEdgeLabels = ref(true) // 默认显示边标签
-const expandedSelfLoops = ref(new Set()) // 展开的自环项
-const showSimulationFinishedHint = ref(false) // 模拟结束后的提示
-const wasSimulating = ref(false) // 追踪之前是否在模拟中
+const showEdgeLabels = ref(true) // Edge labels visible by default
+const expandedSelfLoops = ref(new Set()) // Expanded self-loop items
+const showSimulationFinishedHint = ref(false) // Post-simulation hint visible
+const wasSimulating = ref(false) // Track whether the previous state was simulating
 
-// 关闭模拟结束提示
+// Dismiss the post-simulation hint
 const dismissFinishedHint = () => {
   showSimulationFinishedHint.value = false
 }
 
-// 监听 isSimulating 变化，检测模拟结束
+// Watch isSimulating to detect when the simulation ends
 watch(() => props.isSimulating, (newValue, oldValue) => {
   if (wasSimulating.value && !newValue) {
-    // 从模拟中变为非模拟状态，显示结束提示
+    // Transitioned from simulating to not-simulating — show the post-simulation hint
     showSimulationFinishedHint.value = true
   }
   wasSimulating.value = newValue
 }, { immediate: true })
 
-// 切换自环项展开/折叠状态
+// Toggle a self-loop item's expanded/collapsed state
 const toggleSelfLoop = (id) => {
   const newSet = new Set(expandedSelfLoops.value)
   if (newSet.has(id)) {
@@ -281,11 +281,11 @@ const toggleSelfLoop = (id) => {
   expandedSelfLoops.value = newSet
 }
 
-// 计算实体类型用于图例
+// Compute entity types for the legend
 const entityTypes = computed(() => {
   if (!props.graphData?.nodes) return []
   const typeMap = {}
-  // 美观的颜色调色板
+  // Pleasing color palette
   const colors = ['#FF6B35', '#004E89', '#7B2D8E', '#1A936F', '#C5283D', '#E9724C', '#3498db', '#9b59b6', '#27ae60', '#f39c12']
   
   props.graphData.nodes.forEach(node => {
@@ -298,7 +298,7 @@ const entityTypes = computed(() => {
   return Object.values(typeMap)
 })
 
-// 格式化时间
+// Format datetime
 const formatDateTime = (dateStr) => {
   if (!dateStr) return ''
   try {
@@ -318,7 +318,7 @@ const formatDateTime = (dateStr) => {
 
 const closeDetailPanel = () => {
   selectedItem.value = null
-  expandedSelfLoops.value = new Set() // 重置展开状态
+  expandedSelfLoops.value = new Set() // Reset expanded state
 }
 
 let currentSimulation = null
@@ -328,7 +328,7 @@ let linkLabelBgRef = null
 const renderGraph = () => {
   if (!graphSvg.value || !props.graphData) return
   
-  // 停止之前的仿真
+  // Stop the previous simulation
   if (currentSimulation) {
     currentSimulation.stop()
   }
@@ -362,16 +362,16 @@ const renderGraph = () => {
   
   const nodeIds = new Set(nodes.map(n => n.id))
   
-  // 处理边数据，计算同一对节点间的边数量和索引
+  // Process edge data: count edges between each pair of nodes and assign per-pair indexes
   const edgePairCount = {}
-  const selfLoopEdges = {} // 按节点分组的自环边
+  const selfLoopEdges = {} // Self-loop edges grouped by node
   const tempEdges = edgesData
     .filter(e => nodeIds.has(e.source_node_uuid) && nodeIds.has(e.target_node_uuid))
-  
-  // 统计每对节点之间的边数量，收集自环边
+
+  // Count edges per node pair, collect self-loops
   tempEdges.forEach(e => {
     if (e.source_node_uuid === e.target_node_uuid) {
-      // 自环 - 收集到数组中
+      // Self-loop - collect into the array
       if (!selfLoopEdges[e.source_node_uuid]) {
         selfLoopEdges[e.source_node_uuid] = []
       }
@@ -386,9 +386,9 @@ const renderGraph = () => {
     }
   })
   
-  // 记录当前处理到每对节点的第几条边
+  // Track which edge index we're up to within each node pair
   const edgePairIndex = {}
-  const processedSelfLoopNodes = new Set() // 已处理的自环节点
+  const processedSelfLoopNodes = new Set() // Self-loop nodes already processed
   
   const edges = []
   
@@ -396,9 +396,9 @@ const renderGraph = () => {
     const isSelfLoop = e.source_node_uuid === e.target_node_uuid
     
     if (isSelfLoop) {
-      // 自环边 - 每个节点只添加一条合并的自环
+      // Self-loop edge - emit only one merged self-loop per node
       if (processedSelfLoopNodes.has(e.source_node_uuid)) {
-        return // 已处理过，跳过
+        return // Already processed; skip
       }
       processedSelfLoopNodes.add(e.source_node_uuid)
       
@@ -417,7 +417,7 @@ const renderGraph = () => {
           source_name: nodeName,
           target_name: nodeName,
           selfLoopCount: allSelfLoops.length,
-          selfLoopEdges: allSelfLoops // 存储所有自环边的详细信息
+          selfLoopEdges: allSelfLoops // Store the details of every self-loop edge
         }
       })
       return
@@ -428,19 +428,19 @@ const renderGraph = () => {
     const currentIndex = edgePairIndex[pairKey] || 0
     edgePairIndex[pairKey] = currentIndex + 1
     
-    // 判断边的方向是否与标准化方向一致（源UUID < 目标UUID）
+    // Whether this edge's direction matches the normalized direction (source UUID < target UUID)
     const isReversed = e.source_node_uuid > e.target_node_uuid
-    
-    // 计算曲率：多条边时分散开，单条边为直线
+
+    // Compute curvature: spread multiple edges apart; single edge is straight
     let curvature = 0
     if (totalCount > 1) {
-      // 均匀分布曲率，确保明显区分
-      // 曲率范围根据边数量增加，边越多曲率范围越大
+      // Spread curvature evenly so each edge is visibly distinct.
+      // The curvature range grows with edge count — more edges means a wider spread.
       const curvatureRange = Math.min(1.2, 0.6 + totalCount * 0.15)
       curvature = ((currentIndex / (totalCount - 1)) - 0.5) * curvatureRange * 2
-      
-      // 如果边的方向与标准化方向相反，翻转曲率
-      // 这样确保所有边在同一参考系下分布，不会因方向不同而重叠
+
+      // If the edge direction is reversed relative to the normalized one, flip the curvature
+      // so every edge is laid out in the same reference frame and the directions don't overlap.
       if (isReversed) {
         curvature = -curvature
       }
@@ -468,11 +468,11 @@ const renderGraph = () => {
   entityTypes.value.forEach(t => colorMap[t.name] = t.color)
   const getColor = (type) => colorMap[type] || '#999'
 
-  // Simulation - 根据边数量动态调整节点间距
+  // Simulation - dynamically adjust node spacing based on edge count
   const simulation = d3.forceSimulation(nodes)
     .force('link', d3.forceLink(edges).id(d => d.id).distance(d => {
-      // 根据这对节点之间的边数量动态调整距离
-      // 基础距离 150，每多一条边增加 40
+      // Dynamically adjust distance based on the number of edges between the pair.
+      // Base distance is 150; add 50 per additional edge.
       const baseDistance = 150
       const edgeCount = d.pairTotal || 1
       return baseDistance + (edgeCount - 1) * 50
@@ -480,7 +480,7 @@ const renderGraph = () => {
     .force('charge', d3.forceManyBody().strength(-400))
     .force('center', d3.forceCenter(width / 2, height / 2))
     .force('collide', d3.forceCollide(50))
-    // 添加向中心的引力，让独立的节点群聚集到中心区域
+    // Attract toward the center so disconnected node clusters settle near the middle
     .force('x', d3.forceX(width / 2).strength(0.04))
     .force('y', d3.forceY(height / 2).strength(0.04))
   
@@ -493,39 +493,39 @@ const renderGraph = () => {
     g.attr('transform', event.transform)
   }))
 
-  // Links - 使用 path 支持曲线
+  // Links - use <path> so we can draw curves
   const linkGroup = g.append('g').attr('class', 'links')
-  
-  // 计算曲线路径
+
+  // Compute the curve path
   const getLinkPath = (d) => {
     const sx = d.source.x, sy = d.source.y
     const tx = d.target.x, ty = d.target.y
-    
-    // 检测自环
+
+    // Detect self-loop
     if (d.isSelfLoop) {
-      // 自环：绘制一个圆弧从节点出发再返回
+      // Self-loop: draw an arc that starts at the node and returns to it
       const loopRadius = 30
-      // 从节点右侧出发，绕一圈回来
-      const x1 = sx + 8  // 起点偏移
+      // Start to the right of the node and loop around
+      const x1 = sx + 8  // Start offset
       const y1 = sy - 4
-      const x2 = sx + 8  // 终点偏移
+      const x2 = sx + 8  // End offset
       const y2 = sy + 4
-      // 使用圆弧绘制自环（sweep-flag=1 顺时针）
+      // Use an arc to draw the self-loop (sweep-flag=1 clockwise)
       return `M${x1},${y1} A${loopRadius},${loopRadius} 0 1,1 ${x2},${y2}`
     }
-    
+
     if (d.curvature === 0) {
-      // 直线
+      // Straight line
       return `M${sx},${sy} L${tx},${ty}`
     }
-    
-    // 计算曲线控制点 - 根据边数量和距离动态调整
+
+    // Compute curve control point - dynamically tuned by edge count and distance
     const dx = tx - sx, dy = ty - sy
     const dist = Math.sqrt(dx * dx + dy * dy)
-    // 垂直于连线方向的偏移，根据距离比例计算，保证曲线明显可见
-    // 边越多，偏移量占距离的比例越大
+    // Offset perpendicular to the line, scaled to a fraction of the distance so the curve stays visible.
+    // The more edges in the pair, the larger the proportion of distance we use.
     const pairTotal = d.pairTotal || 1
-    const offsetRatio = 0.25 + pairTotal * 0.05 // 基础25%，每多一条边增加5%
+    const offsetRatio = 0.25 + pairTotal * 0.05 // 25% base, plus 5% per additional edge
     const baseOffset = Math.max(35, dist * offsetRatio)
     const offsetX = -dy / dist * d.curvature * baseOffset
     const offsetY = dx / dist * d.curvature * baseOffset
@@ -535,14 +535,14 @@ const renderGraph = () => {
     return `M${sx},${sy} Q${cx},${cy} ${tx},${ty}`
   }
   
-  // 计算曲线中点（用于标签定位）
+  // Compute the midpoint of the curve (used to position labels)
   const getLinkMidpoint = (d) => {
     const sx = d.source.x, sy = d.source.y
     const tx = d.target.x, ty = d.target.y
-    
-    // 检测自环
+
+    // Detect self-loop
     if (d.isSelfLoop) {
-      // 自环标签位置：节点右侧
+      // Self-loop label position: to the right of the node
       return { x: sx + 70, y: sy }
     }
     
@@ -550,7 +550,7 @@ const renderGraph = () => {
       return { x: (sx + tx) / 2, y: (sy + ty) / 2 }
     }
     
-    // 二次贝塞尔曲线的中点 t=0.5
+    // Quadratic Bezier midpoint at t=0.5
     const dx = tx - sx, dy = ty - sy
     const dist = Math.sqrt(dx * dx + dy * dy)
     const pairTotal = d.pairTotal || 1
@@ -561,7 +561,7 @@ const renderGraph = () => {
     const cx = (sx + tx) / 2 + offsetX
     const cy = (sy + ty) / 2 + offsetY
     
-    // 二次贝塞尔曲线公式 B(t) = (1-t)²P0 + 2(1-t)tP1 + t²P2, t=0.5
+    // Quadratic Bezier formula B(t) = (1-t)²P0 + 2(1-t)tP1 + t²P2, with t=0.5
     const midX = 0.25 * sx + 0.5 * cx + 0.25 * tx
     const midY = 0.25 * sy + 0.5 * cy + 0.25 * ty
     
@@ -577,11 +577,11 @@ const renderGraph = () => {
     .style('cursor', 'pointer')
     .on('click', (event, d) => {
       event.stopPropagation()
-      // 重置之前选中边的样式
+      // Reset the style of any previously selected edge
       linkGroup.selectAll('path').attr('stroke', '#C0C0C0').attr('stroke-width', 1.5)
       linkLabelBg.attr('fill', 'rgba(255,255,255,0.95)')
       linkLabels.attr('fill', '#666')
-      // 高亮当前选中的边
+      // Highlight the currently selected edge
       d3.select(event.target).attr('stroke', '#3498db').attr('stroke-width', 3)
       
       selectedItem.value = {
@@ -590,7 +590,7 @@ const renderGraph = () => {
       }
     })
 
-  // Link labels background (白色背景使文字更清晰)
+  // Link labels background (white background keeps the text legible)
   const linkLabelBg = linkGroup.selectAll('rect')
     .data(edges)
     .enter().append('rect')
@@ -605,7 +605,7 @@ const renderGraph = () => {
       linkGroup.selectAll('path').attr('stroke', '#C0C0C0').attr('stroke-width', 1.5)
       linkLabelBg.attr('fill', 'rgba(255,255,255,0.95)')
       linkLabels.attr('fill', '#666')
-      // 高亮对应的边
+      // Highlight the corresponding edge
       link.filter(l => l === d).attr('stroke', '#3498db').attr('stroke-width', 3)
       d3.select(event.target).attr('fill', 'rgba(52, 152, 219, 0.1)')
       
@@ -633,7 +633,7 @@ const renderGraph = () => {
       linkGroup.selectAll('path').attr('stroke', '#C0C0C0').attr('stroke-width', 1.5)
       linkLabelBg.attr('fill', 'rgba(255,255,255,0.95)')
       linkLabels.attr('fill', '#666')
-      // 高亮对应的边
+      // Highlight the corresponding edge
       link.filter(l => l === d).attr('stroke', '#3498db').attr('stroke-width', 3)
       d3.select(event.target).attr('fill', '#3498db')
       
@@ -643,7 +643,7 @@ const renderGraph = () => {
       }
     })
   
-  // 保存引用供外部控制显隐
+  // Keep refs so external code can toggle visibility
   linkLabelsRef = linkLabels
   linkLabelBgRef = linkLabelBg
 
@@ -661,7 +661,7 @@ const renderGraph = () => {
     .style('cursor', 'pointer')
     .call(d3.drag()
       .on('start', (event, d) => {
-        // 只记录位置，不重启仿真（区分点击和拖拽）
+        // Just record the position; don't restart the simulation yet (distinguish click vs drag)
         d.fx = d.x
         d.fy = d.y
         d._dragStartX = event.x
@@ -669,13 +669,13 @@ const renderGraph = () => {
         d._isDragging = false
       })
       .on('drag', (event, d) => {
-        // 检测是否真正开始拖拽（移动超过阈值）
+        // Detect whether dragging has actually started (movement above threshold)
         const dx = event.x - d._dragStartX
         const dy = event.y - d._dragStartY
         const distance = Math.sqrt(dx * dx + dy * dy)
         
         if (!d._isDragging && distance > 3) {
-          // 首次检测到真正拖拽，才重启仿真
+          // Restart the simulation only on the first real drag
           d._isDragging = true
           simulation.alphaTarget(0.3).restart()
         }
@@ -686,7 +686,7 @@ const renderGraph = () => {
         }
       })
       .on('end', (event, d) => {
-        // 只有真正拖拽过才让仿真逐渐停止
+        // Only ease the simulation back to rest if there was actually a drag
         if (d._isDragging) {
           simulation.alphaTarget(0)
         }
@@ -697,12 +697,12 @@ const renderGraph = () => {
     )
     .on('click', (event, d) => {
       event.stopPropagation()
-      // 重置所有节点样式
+      // Reset every node's style
       node.attr('stroke', '#fff').attr('stroke-width', 2.5)
       linkGroup.selectAll('path').attr('stroke', '#C0C0C0').attr('stroke-width', 1.5)
-      // 高亮选中节点
+      // Highlight the selected node
       d3.select(event.target).attr('stroke', '#E91E63').attr('stroke-width', 4)
-      // 高亮与此节点相连的边
+      // Highlight edges connected to this node
       link.filter(l => l.source.id === d.id || l.target.id === d.id)
         .attr('stroke', '#E91E63')
         .attr('stroke-width', 2.5)
@@ -739,19 +739,19 @@ const renderGraph = () => {
     .style('font-family', 'system-ui, sans-serif')
 
   simulation.on('tick', () => {
-    // 更新曲线路径
+    // Update curve paths
     link.attr('d', d => getLinkPath(d))
     
-    // 更新边标签位置（无旋转，水平显示更清晰）
+    // Update edge label positions (no rotation — horizontal is more legible)
     linkLabels.each(function(d) {
       const mid = getLinkMidpoint(d)
       d3.select(this)
         .attr('x', mid.x)
         .attr('y', mid.y)
-        .attr('transform', '') // 移除旋转，保持水平
+        .attr('transform', '') // Remove rotation, keep horizontal
     })
     
-    // 更新边标签背景
+    // Update edge label background
     linkLabelBg.each(function(d, i) {
       const mid = getLinkMidpoint(d)
       const textEl = linkLabels.nodes()[i]
@@ -761,7 +761,7 @@ const renderGraph = () => {
         .attr('y', mid.y - bbox.height / 2 - 2)
         .attr('width', bbox.width + 8)
         .attr('height', bbox.height + 4)
-        .attr('transform', '') // 移除旋转
+        .attr('transform', '') // Remove rotation
     })
 
     node
@@ -773,7 +773,7 @@ const renderGraph = () => {
       .attr('y', d => d.y)
   })
   
-  // 点击空白处关闭详情面板
+  // Click on empty space closes the detail panel
   svg.on('click', () => {
     selectedItem.value = null
     node.attr('stroke', '#fff').attr('stroke-width', 2.5)
@@ -787,7 +787,7 @@ watch(() => props.graphData, () => {
   nextTick(renderGraph)
 }, { deep: true })
 
-// 监听边标签显示开关
+// Watch the edge-labels toggle
 watch(showEdgeLabels, (newVal) => {
   if (linkLabelsRef) {
     linkLabelsRef.style('display', newVal ? 'block' : 'none')
@@ -1250,7 +1250,7 @@ input:checked + .slider:before {
   50% { opacity: 1; transform: scale(1.15); filter: drop-shadow(0 0 8px rgba(76, 175, 80, 0.6)); }
 }
 
-/* 模拟结束后的提示样式 */
+/* Post-simulation hint styles */
 .graph-building-hint.finished-hint {
   background: rgba(0, 0, 0, 0.65);
   border: 1px solid rgba(255, 255, 255, 0.1);

--- a/frontend/src/components/HistoryDatabase.vue
+++ b/frontend/src/components/HistoryDatabase.vue
@@ -4,20 +4,20 @@
     :class="{ 'no-projects': projects.length === 0 && !loading }"
     ref="historyContainer"
   >
-    <!-- 背景装饰：技术网格线（只在有项目时显示） -->
+    <!-- Background decoration: tech grid lines (only shown when projects exist) -->
     <div v-if="projects.length > 0 || loading" class="tech-grid-bg">
       <div class="grid-pattern"></div>
       <div class="gradient-overlay"></div>
     </div>
 
-    <!-- 标题区域 -->
+    <!-- Title section -->
     <div class="section-header">
       <div class="section-line"></div>
       <span class="section-title">{{ $t('history.title') }}</span>
       <div class="section-line"></div>
     </div>
 
-    <!-- 卡片容器（只在有项目时显示） -->
+    <!-- Card container (only shown when projects exist) -->
     <div v-if="projects.length > 0" class="cards-container" :class="{ expanded: isExpanded }" :style="containerStyle">
       <div 
         v-for="(project, index) in projects" 
@@ -29,7 +29,7 @@
         @mouseleave="hoveringCard = null"
         @click="navigateToProject(project)"
       >
-        <!-- 卡片头部：simulation_id 和 功能可用状态 -->
+        <!-- Card header: simulation_id and feature-availability status -->
         <div class="card-header">
           <span class="card-id">{{ formatSimulationId(project.simulation_id) }}</span>
           <div class="card-status-icons">
@@ -50,12 +50,12 @@
           </div>
         </div>
 
-        <!-- 文件列表区域 -->
+        <!-- File list section -->
         <div class="card-files-wrapper">
-          <!-- 角落装饰 - 取景框风格 -->
+          <!-- Corner decoration - viewfinder style -->
           <div class="corner-mark top-left-only"></div>
-          
-          <!-- 文件列表 -->
+
+          <!-- File list -->
           <div class="files-list" v-if="project.files && project.files.length > 0">
             <div 
               v-for="(file, fileIndex) in project.files.slice(0, 3)" 
@@ -65,25 +65,25 @@
               <span class="file-tag" :class="getFileType(file.filename)">{{ getFileTypeLabel(file.filename) }}</span>
               <span class="file-name">{{ truncateFilename(file.filename, 20) }}</span>
             </div>
-            <!-- 如果有更多文件，显示提示 -->
+            <!-- Show a hint if there are more files -->
             <div v-if="project.files.length > 3" class="files-more">
               {{ $t('history.moreFiles', { count: project.files.length - 3 }) }}
             </div>
           </div>
-          <!-- 无文件时的占位 -->
+          <!-- Placeholder when there are no files -->
           <div class="files-empty" v-else>
             <span class="empty-file-icon">◇</span>
             <span class="empty-file-text">{{ $t('history.noFiles') }}</span>
           </div>
         </div>
 
-        <!-- 卡片标题（使用模拟需求的前20字作为标题） -->
+        <!-- Card title (first 20 chars of the simulation requirement) -->
         <h3 class="card-title">{{ getSimulationTitle(project.simulation_requirement) }}</h3>
 
-        <!-- 卡片描述（模拟需求完整展示） -->
+        <!-- Card description (full simulation requirement) -->
         <p class="card-desc">{{ truncateText(project.simulation_requirement, 55) }}</p>
 
-        <!-- 卡片底部 -->
+        <!-- Card footer -->
         <div class="card-footer">
           <div class="card-datetime">
             <span class="card-date">{{ formatDate(project.created_at) }}</span>
@@ -94,23 +94,23 @@
           </span>
         </div>
         
-        <!-- 底部装饰线 (hover时展开) -->
+        <!-- Bottom decorative line (expands on hover) -->
         <div class="card-bottom-line"></div>
       </div>
     </div>
 
-    <!-- 加载状态 -->
+    <!-- Loading state -->
     <div v-if="loading" class="loading-state">
       <span class="loading-spinner"></span>
       <span class="loading-text">{{ $t('history.loadingText') }}</span>
     </div>
 
-    <!-- 历史回放详情弹窗 -->
+    <!-- History replay detail modal -->
     <Teleport to="body">
       <Transition name="modal">
         <div v-if="selectedProject" class="modal-overlay" @click.self="closeModal">
           <div class="modal-content">
-            <!-- 弹窗头部 -->
+            <!-- Modal header -->
             <div class="modal-header">
               <div class="modal-title-section">
                 <span class="modal-id">{{ formatSimulationId(selectedProject.simulation_id) }}</span>
@@ -122,15 +122,15 @@
               <button class="modal-close" @click="closeModal">×</button>
             </div>
 
-            <!-- 弹窗内容 -->
+            <!-- Modal body -->
             <div class="modal-body">
-              <!-- 模拟需求 -->
+              <!-- Simulation requirement -->
               <div class="modal-section">
                 <div class="modal-label">{{ $t('history.simRequirement') }}</div>
                 <div class="modal-requirement">{{ selectedProject.simulation_requirement || $t('common.none') }}</div>
               </div>
 
-              <!-- 文件列表 -->
+              <!-- File list -->
               <div class="modal-section">
                 <div class="modal-label">{{ $t('history.relatedFiles') }}</div>
                 <div class="modal-files" v-if="selectedProject.files && selectedProject.files.length > 0">
@@ -143,14 +143,14 @@
               </div>
             </div>
 
-            <!-- 推演回放分割线 -->
+            <!-- Replay divider -->
             <div class="modal-divider">
               <span class="divider-line"></span>
               <span class="divider-text">{{ $t('history.replayTitle') }}</span>
               <span class="divider-line"></span>
             </div>
 
-            <!-- 导航按钮 -->
+            <!-- Navigation buttons -->
             <div class="modal-actions">
               <button 
                 class="modal-btn btn-project" 
@@ -179,7 +179,7 @@
                 <span class="btn-text">{{ $t('history.step4Button') }}</span>
               </button>
             </div>
-            <!-- 不可回放提示 -->
+            <!-- Not-replayable hint -->
             <div class="modal-playback-hint">
               <span class="hint-text">{{ $t('history.replayHint') }}</span>
             </div>
@@ -200,66 +200,66 @@ const router = useRouter()
 const route = useRoute()
 const { t } = useI18n()
 
-// 状态
+// State
 const projects = ref([])
 const loading = ref(true)
 const isExpanded = ref(false)
 const hoveringCard = ref(null)
 const historyContainer = ref(null)
-const selectedProject = ref(null)  // 当前选中的项目（用于弹窗）
+const selectedProject = ref(null)  // The project currently selected (for the modal)
 let observer = null
-let isAnimating = false  // 动画锁，防止闪烁
-let expandDebounceTimer = null  // 防抖定时器
-let pendingState = null  // 记录待执行的目标状态
+let isAnimating = false  // Animation lock to prevent flicker
+let expandDebounceTimer = null  // Debounce timer
+let pendingState = null  // Pending target state
 
-// 卡片布局配置 - 调整为更宽的比例
+// Card layout config - tuned for a wider aspect ratio
 const CARDS_PER_ROW = 4
 const CARD_WIDTH = 280  
 const CARD_HEIGHT = 280 
 const CARD_GAP = 24
 
-// 动态计算容器高度样式
+// Compute the container height style dynamically
 const containerStyle = computed(() => {
   if (!isExpanded.value) {
-    // 折叠态：固定高度
+    // Collapsed: fixed height
     return { minHeight: '420px' }
   }
-  
-  // 展开态：根据卡片数量动态计算高度
+
+  // Expanded: compute height from the number of cards
   const total = projects.value.length
   if (total === 0) {
     return { minHeight: '280px' }
   }
-  
+
   const rows = Math.ceil(total / CARDS_PER_ROW)
-  // 计算实际需要的高度：行数 * 卡片高度 + (行数-1) * 间距 + 少量底部间距
+  // Required height: rows * card height + (rows - 1) * gap + small bottom padding
   const expandedHeight = rows * CARD_HEIGHT + (rows - 1) * CARD_GAP + 10
   
   return { minHeight: `${expandedHeight}px` }
 })
 
-// 获取卡片样式
+// Compute card style
 const getCardStyle = (index) => {
   const total = projects.value.length
-  
+
   if (isExpanded.value) {
-    // 展开态：网格布局
+    // Expanded: grid layout
     const transition = 'transform 700ms cubic-bezier(0.23, 1, 0.32, 1), opacity 700ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 0.3s ease, border-color 0.3s ease'
 
     const col = index % CARDS_PER_ROW
     const row = Math.floor(index / CARDS_PER_ROW)
-    
-    // 计算当前行的卡片数量，确保每行居中
+
+    // Compute the cards on the current row to keep each row centered
     const currentRowStart = row * CARDS_PER_ROW
     const currentRowCards = Math.min(CARDS_PER_ROW, total - currentRowStart)
-    
+
     const rowWidth = currentRowCards * CARD_WIDTH + (currentRowCards - 1) * CARD_GAP
-    
+
     const startX = -(rowWidth / 2) + (CARD_WIDTH / 2)
     const colInRow = index % CARDS_PER_ROW
     const x = startX + colInRow * (CARD_WIDTH + CARD_GAP)
-    
-    // 向下展开，增加与标题的间距
+
+    // Expand downward; add some space below the title
     const y = 20 + row * (CARD_HEIGHT + CARD_GAP)
 
     return {
@@ -269,14 +269,14 @@ const getCardStyle = (index) => {
       transition: transition
     }
   } else {
-    // 折叠态：扇形堆叠
+    // Collapsed: fanned-out stack
     const transition = 'transform 700ms cubic-bezier(0.23, 1, 0.32, 1), opacity 700ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 0.3s ease, border-color 0.3s ease'
 
     const centerIndex = (total - 1) / 2
     const offset = index - centerIndex
-    
+
     const x = offset * 35
-    // 调整起始位置，靠近标题但保持适当间距
+    // Tune starting position: close to the title but with some spacing
     const y = 25 + Math.abs(offset) * 8
     const r = offset * 3
     const s = 0.95 - Math.abs(offset) * 0.05
@@ -290,24 +290,24 @@ const getCardStyle = (index) => {
   }
 }
 
-// 根据轮数进度获取样式类
+// Pick a CSS class based on round progress
 const getProgressClass = (simulation) => {
   const current = simulation.current_round || 0
   const total = simulation.total_rounds || 0
-  
+
   if (total === 0 || current === 0) {
-    // 未开始
+    // Not started
     return 'not-started'
   } else if (current >= total) {
-    // 已完成
+    // Completed
     return 'completed'
   } else {
-    // 进行中
+    // In progress
     return 'in-progress'
   }
 }
 
-// 格式化日期（只显示日期部分）
+// Format the date (date only)
 const formatDate = (dateStr) => {
   if (!dateStr) return ''
   try {
@@ -318,7 +318,7 @@ const formatDate = (dateStr) => {
   }
 }
 
-// 格式化时间（显示时:分）
+// Format the time (hours:minutes)
 const formatTime = (dateStr) => {
   if (!dateStr) return ''
   try {
@@ -331,27 +331,27 @@ const formatTime = (dateStr) => {
   }
 }
 
-// 截断文本
+// Truncate text
 const truncateText = (text, maxLength) => {
   if (!text) return ''
   return text.length > maxLength ? text.slice(0, maxLength) + '...' : text
 }
 
-// 从模拟需求生成标题（取前20字）
+// Build a title from the simulation requirement (first 20 chars)
 const getSimulationTitle = (requirement) => {
   if (!requirement) return t('history.untitledSimulation')
   const title = requirement.slice(0, 20)
   return requirement.length > 20 ? title + '...' : title
 }
 
-// 格式化 simulation_id 显示（截取前6位）
+// Format the simulation_id for display (first 6 chars)
 const formatSimulationId = (simulationId) => {
   if (!simulationId) return 'SIM_UNKNOWN'
   const prefix = simulationId.replace('sim_', '').slice(0, 6)
   return `SIM_${prefix.toUpperCase()}`
 }
 
-// 格式化轮数显示（当前轮/总轮数）
+// Format round display (current / total)
 const formatRounds = (simulation) => {
   const current = simulation.current_round || 0
   const total = simulation.total_rounds || 0
@@ -359,7 +359,7 @@ const formatRounds = (simulation) => {
   return t('history.roundsProgress', { current, total })
 }
 
-// 获取文件类型（用于样式）
+// Get file type (for styling)
 const getFileType = (filename) => {
   if (!filename) return 'other'
   const ext = filename.split('.').pop()?.toLowerCase()
@@ -375,14 +375,14 @@ const getFileType = (filename) => {
   return typeMap[ext] || 'other'
 }
 
-// 获取文件类型标签文本
+// Get the label text for the file-type tag
 const getFileTypeLabel = (filename) => {
   if (!filename) return 'FILE'
   const ext = filename.split('.').pop()?.toUpperCase()
   return ext || 'FILE'
 }
 
-// 截断文件名（保留扩展名）
+// Truncate filename (preserving extension)
 const truncateFilename = (filename, maxLength) => {
   if (!filename) return t('history.unknownFile')
   if (filename.length <= maxLength) return filename
@@ -393,17 +393,17 @@ const truncateFilename = (filename, maxLength) => {
   return truncatedName + ext
 }
 
-// 打开项目详情弹窗
+// Open the project detail modal
 const navigateToProject = (simulation) => {
   selectedProject.value = simulation
 }
 
-// 关闭弹窗
+// Close the modal
 const closeModal = () => {
   selectedProject.value = null
 }
 
-// 导航到图谱构建页面（Project）
+// Navigate to the graph-build page (Project)
 const goToProject = () => {
   if (selectedProject.value?.project_id) {
     router.push({
@@ -414,7 +414,7 @@ const goToProject = () => {
   }
 }
 
-// 导航到环境配置页面（Simulation）
+// Navigate to the environment-setup page (Simulation)
 const goToSimulation = () => {
   if (selectedProject.value?.simulation_id) {
     router.push({
@@ -425,7 +425,7 @@ const goToSimulation = () => {
   }
 }
 
-// 导航到分析报告页面（Report）
+// Navigate to the analysis-report page (Report)
 const goToReport = () => {
   if (selectedProject.value?.report_id) {
     router.push({
@@ -436,7 +436,7 @@ const goToReport = () => {
   }
 }
 
-// 加载历史项目
+// Load historical projects
 const loadHistory = async () => {
   try {
     loading.value = true
@@ -445,14 +445,14 @@ const loadHistory = async () => {
       projects.value = response.data || []
     }
   } catch (error) {
-    console.error('加载历史项目失败:', error)
+    console.error('Failed to load historical projects:', error)
     projects.value = []
   } finally {
     loading.value = false
   }
 }
 
-// 初始化 IntersectionObserver
+// Initialize the IntersectionObserver
 const initObserver = () => {
   if (observer) {
     observer.disconnect()
@@ -463,47 +463,47 @@ const initObserver = () => {
       entries.forEach((entry) => {
         const shouldExpand = entry.isIntersecting
         
-        // 更新待执行的目标状态（无论是否在动画中都要记录最新的目标状态）
+        // Update the pending target state (record the latest target whether or not we're animating)
         pendingState = shouldExpand
-        
-        // 清除之前的防抖定时器（新的滚动意图会覆盖旧的）
+
+        // Clear any prior debounce timer (a new scroll intent overrides the old one)
         if (expandDebounceTimer) {
           clearTimeout(expandDebounceTimer)
           expandDebounceTimer = null
         }
-        
-        // 如果正在动画中，只记录状态，等动画结束后处理
+
+        // If already animating, just record the state and handle it after the animation finishes
         if (isAnimating) return
-        
-        // 如果目标状态与当前状态相同，不需要处理
+
+        // If target equals current state, nothing to do
         if (shouldExpand === isExpanded.value) {
           pendingState = null
           return
         }
-        
-        // 使用防抖延迟状态切换，防止快速闪烁
-        // 展开时延迟较短(50ms)，收起时延迟较长(200ms)以增加稳定性
+
+        // Debounce the state toggle to avoid rapid flicker.
+        // Use a short delay (50ms) when expanding, longer (200ms) when collapsing for stability
         const delay = shouldExpand ? 50 : 200
-        
+
         expandDebounceTimer = setTimeout(() => {
-          // 检查是否正在动画
+          // Check whether an animation is still running
           if (isAnimating) return
-          
-          // 检查待执行状态是否仍需要执行（可能已被后续滚动覆盖）
+
+          // Check whether the pending state is still valid (it may have been overridden by a subsequent scroll)
           if (pendingState === null || pendingState === isExpanded.value) return
-          
-          // 设置动画锁
+
+          // Set the animation lock
           isAnimating = true
           isExpanded.value = pendingState
           pendingState = null
-          
-          // 动画完成后解除锁定，并检查是否有待处理的状态变化
+
+          // After the animation finishes, release the lock and check for any queued state change
           setTimeout(() => {
             isAnimating = false
-            
-            // 动画结束后，检查是否有新的待执行状态
+
+            // After animation, check for a new pending state
             if (pendingState !== null && pendingState !== isExpanded.value) {
-              // 延迟一小段时间再执行，避免太快切换
+              // Wait a brief moment so we don't toggle too fast
               expandDebounceTimer = setTimeout(() => {
                 if (pendingState !== null && pendingState !== isExpanded.value) {
                   isAnimating = true
@@ -520,20 +520,20 @@ const initObserver = () => {
       })
     },
     {
-      // 使用多个阈值，使检测更平滑
+      // Use multiple thresholds to smooth detection
       threshold: [0.4, 0.6, 0.8],
-      // 调整 rootMargin，视口底部向上收缩，需要滚动更多才触发展开
+      // Tighten rootMargin: shrink the viewport bottom upward so the user must scroll further before expansion triggers
       rootMargin: '0px 0px -150px 0px'
     }
   )
-  
-  // 开始观察
+
+  // Begin observing
   if (historyContainer.value) {
     observer.observe(historyContainer.value)
   }
 }
 
-// 监听路由变化，当返回首页时重新加载数据
+// Watch route changes; reload data when returning to the home page
 watch(() => route.path, (newPath) => {
   if (newPath === '/') {
     loadHistory()
@@ -541,28 +541,28 @@ watch(() => route.path, (newPath) => {
 })
 
 onMounted(async () => {
-  // 确保 DOM 渲染完成后再加载数据
+  // Wait for the DOM to render before loading data
   await nextTick()
   await loadHistory()
-  
-  // 等待 DOM 渲染后初始化观察器
+
+  // Initialize the observer once the DOM has rendered
   setTimeout(() => {
     initObserver()
   }, 100)
 })
 
-// 如果使用 keep-alive，在组件激活时重新加载数据
+// When used with keep-alive, reload data on activation
 onActivated(() => {
   loadHistory()
 })
 
 onUnmounted(() => {
-  // 清理 Intersection Observer
+  // Clean up the Intersection Observer
   if (observer) {
     observer.disconnect()
     observer = null
   }
-  // 清理防抖定时器
+  // Clean up the debounce timer
   if (expandDebounceTimer) {
     clearTimeout(expandDebounceTimer)
     expandDebounceTimer = null
@@ -571,7 +571,7 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-/* 容器 */
+/* Container */
 .history-database {
   position: relative;
   width: 100%;
@@ -581,13 +581,13 @@ onUnmounted(() => {
   overflow: visible;
 }
 
-/* 无项目时简化显示 */
+/* Simplified display when there are no projects */
 .history-database.no-projects {
   min-height: auto;
   padding: 40px 0 20px;
 }
 
-/* 技术网格背景 */
+/* Tech grid background */
 .tech-grid-bg {
   position: absolute;
   top: 0;
@@ -598,7 +598,7 @@ onUnmounted(() => {
   pointer-events: none;
 }
 
-/* 使用CSS背景图案创建固定间距的正方形网格 */
+/* Use a CSS background pattern for a fixed-spacing square grid */
 .grid-pattern {
   position: absolute;
   top: 0;
@@ -609,7 +609,7 @@ onUnmounted(() => {
     linear-gradient(to right, rgba(0, 0, 0, 0.05) 1px, transparent 1px),
     linear-gradient(to bottom, rgba(0, 0, 0, 0.05) 1px, transparent 1px);
   background-size: 50px 50px;
-  /* 从左上角开始定位，高度变化时只在底部扩展，不影响已有网格位置 */
+  /* Anchor at top-left so height changes only extend the bottom and don't shift the existing grid */
   background-position: top left;
 }
 
@@ -625,7 +625,7 @@ onUnmounted(() => {
   pointer-events: none;
 }
 
-/* 标题区域 */
+/* Title section */
 .section-header {
   position: relative;
   z-index: 100;
@@ -653,7 +653,7 @@ onUnmounted(() => {
   text-transform: uppercase;
 }
 
-/* 卡片容器 */
+/* Card container */
 .cards-container {
   position: relative;
   display: flex;
@@ -661,10 +661,10 @@ onUnmounted(() => {
   align-items: flex-start;
   padding: 0 40px;
   transition: min-height 700ms cubic-bezier(0.23, 1, 0.32, 1);
-  /* min-height 由 JS 动态计算，根据卡片数量自适应 */
+  /* min-height is computed dynamically in JS based on card count */
 }
 
-/* 项目卡片 */
+/* Project card */
 .project-card {
   position: absolute;
   width: 280px;
@@ -687,7 +687,7 @@ onUnmounted(() => {
   z-index: 1000 !important;
 }
 
-/* 卡片头部 */
+/* Card header */
 .card-header {
   display: flex;
   justify-content: space-between;
@@ -705,7 +705,7 @@ onUnmounted(() => {
   font-weight: 500;
 }
 
-/* 功能状态图标组 */
+/* Feature status icon group */
 .card-status-icons {
   display: flex;
   align-items: center;
@@ -722,17 +722,17 @@ onUnmounted(() => {
   opacity: 1;
 }
 
-/* 不同功能的颜色 */
-.status-icon:nth-child(1).available { color: #3B82F6; } /* 图谱构建 - 蓝色 */
-.status-icon:nth-child(2).available { color: #F59E0B; } /* 环境搭建 - 橙色 */
-.status-icon:nth-child(3).available { color: #10B981; } /* 分析报告 - 绿色 */
+/* Per-feature colors */
+.status-icon:nth-child(1).available { color: #3B82F6; } /* Graph build - blue */
+.status-icon:nth-child(2).available { color: #F59E0B; } /* Environment setup - orange */
+.status-icon:nth-child(3).available { color: #10B981; } /* Analysis report - green */
 
 .status-icon.unavailable {
   color: #D1D5DB;
   opacity: 0.5;
 }
 
-/* 轮数进度显示 */
+/* Round progress display */
 .card-progress {
   display: flex;
   align-items: center;
@@ -746,13 +746,13 @@ onUnmounted(() => {
   font-size: 0.5rem;
 }
 
-/* 进度状态颜色 */
-.card-progress.completed { color: #10B981; }    /* 已完成 - 绿色 */
-.card-progress.in-progress { color: #F59E0B; }  /* 进行中 - 橙色 */
-.card-progress.not-started { color: #9CA3AF; }  /* 未开始 - 灰色 */
+/* Progress state colors */
+.card-progress.completed { color: #10B981; }    /* Completed - green */
+.card-progress.in-progress { color: #F59E0B; }  /* In progress - orange */
+.card-progress.not-started { color: #9CA3AF; }  /* Not started - gray */
 .card-status.pending { color: #9CA3AF; }
 
-/* 文件列表区域 */
+/* File list section */
 .card-files-wrapper {
   position: relative;
   width: 100%;
@@ -772,7 +772,7 @@ onUnmounted(() => {
   gap: 4px;
 }
 
-/* 更多文件提示 */
+/* More-files hint */
 .files-more {
   display: flex;
   align-items: center;
@@ -802,7 +802,7 @@ onUnmounted(() => {
   border-color: #e5e7eb;
 }
 
-/* 简约文件标签样式 */
+/* Minimal file-tag styles */
 .file-tag {
   display: inline-flex;
   align-items: center;
@@ -820,7 +820,7 @@ onUnmounted(() => {
   min-width: 28px;
 }
 
-/* 低饱和度配色方案 - Morandi色系 */
+/* Low-saturation color scheme - Morandi palette */
 .file-tag.pdf { background: #f2e6e6; color: #a65a5a; }
 .file-tag.doc { background: #e6eff5; color: #5a7ea6; }
 .file-tag.xls { background: #e6f2e8; color: #5aa668; }
@@ -841,7 +841,7 @@ onUnmounted(() => {
   letter-spacing: 0.1px;
 }
 
-/* 无文件时的占位 */
+/* Placeholder when there are no files */
 .files-empty {
   display: flex;
   align-items: center;
@@ -862,13 +862,13 @@ onUnmounted(() => {
   letter-spacing: 0.5px;
 }
 
-/* 悬停时文件区域效果 */
+/* File-area effect on hover */
 .project-card:hover .card-files-wrapper {
   border-color: #d1d5db;
   background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
 }
 
-/* 角落装饰 */
+/* Corner decoration */
 .corner-mark.top-left-only {
   position: absolute;
   top: 6px;
@@ -881,7 +881,7 @@ onUnmounted(() => {
   z-index: 10;
 }
 
-/* 卡片标题 */
+/* Card title */
 .card-title {
   font-family: 'Inter', -apple-system, sans-serif;
   font-size: 0.9rem;
@@ -899,7 +899,7 @@ onUnmounted(() => {
   color: #2563EB;
 }
 
-/* 卡片描述 */
+/* Card description */
 .card-desc {
   font-family: 'Inter', sans-serif;
   font-size: 0.75rem;
@@ -913,7 +913,7 @@ onUnmounted(() => {
   -webkit-box-orient: vertical;
 }
 
-/* 卡片底部 */
+/* Card footer */
 .card-footer {
   position: relative;
   display: flex;
@@ -927,14 +927,14 @@ onUnmounted(() => {
   font-weight: 500;
 }
 
-/* 日期时间组合 */
+/* Combined date and time */
 .card-datetime {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-/* 底部轮数进度显示 */
+/* Bottom round-progress display */
 .card-footer .card-progress {
   display: flex;
   align-items: center;
@@ -948,12 +948,12 @@ onUnmounted(() => {
   font-size: 0.5rem;
 }
 
-/* 进度状态颜色 - 底部 */
+/* Progress-state colors (bottom) */
 .card-footer .card-progress.completed { color: #10B981; }
 .card-footer .card-progress.in-progress { color: #F59E0B; }
 .card-footer .card-progress.not-started { color: #9CA3AF; }
 
-/* 底部装饰线 */
+/* Bottom decorative line */
 .card-bottom-line {
   position: absolute;
   bottom: 0;
@@ -969,7 +969,7 @@ onUnmounted(() => {
   width: 100%;
 }
 
-/* 空状态 */
+/* Empty state */
 .empty-state, .loading-state {
   display: flex;
   flex-direction: column;
@@ -997,7 +997,7 @@ onUnmounted(() => {
   to { transform: rotate(360deg); }
 }
 
-/* 响应式 */
+/* Responsive */
 @media (max-width: 1200px) {
   .project-card {
     width: 240px;
@@ -1013,7 +1013,7 @@ onUnmounted(() => {
   }
 }
 
-/* ===== 历史回放详情弹窗样式 ===== */
+/* ===== History replay detail modal styles ===== */
 .modal-overlay {
   position: fixed;
   top: 0;
@@ -1039,7 +1039,7 @@ onUnmounted(() => {
   box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
 }
 
-/* 动画过渡 */
+/* Animation transitions */
 .modal-enter-active,
 .modal-leave-active {
   transition: opacity 0.3s ease;
@@ -1068,7 +1068,7 @@ onUnmounted(() => {
   opacity: 0;
 }
 
-/* 弹窗头部 */
+/* Modal header */
 .modal-header {
   display: flex;
   justify-content: space-between;
@@ -1135,7 +1135,7 @@ onUnmounted(() => {
   color: #111827;
 }
 
-/* 弹窗内容 */
+/* Modal body */
 .modal-body {
   padding: 24px 32px;
 }
@@ -1177,7 +1177,7 @@ onUnmounted(() => {
   padding-right: 4px;
 }
 
-/* 自定义滚动条样式 */
+/* Custom scrollbar styles */
 .modal-files::-webkit-scrollbar {
   width: 4px;
 }
@@ -1231,7 +1231,7 @@ onUnmounted(() => {
   text-align: center;
 }
 
-/* 推演回放分割线 */
+/* Replay divider */
 .modal-divider {
   display: flex;
   align-items: center;
@@ -1255,7 +1255,7 @@ onUnmounted(() => {
   white-space: nowrap;
 }
 
-/* 导航按钮 */
+/* Navigation buttons */
 .modal-actions {
   display: flex;
   gap: 16px;
@@ -1322,7 +1322,7 @@ onUnmounted(() => {
   color: #111827;
 }
 
-/* 不可回放提示 */
+/* Not-replayable hint */
 .modal-playback-hint {
   display: flex;
   align-items: center;

--- a/frontend/src/components/Step1GraphBuild.vue
+++ b/frontend/src/components/Step1GraphBuild.vue
@@ -210,10 +210,10 @@ const selectedOntologyItem = ref(null)
 const logContent = ref(null)
 const creatingSimulation = ref(false)
 
-// 进入环境搭建 - 创建 simulation 并跳转
+// Enter environment setup - create simulation and navigate
 const handleEnterEnvSetup = async () => {
   if (!props.projectData?.project_id || !props.projectData?.graph_id) {
-    console.error('缺少项目或图谱信息')
+    console.error('Missing project or graph information')
     return
   }
   
@@ -228,17 +228,17 @@ const handleEnterEnvSetup = async () => {
     })
     
     if (res.success && res.data?.simulation_id) {
-      // 跳转到 simulation 页面
+      // Navigate to the simulation page
       router.push({
         name: 'Simulation',
         params: { simulationId: res.data.simulation_id }
       })
     } else {
-      console.error('创建模拟失败:', res.error)
+      console.error('Failed to create simulation:', res.error)
       alert(t('step1.createSimulationFailed', { error: res.error || t('common.unknownError') }))
     }
   } catch (err) {
-    console.error('创建模拟异常:', err)
+    console.error('Exception while creating simulation:', err)
     alert(t('step1.createSimulationException', { error: err.message }))
   } finally {
     creatingSimulation.value = false

--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="env-setup-panel">
     <div class="scroll-container">
-      <!-- Step 01: 模拟实例 -->
+      <!-- Step 01: Simulation Instance -->
       <div class="step-card" :class="{ 'active': phase === 0, 'completed': phase > 0 }">
         <div class="card-header">
           <div class="step-info">
@@ -41,7 +41,7 @@
         </div>
       </div>
 
-      <!-- Step 02: 生成 Agent 人设 -->
+      <!-- Step 02: Generate Agent Personas -->
       <div class="step-card" :class="{ 'active': phase === 1, 'completed': phase > 1 }">
         <div class="card-header">
           <div class="step-info">
@@ -113,7 +113,7 @@
         </div>
       </div>
 
-      <!-- Step 03: 生成双平台模拟配置 -->
+      <!-- Step 03: Generate Dual-Platform Simulation Config -->
       <div class="step-card" :class="{ 'active': phase === 2, 'completed': phase > 2 }">
         <div class="card-header">
           <div class="step-info">
@@ -135,7 +135,7 @@
           
           <!-- Config Preview -->
           <div v-if="simulationConfig" class="config-detail-panel">
-            <!-- 时间配置 -->
+            <!-- Time configuration -->
             <div class="config-block">
               <div class="config-grid">
                 <div class="config-item">
@@ -179,7 +179,7 @@
               </div>
             </div>
 
-            <!-- Agent 配置 -->
+            <!-- Agent configuration -->
             <div class="config-block">
               <div class="config-block-header">
                 <span class="config-block-title">{{ $t('step2.agentConfig') }}</span>
@@ -191,7 +191,7 @@
                   :key="agent.agent_id" 
                   class="agent-card"
                 >
-                  <!-- 卡片头部 -->
+                  <!-- Card header -->
                   <div class="agent-card-header">
                     <div class="agent-identity">
                       <span class="agent-id">Agent {{ agent.agent_id }}</span>
@@ -203,7 +203,7 @@
                     </div>
                   </div>
                   
-                  <!-- 活跃时间轴 -->
+                  <!-- Activity timeline -->
                   <div class="agent-timeline">
                     <span class="timeline-label">{{ $t('step2.activeTimePeriod') }}</span>
                     <div class="mini-timeline">
@@ -224,7 +224,7 @@
                     </div>
                   </div>
 
-                  <!-- 行为参数 -->
+                  <!-- Behavior parameters -->
                   <div class="agent-params">
                     <div class="param-group">
                       <div class="param-item">
@@ -264,7 +264,7 @@
               </div>
             </div>
 
-            <!-- 平台配置 -->
+            <!-- Platform configuration -->
             <div class="config-block">
               <div class="config-block-header">
                 <span class="config-block-title">{{ $t('step2.recommendAlgoConfig') }}</span>
@@ -327,7 +327,7 @@
               </div>
             </div>
 
-            <!-- LLM 配置推理 -->
+            <!-- LLM configuration reasoning -->
             <div v-if="simulationConfig.generation_reasoning" class="config-block">
               <div class="config-block-header">
                 <span class="config-block-title">{{ $t('step2.llmConfigReasoning') }}</span>
@@ -346,7 +346,7 @@
         </div>
       </div>
 
-      <!-- Step 04: 初始激活编排 -->
+      <!-- Step 04: Initial Activation Orchestration -->
       <div class="step-card" :class="{ 'active': phase === 3, 'completed': phase > 3 }">
         <div class="card-header">
           <div class="step-info">
@@ -367,7 +367,7 @@
           </p>
 
           <div v-if="simulationConfig?.event_config" class="orchestration-content">
-            <!-- 叙事方向 -->
+            <!-- Narrative direction -->
             <div class="narrative-box">
               <span class="box-label narrative-label">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="special-icon">
@@ -385,7 +385,7 @@
               <p class="narrative-text">{{ simulationConfig.event_config.narrative_direction }}</p>
             </div>
 
-            <!-- 热点话题 -->
+            <!-- Hot topics -->
             <div class="topics-section">
               <span class="box-label">{{ $t('step2.initialHotTopics') }}</span>
               <div class="hot-topics-grid">
@@ -395,7 +395,7 @@
               </div>
             </div>
 
-            <!-- 初始帖子流 -->
+            <!-- Initial post timeline -->
             <div class="initial-posts-section">
               <span class="box-label">{{ $t('step2.initialActivationSeq', { count: simulationConfig.event_config.initial_posts.length }) }}</span>
               <div class="posts-timeline">
@@ -418,7 +418,7 @@
         </div>
       </div>
 
-      <!-- Step 05: 准备完成 -->
+      <!-- Step 05: Setup Complete -->
       <div class="step-card" :class="{ 'active': phase === 4 }">
         <div class="card-header">
           <div class="step-info">
@@ -435,7 +435,7 @@
           <p class="api-note">POST /api/simulation/start</p>
           <p class="description">{{ $t('step2.setupCompleteDesc') }}</p>
           
-          <!-- 模拟轮数配置 - 只有在配置生成完成且轮数计算出来后才显示 -->
+          <!-- Simulation rounds configuration - only shown once config has been generated and rounds computed -->
           <div v-if="simulationConfig && autoGeneratedRounds" class="rounds-config-section">
             <div class="rounds-header">
               <div class="header-left">
@@ -544,7 +544,7 @@
         </div>
         
         <div class="modal-body">
-          <!-- 基本信息 -->
+          <!-- Basic info -->
           <div class="modal-info-grid">
             <div class="info-item">
               <span class="info-label">{{ $t('step2.profileModalAge') }}</span>
@@ -564,13 +564,13 @@
             </div>
           </div>
 
-          <!-- 简介 -->
+          <!-- Bio -->
           <div class="modal-section">
             <span class="section-label">{{ $t('step2.profileModalBio') }}</span>
             <p class="section-bio">{{ selectedProfile.bio || $t('step2.noBio') }}</p>
           </div>
 
-          <!-- 关注话题 -->
+          <!-- Followed topics -->
           <div class="modal-section" v-if="selectedProfile.interested_topics?.length">
             <span class="section-label">{{ $t('step2.profileModalTopics') }}</span>
             <div class="topics-grid">
@@ -582,11 +582,11 @@
             </div>
           </div>
 
-          <!-- 详细人设 -->
+          <!-- Detailed persona -->
           <div class="modal-section" v-if="selectedProfile.persona">
             <span class="section-label">{{ $t('step2.profileModalPersona') }}</span>
             
-            <!-- 人设维度概览 -->
+            <!-- Persona dimension overview -->
             <div class="persona-dimensions">
               <div class="dimension-card">
                 <span class="dim-title">{{ $t('step2.personaDimExperience') }}</span>
@@ -645,7 +645,7 @@ import {
 const { t } = useI18n()
 
 const props = defineProps({
-  simulationId: String,  // 从父组件传入
+  simulationId: String,  // Passed in from the parent component
   projectData: Object,
   graphData: Object,
   systemLogs: Array
@@ -654,7 +654,7 @@ const props = defineProps({
 const emit = defineEmits(['go-back', 'next-step', 'add-log', 'update-status'])
 
 // State
-const phase = ref(0) // 0: 初始化, 1: 生成人设, 2: 生成配置, 3: 完成
+const phase = ref(0) // 0: initializing, 1: generating personas, 2: generating config, 3: complete
 const taskId = ref(null)
 const prepareProgress = ref(0)
 const currentStage = ref('')
@@ -666,43 +666,44 @@ const simulationConfig = ref(null)
 const selectedProfile = ref(null)
 const showProfilesDetail = ref(true)
 
-// 日志去重：记录上一次输出的关键信息
+// Log deduplication: remember the last key info we logged
 let lastLoggedMessage = ''
 let lastLoggedProfileCount = 0
 let lastLoggedConfigStage = ''
 
-// 模拟轮数配置
-const useCustomRounds = ref(false) // 默认使用自动配置轮数
-const customMaxRounds = ref(40)   // 默认推荐40轮
+// Simulation rounds configuration
+const useCustomRounds = ref(false) // Default: use the auto-generated round count
+const customMaxRounds = ref(40)   // Default recommendation: 40 rounds
 
 // Watch stage to update phase
 watch(currentStage, (newStage) => {
-  if (newStage === '生成Agent人设' || newStage === 'generating_profiles') {
+  // Backend emits canonical English machine names for stages.
+  if (newStage === 'generating_profiles') {
     phase.value = 1
-  } else if (newStage === '生成模拟配置' || newStage === 'generating_config') {
+  } else if (newStage === 'generating_config') {
     phase.value = 2
-    // 进入配置生成阶段，开始轮询配置
+    // Entering the config-generation stage, begin polling
     if (!configTimer) {
       addLog(t('log.startGeneratingConfig'))
       startConfigPolling()
     }
-  } else if (newStage === '准备模拟脚本' || newStage === 'copying_scripts') {
-    phase.value = 2 // 仍属于配置阶段
+  } else if (newStage === 'copying_scripts') {
+    phase.value = 2 // Still part of the config stage
   }
 })
 
-// 从配置中计算自动生成的轮数（不使用硬编码默认值）
+// Compute the auto-generated round count from the config (no hardcoded default)
 const autoGeneratedRounds = computed(() => {
   if (!simulationConfig.value?.time_config) {
-    return null // 配置未生成时返回 null
+    return null // Config not yet generated
   }
   const totalHours = simulationConfig.value.time_config.total_simulation_hours
   const minutesPerRound = simulationConfig.value.time_config.minutes_per_round
   if (!totalHours || !minutesPerRound) {
-    return null // 配置数据不完整时返回 null
+    return null // Config data is incomplete
   }
   const calculatedRounds = Math.floor((totalHours * 60) / minutesPerRound)
-  // 确保最大轮数不小于40（推荐值），避免滑动条范围异常
+  // Ensure the max is at least 40 (the recommended floor) to keep the slider range sane
   return Math.max(calculatedRounds, 40)
 })
 
@@ -719,7 +720,7 @@ const displayProfiles = computed(() => {
   return profiles.value.slice(0, 6)
 })
 
-// 根据agent_id获取对应的username
+// Look up the username for a given agent_id
 const getAgentUsername = (agentId) => {
   if (profiles.value && profiles.value.length > agentId && agentId >= 0) {
     const profile = profiles.value[agentId]
@@ -728,7 +729,7 @@ const getAgentUsername = (agentId) => {
   return `agent_${agentId}`
 }
 
-// 计算所有人设的关联话题总数
+// Total count of topics associated with all personas
 const totalTopicsCount = computed(() => {
   return profiles.value.reduce((sum, p) => {
     return sum + (p.interested_topics?.length || 0)
@@ -740,17 +741,17 @@ const addLog = (msg) => {
   emit('add-log', msg)
 }
 
-// 处理开始模拟按钮点击
+// Handle the Start Simulation button click
 const handleStartSimulation = () => {
-  // 构建传递给父组件的参数
+  // Build the params to pass back to the parent
   const params = {}
-  
+
   if (useCustomRounds.value) {
-    // 用户自定义轮数，传递 max_rounds 参数
+    // User chose a custom round count — pass max_rounds
     params.maxRounds = customMaxRounds.value
     addLog(t('log.startSimCustomRounds', { rounds: customMaxRounds.value }))
   } else {
-    // 用户选择保持自动生成的轮数，不传递 max_rounds 参数
+    // User chose to keep the auto-generated round count — do not pass max_rounds
     addLog(t('log.startSimAutoRounds', { rounds: autoGeneratedRounds.value }))
   }
   
@@ -768,7 +769,7 @@ const selectProfile = (profile) => {
   selectedProfile.value = profile
 }
 
-// 自动开始准备模拟
+// Automatically kick off the prepare-simulation flow
 const startPrepareSimulation = async () => {
   if (!props.simulationId) {
     addLog(t('log.errorMissingSimId'))
@@ -776,7 +777,7 @@ const startPrepareSimulation = async () => {
     return
   }
   
-  // 标记第一步完成，开始第二步
+  // Mark step 1 complete and start step 2
   phase.value = 1
   addLog(t('log.simInstanceCreated', { id: props.simulationId }))
   addLog(t('log.preparingSimEnv'))
@@ -800,7 +801,7 @@ const startPrepareSimulation = async () => {
       addLog(t('log.prepareTaskStarted'))
       addLog(t('log.prepareTaskId', { taskId: res.data.task_id }))
       
-      // 立即设置预期Agent总数（从prepare接口返回值获取）
+      // Set the expected total agent count immediately (from the prepare endpoint)
       if (res.data.expected_entities_count) {
         expectedTotal.value = res.data.expected_entities_count
         addLog(t('log.zepEntitiesFound', { count: res.data.expected_entities_count }))
@@ -810,9 +811,9 @@ const startPrepareSimulation = async () => {
       }
       
       addLog(t('log.startPollingProgress'))
-      // 开始轮询进度
+      // Start polling progress
       startPolling()
-      // 开始实时获取 Profiles
+      // Start real-time fetching of Profiles
       startProfilesPolling()
     } else {
       addLog(t('log.prepareFailed', { error: res.error || t('common.unknownError') }))
@@ -858,15 +859,15 @@ const pollPrepareStatus = async () => {
     if (res.success && res.data) {
       const data = res.data
       
-      // 更新进度
+      // Update progress
       prepareProgress.value = data.progress || 0
       progressMessage.value = data.message || ''
-      
-      // 解析阶段信息并输出详细日志
+
+      // Parse the stage info and emit a detailed log
       if (data.progress_detail) {
         currentStage.value = data.progress_detail.current_stage_name || ''
-        
-        // 输出详细进度日志（避免重复）
+
+        // Emit a detailed progress log (deduplicated)
         const detail = data.progress_detail
         const logKey = `${detail.current_stage}-${detail.current_item}-${detail.total_items}`
         if (logKey !== lastLoggedMessage && detail.item_description) {
@@ -879,19 +880,19 @@ const pollPrepareStatus = async () => {
           }
         }
       } else if (data.message) {
-        // 从消息中提取阶段
+        // Extract the stage from the message
         const match = data.message.match(/\[(\d+)\/(\d+)\]\s*([^:]+)/)
         if (match) {
           currentStage.value = match[3].trim()
         }
-        // 输出消息日志（避免重复）
+        // Emit the message log (deduplicated)
         if (data.message !== lastLoggedMessage) {
           lastLoggedMessage = data.message
           addLog(data.message)
         }
       }
       
-      // 检查是否完成
+      // Check whether prepare has completed
       if (data.status === 'completed' || data.status === 'ready' || data.already_prepared) {
         addLog(t('log.prepareComplete'))
         stopPolling()
@@ -904,7 +905,7 @@ const pollPrepareStatus = async () => {
       }
     }
   } catch (err) {
-    console.warn('轮询状态失败:', err)
+    console.warn('Failed to poll status:', err)
   }
 }
 
@@ -917,19 +918,19 @@ const fetchProfilesRealtime = async () => {
     if (res.success && res.data) {
       const prevCount = profiles.value.length
       profiles.value = res.data.profiles || []
-      // 只有当 API 返回有效值时才更新，避免覆盖已有的有效值
+      // Only update when the API returns a valid value, so we don't clobber an existing valid one
       if (res.data.total_expected) {
         expectedTotal.value = res.data.total_expected
       }
       
-      // 提取实体类型
+      // Extract entity types
       const types = new Set()
       profiles.value.forEach(p => {
         if (p.entity_type) types.add(p.entity_type)
       })
       entityTypes.value = Array.from(types)
       
-      // 输出 Profile 生成进度日志（仅当数量变化时）
+      // Emit a Profile-generation progress log only when the count changes
       const currentCount = profiles.value.length
       if (currentCount > 0 && currentCount !== lastLoggedProfileCount) {
         lastLoggedProfileCount = currentCount
@@ -941,18 +942,18 @@ const fetchProfilesRealtime = async () => {
         }
         addLog(t('log.agentProfile', { current: currentCount, total: total, name: profileName, profession: latestProfile?.profession || t('step2.unknownProfession') }))
 
-        // 如果全部生成完成
+        // If all profiles have been generated
         if (expectedTotal.value && currentCount >= expectedTotal.value) {
           addLog(t('log.allProfilesComplete', { count: currentCount }))
         }
       }
     }
   } catch (err) {
-    console.warn('获取 Profiles 失败:', err)
+    console.warn('Failed to fetch Profiles:', err)
   }
 }
 
-// 配置轮询
+// Config polling
 const startConfigPolling = () => {
   configTimer = setInterval(fetchConfigRealtime, 2000)
 }
@@ -973,7 +974,7 @@ const fetchConfigRealtime = async () => {
     if (res.success && res.data) {
       const data = res.data
       
-      // 输出配置生成阶段日志（避免重复）
+      // Emit a config-generation stage log (deduplicated)
       if (data.generation_stage && data.generation_stage !== lastLoggedConfigStage) {
         lastLoggedConfigStage = data.generation_stage
         if (data.generation_stage === 'generating_profiles') {
@@ -983,12 +984,12 @@ const fetchConfigRealtime = async () => {
         }
       }
       
-      // 如果配置已生成
+      // If the config has been generated
       if (data.config_generated && data.config) {
         simulationConfig.value = data.config
         addLog(t('log.configComplete'))
 
-        // 显示详细配置摘要
+        // Show a detailed config summary
         if (data.summary) {
           addLog(t('log.configSummaryAgents', { count: data.summary.total_agents }))
           addLog(t('log.configSummaryHours', { hours: data.summary.simulation_hours }))
@@ -997,13 +998,13 @@ const fetchConfigRealtime = async () => {
           addLog(t('log.configSummaryPlatforms', { twitter: data.summary.has_twitter_config ? '✓' : '✗', reddit: data.summary.has_reddit_config ? '✓' : '✗' }))
         }
         
-        // 显示时间配置详情
+        // Show time-config details
         if (data.config.time_config) {
           const tc = data.config.time_config
           addLog(t('log.timeConfigDetail', { minutes: tc.minutes_per_round, rounds: Math.floor((tc.total_simulation_hours * 60) / tc.minutes_per_round) }))
         }
         
-        // 显示事件配置
+        // Show event configuration
         if (data.config.event_config?.narrative_direction) {
           const narrative = data.config.event_config.narrative_direction
           addLog(t('log.narrativeDirection', { direction: narrative.length > 50 ? narrative.substring(0, 50) + '...' : narrative }))
@@ -1016,7 +1017,7 @@ const fetchConfigRealtime = async () => {
       }
     }
   } catch (err) {
-    console.warn('获取 Config 失败:', err)
+    console.warn('Failed to fetch Config:', err)
   }
 }
 
@@ -1024,11 +1025,11 @@ const loadPreparedData = async () => {
   phase.value = 2
   addLog(t('log.loadingExistingConfig'))
 
-  // 最后获取一次 Profiles
+  // Final Profiles fetch
   await fetchProfilesRealtime()
   addLog(t('log.loadedAgentProfiles', { count: profiles.value.length }))
 
-  // 获取配置（使用实时接口）
+  // Fetch the configuration (via the realtime endpoint)
   try {
     const res = await getSimulationConfigRealtime(props.simulationId)
     if (res.success && res.data) {
@@ -1036,7 +1037,7 @@ const loadPreparedData = async () => {
         simulationConfig.value = res.data.config
         addLog(t('log.configLoadSuccess'))
 
-        // 显示详细配置摘要
+        // Show a detailed config summary
         if (res.data.summary) {
           addLog(t('log.configSummaryAgents', { count: res.data.summary.total_agents }))
           addLog(t('log.configSummaryHours', { hours: res.data.summary.simulation_hours }))
@@ -1047,7 +1048,7 @@ const loadPreparedData = async () => {
         phase.value = 4
         emit('update-status', 'completed')
       } else {
-        // 配置尚未生成，开始轮询
+        // Config has not been generated yet — start polling
         addLog(t('log.configGenerating'))
         startConfigPolling()
       }
@@ -1069,7 +1070,7 @@ watch(() => props.systemLogs?.length, () => {
 })
 
 onMounted(() => {
-  // 自动开始准备流程
+  // Automatically kick off the prepare flow
   if (props.simulationId) {
     addLog(t('log.step2Init'))
     startPrepareSimulation()
@@ -1905,7 +1906,7 @@ onUnmounted(() => {
   flex: 1;
 }
 
-/* 基本信息网格 */
+/* Basic info grid */
 .modal-info-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -1941,7 +1942,7 @@ onUnmounted(() => {
   color: #FF5722;
 }
 
-/* 模块区域 */
+/* Module section */
 .modal-section {
   margin-bottom: 28px;
 }
@@ -1967,7 +1968,7 @@ onUnmounted(() => {
   border-left: 3px solid #E0E0E0;
 }
 
-/* 话题标签 */
+/* Topic tags */
 .topics-grid {
   display: flex;
   flex-wrap: wrap;
@@ -1989,7 +1990,7 @@ onUnmounted(() => {
   color: #0D47A1;
 }
 
-/* 详细人设 */
+/* Detailed persona */
 .persona-dimensions {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -2275,7 +2276,7 @@ onUnmounted(() => {
   margin: 0;
 }
 
-/* 模拟轮数配置样式 */
+/* Simulation rounds configuration styles */
 .rounds-config-section {
   margin: 24px 0;
   padding-top: 24px;

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -3,7 +3,7 @@
     <!-- Top Control Bar -->
     <div class="control-bar">
       <div class="status-group">
-        <!-- Twitter 平台进度 -->
+        <!-- Twitter platform progress -->
         <div class="platform-status twitter" :class="{ active: runStatus.twitter_running, completed: runStatus.twitter_completed }">
           <div class="platform-header">
             <svg class="platform-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
@@ -30,7 +30,7 @@
               <span class="stat-value mono">{{ runStatus.twitter_actions_count || 0 }}</span>
             </span>
           </div>
-          <!-- 可用动作提示 -->
+          <!-- Available actions tooltip -->
           <div class="actions-tooltip">
             <div class="tooltip-title">Available Actions</div>
             <div class="tooltip-actions">
@@ -44,7 +44,7 @@
           </div>
         </div>
         
-        <!-- Reddit 平台进度 -->
+        <!-- Reddit platform progress -->
         <div class="platform-status reddit" :class="{ active: runStatus.reddit_running, completed: runStatus.reddit_completed }">
           <div class="platform-header">
             <svg class="platform-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
@@ -71,7 +71,7 @@
               <span class="stat-value mono">{{ runStatus.reddit_actions_count || 0 }}</span>
             </span>
           </div>
-          <!-- 可用动作提示 -->
+          <!-- Available actions tooltip -->
           <div class="actions-tooltip">
             <div class="tooltip-title">Available Actions</div>
             <div class="tooltip-actions">
@@ -157,12 +157,12 @@
               </div>
               
               <div class="card-body">
-                <!-- CREATE_POST: 发布帖子 -->
+                <!-- CREATE_POST: publish a post -->
                 <div v-if="action.action_type === 'CREATE_POST' && action.action_args?.content" class="content-text main-text">
                   {{ action.action_args.content }}
                 </div>
 
-                <!-- QUOTE_POST: 引用帖子 -->
+                <!-- QUOTE_POST: quote a post -->
                 <template v-if="action.action_type === 'QUOTE_POST'">
                   <div v-if="action.action_args?.quote_content" class="content-text">
                     {{ action.action_args.quote_content }}
@@ -178,7 +178,7 @@
                   </div>
                 </template>
 
-                <!-- REPOST: 转发帖子 -->
+                <!-- REPOST: repost -->
                 <template v-if="action.action_type === 'REPOST'">
                   <div class="repost-info">
                     <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="17 1 21 5 17 9"></polyline><path d="M3 11V9a4 4 0 0 1 4-4h14"></path><polyline points="7 23 3 19 7 15"></polyline><path d="M21 13v2a4 4 0 0 1-4 4H3"></path></svg>
@@ -189,7 +189,7 @@
                   </div>
                 </template>
 
-                <!-- LIKE_POST: 点赞帖子 -->
+                <!-- LIKE_POST: like a post -->
                 <template v-if="action.action_type === 'LIKE_POST'">
                   <div class="like-info">
                     <svg class="icon-small filled" viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
@@ -200,7 +200,7 @@
                   </div>
                 </template>
 
-                <!-- CREATE_COMMENT: 发表评论 -->
+                <!-- CREATE_COMMENT: post a comment -->
                 <template v-if="action.action_type === 'CREATE_COMMENT'">
                   <div v-if="action.action_args?.content" class="content-text">
                     {{ action.action_args.content }}
@@ -211,7 +211,7 @@
                   </div>
                 </template>
 
-                <!-- SEARCH_POSTS: 搜索帖子 -->
+                <!-- SEARCH_POSTS: search posts -->
                 <template v-if="action.action_type === 'SEARCH_POSTS'">
                   <div class="search-info">
                     <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
@@ -220,7 +220,7 @@
                   </div>
                 </template>
 
-                <!-- FOLLOW: 关注用户 -->
+                <!-- FOLLOW: follow a user -->
                 <template v-if="action.action_type === 'FOLLOW'">
                   <div class="follow-info">
                     <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="8.5" cy="7" r="4"></circle><line x1="20" y1="8" x2="20" y2="14"></line><line x1="23" y1="11" x2="17" y2="11"></line></svg>
@@ -240,7 +240,7 @@
                   </div>
                 </template>
 
-                <!-- DO_NOTHING: 无操作（静默） -->
+                <!-- DO_NOTHING: no-op (silent) -->
                 <template v-if="action.action_type === 'DO_NOTHING'">
                   <div class="idle-info">
                     <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
@@ -248,7 +248,7 @@
                   </div>
                 </template>
 
-                <!-- 通用回退：未知类型或有 content 但未被上述处理 -->
+                <!-- Generic fallback: unknown action type, or has content but wasn't handled above -->
                 <div v-if="!['CREATE_POST', 'QUOTE_POST', 'REPOST', 'LIKE_POST', 'CREATE_COMMENT', 'SEARCH_POSTS', 'FOLLOW', 'UPVOTE_POST', 'DOWNVOTE_POST', 'DO_NOTHING'].includes(action.action_type) && action.action_args?.content" class="content-text">
                   {{ action.action_args.content }}
                 </div>
@@ -301,10 +301,10 @@ const { t } = useI18n()
 
 const props = defineProps({
   simulationId: String,
-  maxRounds: Number, // 从Step2传入的最大轮数
+  maxRounds: Number, // Max rounds passed in from Step 2
   minutesPerRound: {
     type: Number,
-    default: 30 // 默认每轮30分钟
+    default: 30 // Default of 30 minutes per round
   },
   projectData: Object,
   graphData: Object,
@@ -317,22 +317,22 @@ const router = useRouter()
 
 // State
 const isGeneratingReport = ref(false)
-const phase = ref(0) // 0: 未开始, 1: 运行中, 2: 已完成
+const phase = ref(0) // 0: not started, 1: running, 2: completed
 const isStarting = ref(false)
 const isStopping = ref(false)
 const startError = ref(null)
 const runStatus = ref({})
-const allActions = ref([]) // 所有动作（增量累积）
-const actionIds = ref(new Set()) // 用于去重的动作ID集合
+const allActions = ref([]) // All actions (accumulated incrementally)
+const actionIds = ref(new Set()) // Set of action IDs used for deduplication
 const scrollContainer = ref(null)
 
 // Computed
-// 按时间顺序显示动作（最新的在最后面，即底部）
+// Show actions in chronological order (most recent at the bottom)
 const chronologicalActions = computed(() => {
   return allActions.value
 })
 
-// 各平台动作计数
+// Per-platform action counts
 const twitterActionsCount = computed(() => {
   return allActions.value.filter(a => a.platform === 'twitter').length
 })
@@ -341,7 +341,7 @@ const redditActionsCount = computed(() => {
   return allActions.value.filter(a => a.platform === 'reddit').length
 })
 
-// 格式化模拟流逝时间（根据轮次和每轮分钟数计算）
+// Format simulated elapsed time (computed from round count and minutes per round)
 const formatElapsedTime = (currentRound) => {
   if (!currentRound || currentRound <= 0) return '0h 0m'
   const totalMinutes = currentRound * props.minutesPerRound
@@ -350,12 +350,12 @@ const formatElapsedTime = (currentRound) => {
   return `${hours}h ${minutes}m`
 }
 
-// Twitter平台的模拟流逝时间
+// Twitter platform's simulated elapsed time
 const twitterElapsedTime = computed(() => {
   return formatElapsedTime(runStatus.value.twitter_current_round || 0)
 })
 
-// Reddit平台的模拟流逝时间
+// Reddit platform's simulated elapsed time
 const redditElapsedTime = computed(() => {
   return formatElapsedTime(runStatus.value.reddit_current_round || 0)
 })
@@ -365,7 +365,7 @@ const addLog = (msg) => {
   emit('add-log', msg)
 }
 
-// 重置所有状态（用于重新启动模拟）
+// Reset all state (used when restarting the simulation)
 const resetAllState = () => {
   phase.value = 0
   runStatus.value = {}
@@ -376,17 +376,17 @@ const resetAllState = () => {
   startError.value = null
   isStarting.value = false
   isStopping.value = false
-  stopPolling()  // 停止之前可能存在的轮询
+  stopPolling()  // Stop any pre-existing polling
 }
 
-// 启动模拟
+// Start the simulation
 const doStartSimulation = async () => {
   if (!props.simulationId) {
     addLog(t('log.errorMissingSimId'))
     return
   }
 
-  // 先重置所有状态，确保不会受到上一次模拟的影响
+  // Reset all state first so this run isn't affected by the previous one
   resetAllState()
   
   isStarting.value = true
@@ -398,8 +398,8 @@ const doStartSimulation = async () => {
     const params = {
       simulation_id: props.simulationId,
       platform: 'parallel',
-      force: true,  // 强制重新开始
-      enable_graph_memory_update: true  // 开启动态图谱更新
+      force: true,  // Force a fresh restart
+      enable_graph_memory_update: true  // Enable dynamic graph-memory updates
     }
     
     if (props.maxRounds) {
@@ -424,7 +424,7 @@ const doStartSimulation = async () => {
       startStatusPolling()
       startDetailPolling()
     } else {
-      startError.value = res.error || '启动失败'
+      startError.value = res.error || 'Failed to start'
       addLog(t('log.startFailed', { error: res.error || t('common.unknownError') }))
       emit('update-status', 'error')
     }
@@ -437,7 +437,7 @@ const doStartSimulation = async () => {
   }
 }
 
-// 停止模拟
+// Stop the simulation
 const handleStopSimulation = async () => {
   if (!props.simulationId) return
   
@@ -462,7 +462,7 @@ const handleStopSimulation = async () => {
   }
 }
 
-// 轮询状态
+// Poll status
 let statusTimer = null
 let detailTimer = null
 
@@ -485,7 +485,7 @@ const stopPolling = () => {
   }
 }
 
-// 追踪各平台的上一次轮次，用于检测变化并输出日志
+// Track the previous round per platform so we can detect changes and log them
 const prevTwitterRound = ref(0)
 const prevRedditRound = ref(0)
 
@@ -500,7 +500,7 @@ const fetchRunStatus = async () => {
       
       runStatus.value = data
       
-      // 分别检测各平台的轮次变化并输出日志
+      // Detect per-platform round changes and log them
       if (data.twitter_current_round > prevTwitterRound.value) {
         addLog(`[Plaza] R${data.twitter_current_round}/${data.total_rounds} | T:${data.twitter_simulated_hours || 0}h | A:${data.twitter_actions_count}`)
         prevTwitterRound.value = data.twitter_current_round
@@ -511,11 +511,11 @@ const fetchRunStatus = async () => {
         prevRedditRound.value = data.reddit_current_round
       }
       
-      // 检测模拟是否已完成（通过 runner_status 或平台完成状态判断）
+      // Detect simulation completion (via runner_status or platform completion flags)
       const isCompleted = data.runner_status === 'completed' || data.runner_status === 'stopped'
-      
-      // 额外检查：如果后端还没来得及更新 runner_status，但平台已经报告完成
-      // 通过检测 twitter_completed 和 reddit_completed 状态判断
+
+      // Additional check: the backend may not have updated runner_status yet, but the platforms have reported completion.
+      // Detect this via the twitter_completed and reddit_completed flags.
       const platformsCompleted = checkPlatformsCompleted(data)
       
       if (isCompleted || platformsCompleted) {
@@ -529,28 +529,28 @@ const fetchRunStatus = async () => {
       }
     }
   } catch (err) {
-    console.warn('获取运行状态失败:', err)
+    console.warn('Failed to fetch run status:', err)
   }
 }
 
-// 检查所有启用的平台是否已完成
+// Check whether every enabled platform has completed
 const checkPlatformsCompleted = (data) => {
-  // 如果没有任何平台数据，返回 false
+  // If there's no platform data, return false
   if (!data) return false
-  
-  // 检查各平台的完成状态
+
+  // Per-platform completion flags
   const twitterCompleted = data.twitter_completed === true
   const redditCompleted = data.reddit_completed === true
-  
-  // 如果至少有一个平台完成了，检查是否所有启用的平台都完成了
-  // 通过 actions_count 判断平台是否被启用（如果 count > 0 或 running 曾为 true）
+
+  // If at least one platform finished, check whether every enabled platform did.
+  // A platform is considered enabled if actions_count > 0 or running was ever true.
   const twitterEnabled = (data.twitter_actions_count > 0) || data.twitter_running || twitterCompleted
   const redditEnabled = (data.reddit_actions_count > 0) || data.reddit_running || redditCompleted
-  
-  // 如果没有任何平台被启用，返回 false
+
+  // If no platform is enabled, return false
   if (!twitterEnabled && !redditEnabled) return false
-  
-  // 检查所有启用的平台是否都已完成
+
+  // Verify every enabled platform has completed
   if (twitterEnabled && !twitterCompleted) return false
   if (redditEnabled && !redditCompleted) return false
   
@@ -564,13 +564,13 @@ const fetchRunStatusDetail = async () => {
     const res = await getRunStatusDetail(props.simulationId)
     
     if (res.success && res.data) {
-      // 使用 all_actions 获取完整的动作列表
+      // Use all_actions to get the complete action list
       const serverActions = res.data.all_actions || []
-      
-      // 增量添加新动作（去重）
+
+      // Append new actions incrementally (deduplicated)
       let newActionsAdded = 0
       serverActions.forEach(action => {
-        // 生成唯一ID
+        // Generate a unique ID
         const actionId = action.id || `${action.timestamp}-${action.platform}-${action.agent_id}-${action.action_type}`
         
         if (!actionIds.value.has(actionId)) {
@@ -583,11 +583,11 @@ const fetchRunStatusDetail = async () => {
         }
       })
       
-      // 不自动滚动，让用户自由查看时间轴
-      // 新动作会在底部追加
+      // Do not auto-scroll — let the user browse the timeline freely.
+      // New actions are appended at the bottom.
     }
   } catch (err) {
-    console.warn('获取详细状态失败:', err)
+    console.warn('Failed to fetch detailed status:', err)
   }
 }
 
@@ -665,7 +665,7 @@ const handleNextStep = async () => {
       const reportId = res.data.report_id
       addLog(t('log.reportGenTaskStarted', { reportId }))
       
-      // 跳转到报告页面
+      // Navigate to the report page
       router.push({ name: 'Report', params: { reportId } })
     } else {
       addLog(t('log.reportGenFailed', { error: res.error || t('common.unknownError') }))

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -127,7 +127,7 @@
             </div>
           </div>
 
-          <!-- Next Step Button - 在完成后显示 -->
+          <!-- Next Step Button - shown when generation completes -->
           <button v-if="isComplete" class="next-step-btn" @click="goToInteraction">
             <span>{{ $t('step4.goToInteraction') }}</span>
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
@@ -194,7 +194,7 @@
                     </div>
                   </template>
                   
-                  <!-- Section Content Generated (内容生成完成，但整个章节可能还没完成) -->
+                  <!-- Section Content Generated (content done, but the full section may not be complete yet) -->
                   <template v-if="log.action === 'section_content'">
                     <div class="section-tag content-ready">
                       <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
@@ -205,7 +205,7 @@
                     </div>
                   </template>
 
-                  <!-- Section Complete (章节生成完成) -->
+                  <!-- Section Complete (entire section finished) -->
                   <template v-if="log.action === 'section_complete'">
                     <div class="section-tag completed">
                       <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
@@ -315,7 +315,7 @@
                         Final: {{ log.details?.has_final_answer ? 'Yes' : 'No' }}
                       </span>
                     </div>
-                    <!-- 当是最终答案时，显示特殊提示 -->
+                    <!-- When this is the final answer, show a special hint -->
                     <div v-if="log.details?.has_final_answer" class="final-answer-hint">
                       <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
                         <polyline points="20 6 9 17 4 12"></polyline>
@@ -433,22 +433,22 @@ const showRawResult = reactive({})
 
 // Toggle functions
 const toggleRawResult = (timestamp, event) => {
-  // 保存按钮相对于视口的位置
+  // Save the button's position relative to the viewport
   const button = event?.target
   const buttonRect = button?.getBoundingClientRect()
   const buttonTopBeforeToggle = buttonRect?.top
-  
-  // 切换状态
+
+  // Toggle state
   showRawResult[timestamp] = !showRawResult[timestamp]
-  
-  // 等待 DOM 更新后，调整滚动位置以保持按钮在相同位置
+
+  // After the DOM updates, adjust scroll so the button stays in the same place
   if (button && buttonTopBeforeToggle !== undefined && rightPanel.value) {
     nextTick(() => {
       const newButtonRect = button.getBoundingClientRect()
       const buttonTopAfterToggle = newButtonRect.top
       const scrollDelta = buttonTopAfterToggle - buttonTopBeforeToggle
-      
-      // 调整滚动位置
+
+      // Adjust scroll position
       rightPanel.value.scrollTop += scrollDelta
     })
   }
@@ -466,7 +466,7 @@ const toggleSectionContent = (idx) => {
 }
 
 const toggleSectionCollapse = (idx) => {
-  // 只有已完成的章节才能折叠
+  // Only completed sections can be collapsed
   if (!generatedSections.value[idx + 1]) return
   const newSet = new Set(collapsedSections.value)
   if (newSet.has(idx)) {
@@ -499,32 +499,32 @@ const toolConfig = {
   'insight_forge': {
     name: 'Deep Insight',
     color: 'purple',
-    icon: 'lightbulb' // 灯泡图标 - 代表洞察
+    icon: 'lightbulb' // Lightbulb icon - represents insight
   },
   'panorama_search': {
     name: 'Panorama Search',
     color: 'blue',
-    icon: 'globe' // 地球图标 - 代表全景搜索
+    icon: 'globe' // Globe icon - represents panorama search
   },
   'interview_agents': {
     name: 'Agent Interview',
     color: 'green',
-    icon: 'users' // 用户图标 - 代表对话
+    icon: 'users' // Users icon - represents dialogue
   },
   'quick_search': {
     name: 'Quick Search',
     color: 'orange',
-    icon: 'zap' // 闪电图标 - 代表快速
+    icon: 'zap' // Lightning icon - represents speed
   },
   'get_graph_statistics': {
     name: 'Graph Stats',
     color: 'cyan',
-    icon: 'chart' // 图表图标 - 代表统计
+    icon: 'chart' // Chart icon - represents statistics
   },
   'get_entities_by_type': {
     name: 'Entity Query',
     color: 'pink',
-    icon: 'database' // 数据库图标 - 代表实体
+    icon: 'database' // Database icon - represents entities
   }
 }
 
@@ -553,31 +553,31 @@ const parseInsightForge = (text) => {
   }
   
   try {
-    // 提取分析问题
-    const queryMatch = text.match(/分析问题:\s*(.+?)(?:\n|$)/)
+    // Extract the analysis question (regex matches the English-formatted backend output)
+    const queryMatch = text.match(/Analysis question:\s*(.+?)(?:\n|$)/)
     if (queryMatch) result.query = queryMatch[1].trim()
-    
-    // 提取预测场景
-    const reqMatch = text.match(/预测场景:\s*(.+?)(?:\n|$)/)
+
+    // Extract the prediction scenario
+    const reqMatch = text.match(/Prediction scenario:\s*(.+?)(?:\n|$)/)
     if (reqMatch) result.simulationRequirement = reqMatch[1].trim()
-    
-    // 提取统计数据 - 匹配"相关预测事实: X条"格式
-    const factMatch = text.match(/相关预测事实:\s*(\d+)/)
-    const entityMatch = text.match(/涉及实体:\s*(\d+)/)
-    const relMatch = text.match(/关系链:\s*(\d+)/)
+
+    // Extract statistics - matches the "Relevant predicted facts: N" format
+    const factMatch = text.match(/Relevant predicted facts:\s*(\d+)/)
+    const entityMatch = text.match(/Entities involved:\s*(\d+)/)
+    const relMatch = text.match(/Relationship chains:\s*(\d+)/)
     if (factMatch) result.stats.facts = parseInt(factMatch[1])
     if (entityMatch) result.stats.entities = parseInt(entityMatch[1])
     if (relMatch) result.stats.relationships = parseInt(relMatch[1])
     
-    // 提取子问题 - 完整提取，不限制数量
-    const subQSection = text.match(/### 分析的子问题\n([\s\S]*?)(?=\n###|$)/)
+    // Extract sub-questions - take all of them, no cap
+    const subQSection = text.match(/### Sub-Questions Analyzed\n([\s\S]*?)(?=\n###|$)/)
     if (subQSection) {
       const lines = subQSection[1].split('\n').filter(l => l.match(/^\d+\./))
       result.subQueries = lines.map(l => l.replace(/^\d+\.\s*/, '').trim()).filter(Boolean)
     }
     
-    // 提取关键事实 - 完整提取，不限制数量
-    const factsSection = text.match(/### 【关键事实】[\s\S]*?\n([\s\S]*?)(?=\n###|$)/)
+    // Extract key facts - take all of them, no cap
+    const factsSection = text.match(/### \[Key Facts\][\s\S]*?\n([\s\S]*?)(?=\n###|$)/)
     if (factsSection) {
       const lines = factsSection[1].split('\n').filter(l => l.match(/^\d+\./))
       result.facts = lines.map(l => {
@@ -586,16 +586,16 @@ const parseInsightForge = (text) => {
       }).filter(Boolean)
     }
     
-    // 提取核心实体 - 完整提取，包含摘要和相关事实数
-    const entitySection = text.match(/### 【核心实体】\n([\s\S]*?)(?=\n###|$)/)
+    // Extract core entities - take all, including summary and related-fact counts
+    const entitySection = text.match(/### \[Core Entities\]\n([\s\S]*?)(?=\n###|$)/)
     if (entitySection) {
       const entityText = entitySection[1]
-      // 按 "- **" 分割实体块
+      // Split entity blocks on "- **"
       const entityBlocks = entityText.split(/\n(?=- \*\*)/).filter(b => b.trim().startsWith('- **'))
       result.entities = entityBlocks.map(block => {
         const nameMatch = block.match(/^-\s*\*\*(.+?)\*\*\s*\((.+?)\)/)
-        const summaryMatch = block.match(/摘要:\s*"?(.+?)"?(?:\n|$)/)
-        const relatedMatch = block.match(/相关事实:\s*(\d+)/)
+        const summaryMatch = block.match(/Summary:\s*"?(.+?)"?(?:\n|$)/)
+        const relatedMatch = block.match(/Related facts:\s*(\d+)/)
         return {
           name: nameMatch ? nameMatch[1].trim() : '',
           type: nameMatch ? nameMatch[2].trim() : '',
@@ -605,8 +605,8 @@ const parseInsightForge = (text) => {
       }).filter(e => e.name)
     }
     
-    // 提取关系链 - 完整提取，不限制数量
-    const relSection = text.match(/### 【关系链】\n([\s\S]*?)(?=\n###|$)/)
+    // Extract relation chains - take all, no cap
+    const relSection = text.match(/### \[Relationship Chains\]\n([\s\S]*?)(?=\n###|$)/)
     if (relSection) {
       const lines = relSection[1].split('\n').filter(l => l.trim().startsWith('-'))
       result.relations = lines.map(l => {
@@ -634,33 +634,33 @@ const parsePanorama = (text) => {
   }
   
   try {
-    // 提取查询
-    const queryMatch = text.match(/查询:\s*(.+?)(?:\n|$)/)
+    // Extract query
+    const queryMatch = text.match(/Query:\s*(.+?)(?:\n|$)/)
     if (queryMatch) result.query = queryMatch[1].trim()
-    
-    // 提取统计数据
-    const nodesMatch = text.match(/总节点数:\s*(\d+)/)
-    const edgesMatch = text.match(/总边数:\s*(\d+)/)
-    const activeMatch = text.match(/当前有效事实:\s*(\d+)/)
-    const histMatch = text.match(/历史\/过期事实:\s*(\d+)/)
+
+    // Extract statistics
+    const nodesMatch = text.match(/Total nodes:\s*(\d+)/)
+    const edgesMatch = text.match(/Total edges:\s*(\d+)/)
+    const activeMatch = text.match(/Currently valid facts:\s*(\d+)/)
+    const histMatch = text.match(/Historical \/ expired facts:\s*(\d+)/)
     if (nodesMatch) result.stats.nodes = parseInt(nodesMatch[1])
     if (edgesMatch) result.stats.edges = parseInt(edgesMatch[1])
     if (activeMatch) result.stats.activeFacts = parseInt(activeMatch[1])
     if (histMatch) result.stats.historicalFacts = parseInt(histMatch[1])
     
-    // 提取当前有效事实 - 完整提取，不限制数量
-    const activeSection = text.match(/### 【当前有效事实】[\s\S]*?\n([\s\S]*?)(?=\n###|$)/)
+    // Extract currently-valid facts - take all, no cap
+    const activeSection = text.match(/### \[Currently Valid Facts\][\s\S]*?\n([\s\S]*?)(?=\n###|$)/)
     if (activeSection) {
       const lines = activeSection[1].split('\n').filter(l => l.match(/^\d+\./))
       result.activeFacts = lines.map(l => {
-        // 移除编号和引号
+        // Strip numbering and quote characters
         const factText = l.replace(/^\d+\.\s*/, '').replace(/^"|"$/g, '').trim()
         return factText
       }).filter(Boolean)
     }
     
-    // 提取历史/过期事实 - 完整提取，不限制数量
-    const histSection = text.match(/### 【历史\/过期事实】[\s\S]*?\n([\s\S]*?)(?=\n###|$)/)
+    // Extract historical / expired facts - take all, no cap
+    const histSection = text.match(/### \[Historical \/ Expired Facts\][\s\S]*?\n([\s\S]*?)(?=\n###|$)/)
     if (histSection) {
       const lines = histSection[1].split('\n').filter(l => l.match(/^\d+\./))
       result.historicalFacts = lines.map(l => {
@@ -669,8 +669,8 @@ const parsePanorama = (text) => {
       }).filter(Boolean)
     }
     
-    // 提取涉及实体 - 完整提取，不限制数量
-    const entitySection = text.match(/### 【涉及实体】\n([\s\S]*?)(?=\n###|$)/)
+    // Extract involved entities - take all, no cap
+    const entitySection = text.match(/### \[Entities Involved\]\n([\s\S]*?)(?=\n###|$)/)
     if (entitySection) {
       const lines = entitySection[1].split('\n').filter(l => l.trim().startsWith('-'))
       result.entities = lines.map(l => {
@@ -698,25 +698,25 @@ const parseInterview = (text) => {
   }
   
   try {
-    // 提取采访主题
-    const topicMatch = text.match(/\*\*采访主题:\*\*\s*(.+?)(?:\n|$)/)
+    // Extract interview topic
+    const topicMatch = text.match(/\*\*Interview topic:\*\*\s*(.+?)(?:\n|$)/)
     if (topicMatch) result.topic = topicMatch[1].trim()
     
-    // 提取采访人数（如 "5 / 9 位模拟Agent"）
-    const countMatch = text.match(/\*\*采访人数:\*\*\s*(\d+)\s*\/\s*(\d+)/)
+    // Extract interviewee count (e.g. "5 / 9 simulated agents")
+    const countMatch = text.match(/\*\*Number of interviewees:\*\*\s*(\d+)\s*\/\s*(\d+)/)
     if (countMatch) {
       result.successCount = parseInt(countMatch[1])
       result.totalCount = parseInt(countMatch[2])
       result.agentCount = `${countMatch[1]} / ${countMatch[2]}`
     }
     
-    // 提取采访对象选择理由
-    const reasonMatch = text.match(/### 采访对象选择理由\n([\s\S]*?)(?=\n---\n|\n### 采访实录)/)
+    // Extract the rationale for selecting interviewees
+    const reasonMatch = text.match(/### Reasoning for Selecting Interviewees\n([\s\S]*?)(?=\n---\n|\n### Interview Transcripts)/)
     if (reasonMatch) {
       result.selectionReason = reasonMatch[1].trim()
     }
     
-    // 解析每个人的选择理由
+    // Parse the per-person selection rationale
     const parseIndividualReasons = (reasonText) => {
       const reasons = {}
       if (!reasonText) return reasons
@@ -730,28 +730,28 @@ const parseInterview = (text) => {
         let name = null
         let reasonStart = null
         
-        // 格式1: 数字. **名字（index=X）**：理由
-        // 例如: 1. **校友_345（index=1）**：作为武大校友...
-        headerMatch = line.match(/^\d+\.\s*\*\*([^*（(]+)(?:[（(]index\s*=?\s*\d+[)）])?\*\*[：:]\s*(.*)/)
+        // Format 1: number. **name (index=X)**: reason
+        // e.g.: 1. **Alumni_345 (index=1)**: As an alumnus of Wuhan University...
+        headerMatch = line.match(/^\d+\.\s*\*\*([^*(]+)(?:\(index\s*=?\s*\d+\))?\*\*\s*[:：]\s*(.*)/)
         if (headerMatch) {
           name = headerMatch[1].trim()
           reasonStart = headerMatch[2]
         }
-        
-        // 格式2: - 选择名字（index X）：理由
-        // 例如: - 选择家长_601（index 0）：作为家长群体代表...
+
+        // Format 2: - Select(ed) name (index X): reason
+        // e.g.: - Selected Parent_601 (index 0): As a representative of the parent group...
         if (!headerMatch) {
-          headerMatch = line.match(/^-\s*选择([^（(]+)(?:[（(]index\s*=?\s*\d+[)）])?[：:]\s*(.*)/)
+          headerMatch = line.match(/^-\s*(?:Selected|Select|Choose|Chose)\s+([^(]+?)(?:\s*\(index\s*=?\s*\d+\))?\s*[:：]\s*(.*)/i)
           if (headerMatch) {
             name = headerMatch[1].trim()
             reasonStart = headerMatch[2]
           }
         }
-        
-        // 格式3: - **名字（index X）**：理由
-        // 例如: - **家长_601（index 0）**：作为家长群体代表...
+
+        // Format 3: - **name (index X)**: reason
+        // e.g.: - **Parent_601 (index 0)**: As a representative of the parent group...
         if (!headerMatch) {
-          headerMatch = line.match(/^-\s*\*\*([^*（(]+)(?:[（(]index\s*=?\s*\d+[)）])?\*\*[：:]\s*(.*)/)
+          headerMatch = line.match(/^-\s*\*\*([^*(]+?)(?:\s*\(index\s*=?\s*\d+\))?\*\*\s*[:：]\s*(.*)/)
           if (headerMatch) {
             name = headerMatch[1].trim()
             reasonStart = headerMatch[2]
@@ -759,20 +759,20 @@ const parseInterview = (text) => {
         }
         
         if (name) {
-          // 保存上一个人的理由
+          // Save the previous person's reason
           if (currentName && currentReason.length > 0) {
             reasons[currentName] = currentReason.join(' ').trim()
           }
-          // 开始新的人
+          // Start a new person
           currentName = name
           currentReason = reasonStart ? [reasonStart.trim()] : []
-        } else if (currentName && line.trim() && !line.match(/^未选|^综上|^最终选择/)) {
-          // 理由的续行（排除结尾总结段落）
+        } else if (currentName && line.trim() && !line.match(/^Not selected|^In summary|^Final selection|^Overall/i)) {
+          // Continuation of the reason (excluding trailing summary paragraphs)
           currentReason.push(line.trim())
         }
       }
       
-      // 保存最后一个人的理由
+      // Save the last person's reason
       if (currentName && currentReason.length > 0) {
         reasons[currentName] = currentReason.join(' ').trim()
       }
@@ -782,8 +782,8 @@ const parseInterview = (text) => {
     
     const individualReasons = parseIndividualReasons(result.selectionReason)
     
-    // 提取每个采访记录
-    const interviewBlocks = text.split(/#### 采访 #\d+:/).slice(1)
+    // Extract each interview record
+    const interviewBlocks = text.split(/#### Interview #\d+:/).slice(1)
     
     interviewBlocks.forEach((block, index) => {
       const interview = {
@@ -799,33 +799,33 @@ const parseInterview = (text) => {
         quotes: []
       }
       
-      // 提取标题（如 "学生"、"教育从业者" 等）
+      // Extract the title (e.g. "Student", "Educator", etc.)
       const titleMatch = block.match(/^(.+?)\n/)
       if (titleMatch) interview.title = titleMatch[1].trim()
       
-      // 提取姓名和角色
+      // Extract name and role
       const nameRoleMatch = block.match(/\*\*(.+?)\*\*\s*\((.+?)\)/)
       if (nameRoleMatch) {
         interview.name = nameRoleMatch[1].trim()
         interview.role = nameRoleMatch[2].trim()
-        // 设置该人的选择理由
+        // Set this person's selection reason
         interview.selectionReason = individualReasons[interview.name] || ''
       }
       
-      // 提取简介
-      const bioMatch = block.match(/_简介:\s*([\s\S]*?)_\n/)
+      // Extract bio
+      const bioMatch = block.match(/_Bio:\s*([\s\S]*?)_\n/)
       if (bioMatch) {
         interview.bio = bioMatch[1].trim().replace(/\.\.\.$/, '...')
       }
       
-      // 提取问题列表
+      // Extract the question list
       const qMatch = block.match(/\*\*Q:\*\*\s*([\s\S]*?)(?=\n\n\*\*A:\*\*|\*\*A:\*\*)/)
       if (qMatch) {
         const qText = qMatch[1].trim()
-        // 按数字编号分割问题
+        // Split questions on numeric markers
         const questions = qText.split(/\n\d+\.\s+/).filter(q => q.trim())
         if (questions.length > 0) {
-          // 如果第一个问题前面有"1."，需要特殊处理
+          // If the first question is prefixed by "1.", handle it specially
           const firstQ = qText.match(/^1\.\s+(.+)/)
           if (firstQ) {
             interview.questions = [firstQ[1].trim(), ...questions.slice(1).map(q => q.trim())]
@@ -835,14 +835,14 @@ const parseInterview = (text) => {
         }
       }
       
-      // 提取回答 - 分Twitter和Reddit
-      const answerMatch = block.match(/\*\*A:\*\*\s*([\s\S]*?)(?=\*\*关键引言|$)/)
+      // Extract responses - separated by Twitter and Reddit
+      const answerMatch = block.match(/\*\*A:\*\*\s*([\s\S]*?)(?=\*\*Key Quotes|$)/)
       if (answerMatch) {
         const answerText = answerMatch[1].trim()
         
-        // 分离Twitter和Reddit回答
-        const twitterMatch = answerText.match(/【Twitter平台回答】\n?([\s\S]*?)(?=【Reddit平台回答】|$)/)
-        const redditMatch = answerText.match(/【Reddit平台回答】\n?([\s\S]*?)$/)
+        // Separate the Twitter and Reddit responses
+        const twitterMatch = answerText.match(/\[Twitter platform answer\]\n?([\s\S]*?)(?=\[Reddit platform answer\]|$)/)
+        const redditMatch = answerText.match(/\[Reddit platform answer\]\n?([\s\S]*?)$/)
         
         if (twitterMatch) {
           interview.twitterAnswer = twitterMatch[1].trim()
@@ -851,29 +851,29 @@ const parseInterview = (text) => {
           interview.redditAnswer = redditMatch[1].trim()
         }
         
-        // 平台回退逻辑（兼容旧格式：只有一个平台标记的情况）
+        // Platform fallback logic (compatible with the old format that only had one platform marker)
         if (!twitterMatch && redditMatch) {
-          // 只有 Reddit 回答，仅在非占位文本时复制为默认显示
-          if (interview.redditAnswer && interview.redditAnswer !== '（该平台未获得回复）') {
+          // Only a Reddit reply — copy it as the default display only if it isn't placeholder text
+          if (interview.redditAnswer && interview.redditAnswer !== '(no reply on this platform)') {
             interview.twitterAnswer = interview.redditAnswer
           }
         } else if (twitterMatch && !redditMatch) {
-          if (interview.twitterAnswer && interview.twitterAnswer !== '（该平台未获得回复）') {
+          if (interview.twitterAnswer && interview.twitterAnswer !== '(no reply on this platform)') {
             interview.redditAnswer = interview.twitterAnswer
           }
         } else if (!twitterMatch && !redditMatch) {
-          // 没有分平台标记（极旧格式），整体作为回答
+          // No platform markers at all (very old format) — treat the whole text as the answer
           interview.twitterAnswer = answerText
         }
       }
       
-      // 提取关键引言（兼容多种引号格式）
-      const quotesMatch = block.match(/\*\*关键引言:\*\*\n([\s\S]*?)(?=\n---|\n####|$)/)
+      // Extract key quotes (handles several quote-character variants)
+      const quotesMatch = block.match(/\*\*Key Quotes:\*\*\n([\s\S]*?)(?=\n---|\n####|$)/)
       if (quotesMatch) {
         const quotesText = quotesMatch[1]
-        // 优先匹配 > "text" 格式
+        // First try the > "text" format
         let quoteMatches = quotesText.match(/> "([^"]+)"/g)
-        // 回退：匹配 > "text" 或 > \u201Ctext\u201D（中文引号）
+        // Fallback: match > "text" or > \u201Ctext\u201D (Chinese curly quotes)
         if (!quoteMatches) {
           quoteMatches = quotesText.match(/> [\u201C""]([^\u201D""]+)[\u201D""]/g)
         }
@@ -889,8 +889,8 @@ const parseInterview = (text) => {
       }
     })
     
-    // 提取采访摘要
-    const summaryMatch = text.match(/### 采访摘要与核心观点\n([\s\S]*?)$/)
+    // Extract interview summary
+    const summaryMatch = text.match(/### Interview Summary and Key Points\n([\s\S]*?)$/)
     if (summaryMatch) {
       result.summary = summaryMatch[1].trim()
     }
@@ -911,23 +911,23 @@ const parseQuickSearch = (text) => {
   }
   
   try {
-    // 提取搜索查询
-    const queryMatch = text.match(/搜索查询:\s*(.+?)(?:\n|$)/)
+    // Extract search query
+    const queryMatch = text.match(/Search query:\s*(.+?)(?:\n|$)/)
     if (queryMatch) result.query = queryMatch[1].trim()
     
-    // 提取结果数量
-    const countMatch = text.match(/找到\s*(\d+)\s*条/)
+    // Extract the result count
+    const countMatch = text.match(/Found\s*(\d+)\s*relevant items/)
     if (countMatch) result.count = parseInt(countMatch[1])
     
-    // 提取相关事实 - 完整提取，不限制数量
-    const factsSection = text.match(/### 相关事实:\n([\s\S]*)$/)
+    // Extract related facts - take all, no cap
+    const factsSection = text.match(/### Relevant Facts:\n([\s\S]*)$/)
     if (factsSection) {
       const lines = factsSection[1].split('\n').filter(l => l.match(/^\d+\./))
       result.facts = lines.map(l => l.replace(/^\d+\.\s*/, '').trim()).filter(Boolean)
     }
     
-    // 尝试提取边信息（如果有）
-    const edgesSection = text.match(/### 相关边:\n([\s\S]*?)(?=\n###|$)/)
+    // Try to extract edge info (if present)
+    const edgesSection = text.match(/### Related Edges:\n([\s\S]*?)(?=\n###|$)/)
     if (edgesSection) {
       const lines = edgesSection[1].split('\n').filter(l => l.trim().startsWith('-'))
       result.edges = lines.map(l => {
@@ -939,8 +939,8 @@ const parseQuickSearch = (text) => {
       }).filter(Boolean)
     }
     
-    // 尝试提取节点信息（如果有）
-    const nodesSection = text.match(/### 相关节点:\n([\s\S]*?)(?=\n###|$)/)
+    // Try to extract node info (if present)
+    const nodesSection = text.match(/### Related Nodes:\n([\s\S]*?)(?=\n###|$)/)
     if (nodesSection) {
       const lines = nodesSection[1].split('\n').filter(l => l.trim().startsWith('-'))
       result.nodes = lines.map(l => {
@@ -1229,7 +1229,7 @@ const PanoramaDisplay = {
               h('div', { class: 'fact-item historical', key: i }, [
                 h('span', { class: 'fact-number' }, i + 1),
                 h('div', { class: 'fact-content' }, [
-                  // 尝试提取时间信息 [time - time]
+                  // Try to extract time info [time - time]
                   (() => {
                     const timeMatch = fact.match(/^\[(.+?)\]\s*(.*)$/)
                     if (timeMatch) {
@@ -1296,16 +1296,16 @@ const InterviewDisplay = {
     
     const activeIndex = ref(0)
     const expandedAnswers = ref(new Set())
-    // 为每个问题-回答对维护独立的平台选择状态
+    // Per question-and-answer pair, track an independent platform selection
     const platformTabs = reactive({}) // { 'agentIdx-qIdx': 'twitter' | 'reddit' }
     
-    // 获取某个问题的当前平台选择
+    // Get the current platform selection for a question
     const getPlatformTab = (agentIdx, qIdx) => {
       const key = `${agentIdx}-${qIdx}`
       return platformTabs[key] || 'twitter'
     }
     
-    // 设置某个问题的平台选择
+    // Set the platform selection for a question
     const setPlatformTab = (agentIdx, qIdx, platform) => {
       const key = `${agentIdx}-${qIdx}`
       platformTabs[key] = platform
@@ -1327,26 +1327,26 @@ const InterviewDisplay = {
       return text.substring(0, 400) + '...'
     }
     
-    // 检查是否为平台占位文本
+    // Check whether the text is a platform placeholder
     const isPlaceholderText = (text) => {
       if (!text) return true
       const t = text.trim()
-      return t === '（该平台未获得回复）' || t === '(该平台未获得回复)' || t === '[无回复]'
+      return t === '(no reply on this platform)' || t === '[no reply]'
     }
 
-    // 尝试按问题编号分割回答
+    // Try splitting the answer by question numbers
     const splitAnswerByQuestions = (answerText, questionCount) => {
       if (!answerText || questionCount <= 0) return [answerText]
       if (isPlaceholderText(answerText)) return ['']
 
-      // 支持两种编号格式：
-      // 1. "问题X：" 或 "问题X:" （中文格式，后端新格式）
-      // 2. "1. " 或 "\n1. " （数字+点，旧格式兼容）
+      // Support two numbering formats:
+      // 1. "Question X:" (English format, the new backend format)
+      // 2. "1. " or "\n1. " (number + dot, legacy format compatibility)
       let matches = []
       let match
 
-      // 优先尝试 "问题X：" 格式
-      const cnPattern = /(?:^|[\r\n]+)问题(\d+)[：:]\s*/g
+      // First try the "Question X:" format
+      const cnPattern = /(?:^|[\r\n]+)Question\s*(\d+)\s*[:：]\s*/g
       while ((match = cnPattern.exec(answerText)) !== null) {
         matches.push({
           num: parseInt(match[1]),
@@ -1355,7 +1355,7 @@ const InterviewDisplay = {
         })
       }
 
-      // 如果没匹配到，回退到 "数字." 格式
+      // If nothing matched, fall back to the "number." format
       if (matches.length === 0) {
         const numPattern = /(?:^|[\r\n]+)(\d+)\.\s+/g
         while ((match = numPattern.exec(answerText)) !== null) {
@@ -1367,16 +1367,16 @@ const InterviewDisplay = {
         }
       }
 
-      // 如果没有找到编号或只找到一个，返回整体
+      // If no numbering or only a single match, return the whole text
       if (matches.length <= 1) {
         const cleaned = answerText
-          .replace(/^问题\d+[：:]\s*/, '')
+          .replace(/^Question\s*\d+\s*[:：]\s*/, '')
           .replace(/^\d+\.\s+/, '')
           .trim()
         return [cleaned || answerText]
       }
 
-      // 按编号提取各部分
+      // Extract each part by its numbering
       const parts = []
       for (let i = 0; i < matches.length; i++) {
         const current = matches[i]
@@ -1397,7 +1397,7 @@ const InterviewDisplay = {
       return [answerText]
     }
     
-    // 获取某个问题对应的回答
+    // Get the answer for a specific question
     const getAnswerForQuestion = (interview, qIdx, platform) => {
       const answer = platform === 'twitter' ? interview.twitterAnswer : (interview.redditAnswer || interview.twitterAnswer)
       if (!answer || isPlaceholderText(answer)) return answer || ''
@@ -1405,21 +1405,21 @@ const InterviewDisplay = {
       const questionCount = interview.questions?.length || 1
       const answers = splitAnswerByQuestions(answer, questionCount)
 
-      // 分割成功且索引有效
+      // Split succeeded and the index is valid
       if (answers.length > 1 && qIdx < answers.length) {
         return answers[qIdx] || ''
       }
 
-      // 分割失败：第一个问题返回完整回答，其余返回空
+      // Split failed: return the whole answer for the first question and empty for the rest
       return qIdx === 0 ? answer : ''
     }
     
-    // 检查某个问题是否有双平台回答（过滤占位文本）
+    // Check whether a question has answers from both platforms (filter out placeholder text)
     const hasMultiplePlatforms = (interview, qIdx) => {
       if (!interview.twitterAnswer || !interview.redditAnswer) return false
       const twitterAnswer = getAnswerForQuestion(interview, qIdx, 'twitter')
       const redditAnswer = getAnswerForQuestion(interview, qIdx, 'reddit')
-      // 两个平台都有真实回答（非占位文本）且内容不同
+      // Both platforms have real (non-placeholder) answers and the content differs
       return !isPlaceholderText(twitterAnswer) && !isPlaceholderText(redditAnswer) && twitterAnswer !== redditAnswer
     }
     
@@ -1469,13 +1469,13 @@ const InterviewDisplay = {
           ])
         ]),
         
-        // Selection Reason - 选择理由
+        // Selection Reason
         props.result.interviews[activeIndex.value]?.selectionReason && h('div', { class: 'selection-reason' }, [
-          h('div', { class: 'reason-label' }, '选择理由'),
+          h('div', { class: 'reason-label' }, 'Selection Reason'),
           h('div', { class: 'reason-content' }, props.result.interviews[activeIndex.value].selectionReason)
         ]),
         
-        // Q&A Conversation Thread - 一问一答样式
+        // Q&A Conversation Thread - one-question-per-answer style
         h('div', { class: 'qa-thread' }, 
           (props.result.interviews[activeIndex.value]?.questions?.length > 0 
             ? props.result.interviews[activeIndex.value].questions 
@@ -1505,7 +1505,7 @@ const InterviewDisplay = {
                 h('div', { class: 'qa-content' }, [
                   h('div', { class: 'qa-answer-header' }, [
                     h('div', { class: 'qa-sender' }, interview?.name || 'Agent'),
-                    // 双平台切换按钮（仅在有真实双平台回答时显示）
+                    // Dual-platform switch buttons (only shown when both platforms have real answers)
                     hasDualPlatform && h('div', { class: 'platform-switch' }, [
                       h('button', {
                         class: ['platform-btn', { active: currentPlatform === 'twitter' }],
@@ -1537,7 +1537,7 @@ const InterviewDisplay = {
                           .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
                           .replace(/\n/g, '<br>')
                   }),
-                  // Expand/Collapse Button（占位文本不显示）
+                  // Expand/Collapse Button (hidden for placeholder text)
                   !isPlaceholder && answerText.length > 400 && h('button', {
                     class: 'expand-answer-btn',
                     onClick: () => toggleAnswer(expandKey)
@@ -1769,19 +1769,19 @@ const isFinalizing = computed(() => {
   return !isComplete.value && isPlanningDone.value && totalSections.value > 0 && completedSections.value >= totalSections.value
 })
 
-// 当前活跃的步骤（用于顶部显示）
+// Currently active step (for the top display)
 const activeStep = computed(() => {
   const steps = workflowSteps.value
-  // 找到当前 active 的步骤
+  // Find the currently-active step
   const active = steps.find(s => s.status === 'active')
   if (active) return active
-  
-  // 如果没有 active，返回最后一个 done 的步骤
+
+  // If none is active, return the last completed step
   const doneSteps = steps.filter(s => s.status === 'done')
   if (doneSteps.length > 0) return doneSteps[doneSteps.length - 1]
-  
-  // 否则返回第一个步骤
-  return steps[0] || { noLabel: '--', title: '等待开始', status: 'todo', meta: '' }
+
+  // Otherwise return the first step
+  return steps[0] || { noLabel: '--', title: 'Waiting to start', status: 'todo', meta: '' }
 })
 
 const workflowSteps = computed(() => {
@@ -1874,25 +1874,25 @@ const truncateText = (text, maxLen) => {
 const renderMarkdown = (content) => {
   if (!content) return ''
   
-  // 去掉开头的二级标题（## xxx），因为章节标题已在外层显示
+  // Strip the leading h2 (## xxx) since the section title is already shown above
   let processedContent = content.replace(/^##\s+.+\n+/, '')
-  
-  // 处理代码块
+
+  // Handle code blocks
   let html = processedContent.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre class="code-block"><code>$2</code></pre>')
-  
-  // 处理行内代码
+
+  // Handle inline code
   html = html.replace(/`([^`]+)`/g, '<code class="inline-code">$1</code>')
-  
-  // 处理标题
+
+  // Handle headings
   html = html.replace(/^#### (.+)$/gm, '<h5 class="md-h5">$1</h5>')
   html = html.replace(/^### (.+)$/gm, '<h4 class="md-h4">$1</h4>')
   html = html.replace(/^## (.+)$/gm, '<h3 class="md-h3">$1</h3>')
   html = html.replace(/^# (.+)$/gm, '<h2 class="md-h2">$1</h2>')
   
-  // 处理引用块
+  // Handle blockquotes
   html = html.replace(/^> (.+)$/gm, '<blockquote class="md-quote">$1</blockquote>')
   
-  // 处理列表 - 支持子列表
+  // Handle lists - support nested lists
   html = html.replace(/^(\s*)- (.+)$/gm, (match, indent, text) => {
     const level = Math.floor(indent.length / 2)
     return `<li class="md-li" data-level="${level}">${text}</li>`
@@ -1902,52 +1902,52 @@ const renderMarkdown = (content) => {
     return `<li class="md-oli" data-level="${level}">${text}</li>`
   })
 
-  // 包装无序列表
+  // Wrap unordered lists
   html = html.replace(/(<li class="md-li"[^>]*>.*?<\/li>\s*)+/g, '<ul class="md-ul">$&</ul>')
-  // 包装有序列表
+  // Wrap ordered lists
   html = html.replace(/(<li class="md-oli"[^>]*>.*?<\/li>\s*)+/g, '<ol class="md-ol">$&</ol>')
 
-  // 清理列表项之间的所有空白
+  // Strip all whitespace between list items
   html = html.replace(/<\/li>\s+<li/g, '</li><li')
-  // 清理列表开始标签后的空白
+  // Strip whitespace right after the list opening tag
   html = html.replace(/<ul class="md-ul">\s+/g, '<ul class="md-ul">')
   html = html.replace(/<ol class="md-ol">\s+/g, '<ol class="md-ol">')
-  // 清理列表结束标签前的空白
+  // Strip whitespace right before the list closing tag
   html = html.replace(/\s+<\/ul>/g, '</ul>')
   html = html.replace(/\s+<\/ol>/g, '</ol>')
   
-  // 处理粗体和斜体
+  // Handle bold and italic
   html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
   html = html.replace(/\*(.+?)\*/g, '<em>$1</em>')
   html = html.replace(/_(.+?)_/g, '<em>$1</em>')
   
-  // 处理分隔线
+  // Handle horizontal rules
   html = html.replace(/^---$/gm, '<hr class="md-hr">')
   
-  // 处理换行 - 空行变成段落分隔，单换行变成 <br>
+  // Handle newlines - blank lines become paragraph breaks, single newlines become <br>
   html = html.replace(/\n\n/g, '</p><p class="md-p">')
   html = html.replace(/\n/g, '<br>')
   
-  // 包装在段落中
+  // Wrap in a paragraph
   html = '<p class="md-p">' + html + '</p>'
   
-  // 清理空段落
+  // Remove empty paragraphs
   html = html.replace(/<p class="md-p"><\/p>/g, '')
   html = html.replace(/<p class="md-p">(<h[2-5])/g, '$1')
   html = html.replace(/(<\/h[2-5]>)<\/p>/g, '$1')
   html = html.replace(/<p class="md-p">(<ul|<ol|<blockquote|<pre|<hr)/g, '$1')
   html = html.replace(/(<\/ul>|<\/ol>|<\/blockquote>|<\/pre>)<\/p>/g, '$1')
-  // 清理块级元素前后的 <br> 标签
+  // Strip <br> tags around block-level elements
   html = html.replace(/<br>\s*(<ul|<ol|<blockquote)/g, '$1')
   html = html.replace(/(<\/ul>|<\/ol>|<\/blockquote>)\s*<br>/g, '$1')
-  // 清理 <p><br> 紧跟块级元素的情况（多余空行导致）
+  // Clean up <p><br> followed by a block-level element (caused by extra blank lines)
   html = html.replace(/<p class="md-p">(<br>\s*)+(<ul|<ol|<blockquote|<pre|<hr)/g, '$2')
-  // 清理连续的 <br> 标签
+  // Collapse consecutive <br> tags
   html = html.replace(/(<br>\s*){2,}/g, '<br>')
-  // 清理块级元素后紧跟的段落开始标签前的 <br>
+  // Remove a <br> right before a paragraph that follows a block element
   html = html.replace(/(<\/ol>|<\/ul>|<\/blockquote>)<br>(<p|<div)/g, '$1$2')
 
-  // 修复非连续有序列表的编号：当单项 <ol> 被段落内容隔开时，保持编号递增
+  // Fix non-contiguous ordered-list numbering: when single-item <ol>s are separated by paragraph content, keep the count incrementing
   const tokens = html.split(/(<ol class="md-ol">(?:<li class="md-oli"[^>]*>[\s\S]*?<\/li>)+<\/ol>)/g)
   let olCounter = 0
   let inSequence = false
@@ -2011,9 +2011,10 @@ const getActionLabel = (action) => {
 }
 
 const getLogLevelClass = (log) => {
-  if (log.includes('ERROR') || log.includes('错误')) return 'error'
-  if (log.includes('WARNING') || log.includes('警告')) return 'warning'
-  // INFO 使用默认颜色，不标记为 success
+  // Match log levels emitted by the backend (case-insensitive English)
+  if (/error/i.test(log)) return 'error'
+  if (/warning/i.test(log)) return 'warning'
+  // INFO uses the default color and is not styled as success
   return ''
 }
 
@@ -2042,11 +2043,11 @@ const fetchAgentLog = async () => {
             currentSectionIndex.value = log.section_index
           }
 
-          // section_complete - 章节生成完成
+          // section_complete - section generation finished
           if (log.action === 'section_complete') {
             if (log.details?.content) {
               generatedSections.value[log.section_index] = log.details.content
-              // 自动展开刚生成的章节
+              // Auto-expand the freshly-generated section
               expandedContent.value.add(log.section_index - 1)
               currentSectionIndex.value = null
             }
@@ -2054,10 +2055,10 @@ const fetchAgentLog = async () => {
           
           if (log.action === 'report_complete') {
             isComplete.value = true
-            currentSectionIndex.value = null  // 确保清除 loading 状态
+            currentSectionIndex.value = null  // Make sure the loading state is cleared
             emit('update-status', 'completed')
             stopPolling()
-            // 滚动逻辑统一在循环结束后的 nextTick 中处理
+            // Scroll handling is done uniformly in the nextTick after the loop
           }
           
           if (log.action === 'report_start') {
@@ -2069,7 +2070,7 @@ const fetchAgentLog = async () => {
         
         nextTick(() => {
           if (rightPanel.value) {
-            // 如果任务已完成，滚动到顶部；否则滚动到底部跟随最新日志
+            // If the task is complete, scroll to the top; otherwise stay at the bottom to follow the latest logs
             if (isComplete.value) {
               rightPanel.value.scrollTop = 0
             } else {
@@ -2084,39 +2085,33 @@ const fetchAgentLog = async () => {
   }
 }
 
-// 提取最终答案内容 - 从 LLM response 中提取章节内容
+// Extract the final answer - pull the section content out of an LLM response
 const extractFinalContent = (response) => {
   if (!response) return null
-  
-  // 尝试提取 <final_answer> 标签内的内容
+
+  // Try to extract the content inside <final_answer> tags
   const finalAnswerTagMatch = response.match(/<final_answer>([\s\S]*?)<\/final_answer>/)
   if (finalAnswerTagMatch) {
     return finalAnswerTagMatch[1].trim()
   }
-  
-  // 尝试找 Final Answer: 后面的内容（支持多种格式）
-  // 格式1: Final Answer:\n\n内容
-  // 格式2: Final Answer: 内容
+
+  // Try to find content after "Final Answer:" (handles multiple formats)
+  // Format 1: Final Answer:\n\n<content>
+  // Format 2: Final Answer: <content>
   const finalAnswerMatch = response.match(/Final\s*Answer:\s*\n*([\s\S]*)$/i)
   if (finalAnswerMatch) {
     return finalAnswerMatch[1].trim()
   }
-  
-  // 尝试找 最终答案: 后面的内容
-  const chineseFinalMatch = response.match(/最终答案[:：]\s*\n*([\s\S]*)$/i)
-  if (chineseFinalMatch) {
-    return chineseFinalMatch[1].trim()
-  }
-  
-  // 如果以 ## 或 # 或 > 开头，可能是直接的 markdown 内容
+
+  // If it starts with ##, #, or >, it may already be plain markdown
   const trimmedResponse = response.trim()
   if (trimmedResponse.match(/^[#>]/)) {
     return trimmedResponse
   }
-  
-  // 如果内容较长且包含markdown格式，尝试移除思考过程后返回
+
+  // If the content is long and contains markdown formatting, try stripping the "Thought:" prefix
   if (response.length > 300 && (response.includes('**') || response.includes('>'))) {
-    // 移除 Thought: 开头的思考过程
+    // Remove the "Thought:" prelude
     const thoughtMatch = response.match(/^Thought:[\s\S]*?(?=\n\n[^T]|\n\n$)/i)
     if (thoughtMatch) {
       const afterThought = response.substring(thoughtMatch[0].length).trim()
@@ -2461,7 +2456,7 @@ watch(() => props.reportId, (newId) => {
 .section-number {
   font-family: 'JetBrains Mono', monospace;
   font-size: 16px;
-  color: #9CA3AF; /* 深灰色，不随状态变化 */
+  color: #9CA3AF; /* Dark gray, does not change with state */
   font-weight: 500;
 }
 
@@ -3903,7 +3898,7 @@ watch(() => props.reportId, (newId) => {
   overflow: hidden;
 }
 
-/* Selection Reason - 选择理由 */
+/* Selection Reason */
 :deep(.interview-display .selection-reason) {
   background: #F8FAFC;
   border: 1px solid #E2E8F0;
@@ -5102,7 +5097,7 @@ watch(() => props.reportId, (newId) => {
   border-radius: 4px;
 }
 
-/* Console Logs - 与 Step3Simulation.vue 保持一致 */
+/* Console Logs - kept in sync with Step3Simulation.vue */
 .console-logs {
   background: #000;
   color: #DDD;

--- a/frontend/src/components/Step5Interaction.vue
+++ b/frontend/src/components/Step5Interaction.vue
@@ -437,7 +437,7 @@ const showToolsDetail = ref(true)
 // Chat State
 const chatInput = ref('')
 const chatHistory = ref([])
-const chatHistoryCache = ref({}) // 缓存所有对话记录: { 'report_agent': [], 'agent_0': [], 'agent_1': [], ... }
+const chatHistoryCache = ref({}) // Cache of all chat histories: { 'report_agent': [], 'agent_0': [], 'agent_1': [], ... }
 const isSending = ref(false)
 const chatMessages = ref(null)
 const chatInputRef = ref(null)
@@ -487,7 +487,7 @@ const selectChatTarget = (target) => {
   }
 }
 
-// 保存当前对话记录到缓存
+// Save the current chat history to the cache
 const saveChatHistory = () => {
   if (chatHistory.value.length === 0) return
   
@@ -499,16 +499,16 @@ const saveChatHistory = () => {
 }
 
 const selectReportAgentChat = () => {
-  // 保存当前对话记录
+  // Save current chat history
   saveChatHistory()
-  
+
   activeTab.value = 'chat'
   chatTarget.value = 'report_agent'
   selectedAgent.value = null
   selectedAgentIndex.value = null
   showAgentDropdown.value = false
-  
-  // 恢复 Report Agent 的对话记录
+
+  // Restore the Report Agent's chat history
   chatHistory.value = chatHistoryCache.value['report_agent'] || []
 }
 
@@ -528,15 +528,15 @@ const toggleAgentDropdown = () => {
 }
 
 const selectAgent = (agent, idx) => {
-  // 保存当前对话记录
+  // Save current chat history
   saveChatHistory()
-  
+
   selectedAgent.value = agent
   selectedAgentIndex.value = idx
   chatTarget.value = 'agent'
   showAgentDropdown.value = false
-  
-  // 恢复该 Agent 的对话记录
+
+  // Restore this Agent's chat history
   chatHistory.value = chatHistoryCache.value[`agent_${idx}`] || []
   addLog(t('log.selectChatTarget', { name: agent.username }))
 }
@@ -566,7 +566,7 @@ const renderMarkdown = (content) => {
   html = html.replace(/^# (.+)$/gm, '<h2 class="md-h2">$1</h2>')
   html = html.replace(/^> (.+)$/gm, '<blockquote class="md-quote">$1</blockquote>')
   
-  // 处理列表 - 支持子列表
+  // Process lists - support nested lists
   html = html.replace(/^(\s*)- (.+)$/gm, (match, indent, text) => {
     const level = Math.floor(indent.length / 2)
     return `<li class="md-li" data-level="${level}">${text}</li>`
@@ -576,17 +576,17 @@ const renderMarkdown = (content) => {
     return `<li class="md-oli" data-level="${level}">${text}</li>`
   })
   
-  // 包装无序列表
+  // Wrap unordered lists
   html = html.replace(/(<li class="md-li"[^>]*>.*?<\/li>\s*)+/g, '<ul class="md-ul">$&</ul>')
-  // 包装有序列表
+  // Wrap ordered lists
   html = html.replace(/(<li class="md-oli"[^>]*>.*?<\/li>\s*)+/g, '<ol class="md-ol">$&</ol>')
-  
-  // 清理列表项之间的所有空白
+
+  // Strip all whitespace between list items
   html = html.replace(/<\/li>\s+<li/g, '</li><li')
-  // 清理列表开始标签后的空白
+  // Strip whitespace right after the list opening tag
   html = html.replace(/<ul class="md-ul">\s+/g, '<ul class="md-ul">')
   html = html.replace(/<ol class="md-ol">\s+/g, '<ol class="md-ol">')
-  // 清理列表结束标签前的空白
+  // Strip whitespace right before the list closing tag
   html = html.replace(/\s+<\/ul>/g, '</ul>')
   html = html.replace(/\s+<\/ol>/g, '</ol>')
   
@@ -602,17 +602,17 @@ const renderMarkdown = (content) => {
   html = html.replace(/(<\/h[2-5]>)<\/p>/g, '$1')
   html = html.replace(/<p class="md-p">(<ul|<ol|<blockquote|<pre|<hr)/g, '$1')
   html = html.replace(/(<\/ul>|<\/ol>|<\/blockquote>|<\/pre>)<\/p>/g, '$1')
-  // 清理块级元素前后的 <br> 标签
+  // Strip <br> tags around block-level elements
   html = html.replace(/<br>\s*(<ul|<ol|<blockquote)/g, '$1')
   html = html.replace(/(<\/ul>|<\/ol>|<\/blockquote>)\s*<br>/g, '$1')
-  // 清理 <p><br> 紧跟块级元素的情况（多余空行导致）
+  // Clean up <p><br> followed by a block-level element (caused by extra blank lines)
   html = html.replace(/<p class="md-p">(<br>\s*)+(<ul|<ol|<blockquote|<pre|<hr)/g, '$2')
-  // 清理连续的 <br> 标签
+  // Collapse consecutive <br> tags
   html = html.replace(/(<br>\s*){2,}/g, '<br>')
-  // 清理块级元素后紧跟的段落开始标签前的 <br>
+  // Remove a <br> right before a paragraph that follows a block element
   html = html.replace(/(<\/ol>|<\/ul>|<\/blockquote>)<br>(<p|<div)/g, '$1$2')
 
-  // 修复非连续有序列表的编号：当单项 <ol> 被段落内容隔开时，保持编号递增
+  // Fix non-contiguous ordered-list numbering: when single-item <ol>s are separated by paragraph content, keep the count incrementing
   const tokens = html.split(/(<ol class="md-ol">(?:<li class="md-oli"[^>]*>[\s\S]*?<\/li>)+<\/ol>)/g)
   let olCounter = 0
   let inSequence = false
@@ -674,7 +674,7 @@ const sendMessage = async () => {
   } finally {
     isSending.value = false
     scrollToBottom()
-    // 自动保存对话记录到缓存
+    // Auto-save the chat history to the cache
     saveChatHistory()
   }
 }
@@ -722,9 +722,9 @@ const sendToAgent = async (message) => {
     const historyContext = chatHistory.value
       .filter(msg => msg.content !== message)
       .slice(-6)
-      .map(msg => `${msg.role === 'user' ? '提问者' : '你'}：${msg.content}`)
+      .map(msg => `${msg.role === 'user' ? 'Interviewer' : 'You'}: ${msg.content}`)
       .join('\n')
-    prompt = `以下是我们之前的对话：\n${historyContext}\n\n现在我的新问题是：${message}`
+    prompt = `Here is our previous conversation:\n${historyContext}\n\nMy new question is: ${message}`
   }
   
   const res = await interviewAgents({
@@ -736,17 +736,17 @@ const sendToAgent = async (message) => {
   })
   
   if (res.success && res.data) {
-    // 正确的数据路径: res.data.result.results 是一个对象字典
-    // 格式: {"twitter_0": {...}, "reddit_0": {...}} 或单平台 {"reddit_0": {...}}
+    // Correct data path: res.data.result.results is a dictionary
+    // Shape: {"twitter_0": {...}, "reddit_0": {...}} or single-platform {"reddit_0": {...}}
     const resultData = res.data.result || res.data
     const resultsDict = resultData.results || resultData
-    
-    // 将对象字典转换为数组，优先获取 reddit 平台的回复
+
+    // Convert the dictionary to an array, preferring the reddit platform reply
     let responseContent = null
     const agentId = selectedAgentIndex.value
-    
+
     if (typeof resultsDict === 'object' && !Array.isArray(resultsDict)) {
-      // 优先使用 reddit 平台回复，其次 twitter
+      // Prefer the reddit reply, fall back to twitter
       const redditKey = `reddit_${agentId}`
       const twitterKey = `twitter_${agentId}`
       const agentResult = resultsDict[redditKey] || resultsDict[twitterKey] || Object.values(resultsDict)[0]
@@ -754,7 +754,7 @@ const sendToAgent = async (message) => {
         responseContent = agentResult.response || agentResult.answer
       }
     } else if (Array.isArray(resultsDict) && resultsDict.length > 0) {
-      // 兼容数组格式
+      // Backwards compatibility with array shape
       responseContent = resultsDict[0].response || resultsDict[0].answer
     }
     
@@ -820,19 +820,19 @@ const submitSurvey = async () => {
     })
     
     if (res.success && res.data) {
-      // 正确的数据路径: res.data.result.results 是一个对象字典
-      // 格式: {"twitter_0": {...}, "reddit_0": {...}, "twitter_1": {...}, ...}
+      // Correct data path: res.data.result.results is a dictionary
+      // Shape: {"twitter_0": {...}, "reddit_0": {...}, "twitter_1": {...}, ...}
       const resultData = res.data.result || res.data
       const resultsDict = resultData.results || resultData
-      
-      // 将对象字典转换为数组格式
+
+      // Convert the dictionary into a list
       const surveyResultsList = []
-      
+
       for (const interview of interviews) {
         const agentIdx = interview.agent_id
         const agent = profiles.value[agentIdx]
-        
-        // 优先使用 reddit 平台回复，其次 twitter
+
+        // Prefer the reddit reply, fall back to twitter
         let responseContent = t('step5.noResponse')
 
         if (typeof resultsDict === 'object' && !Array.isArray(resultsDict)) {
@@ -843,7 +843,7 @@ const submitSurvey = async () => {
             responseContent = agentResult.response || agentResult.answer || t('step5.noResponse')
           }
         } else if (Array.isArray(resultsDict)) {
-          // 兼容数组格式
+          // Backwards compatibility with array shape
           const matchedResult = resultsDict.find(r => r.agent_id === agentIdx)
           if (matchedResult) {
             responseContent = matchedResult.response || matchedResult.answer || t('step5.noResponse')
@@ -983,7 +983,7 @@ watch(() => props.simulationId, (newId) => {
   overflow: hidden;
 }
 
-/* Left Panel - Report Style (与 Step4Report.vue 完全一致) */
+/* Left Panel - Report Style (matches Step4Report.vue exactly) */
 .left-panel.report-style {
   width: 45%;
   min-width: 450px;
@@ -2031,7 +2031,7 @@ watch(() => props.simulationId, (newId) => {
   margin-bottom: 0;
 }
 
-/* 修复有序列表编号 - 使用 CSS 计数器让多个 ol 连续编号 */
+/* Fix ordered-list numbering - use CSS counters so multiple <ol>s number continuously */
 .message-text {
   counter-reset: list-counter;
 }
@@ -2057,7 +2057,7 @@ watch(() => props.simulationId, (newId) => {
   flex-shrink: 0;
 }
 
-/* 无序列表样式 */
+/* Unordered list styles */
 .message-text :deep(.md-ul) {
   padding-left: 20px;
   margin: 8px 0;
@@ -2536,7 +2536,7 @@ watch(() => props.simulationId, (newId) => {
   margin: 6px 0;
 }
 
-/* 聊天/问卷区域的引用样式 */
+/* Quote styles for the chat/survey area */
 .chat-messages :deep(.md-quote),
 .result-answer :deep(.md-quote) {
   margin: 12px 0;

--- a/frontend/src/i18n/index.js
+++ b/frontend/src/i18n/index.js
@@ -14,12 +14,14 @@ for (const path in localeFiles) {
   }
 }
 
-const savedLocale = localStorage.getItem('locale') || 'zh'
+// Default to English for production, can be overridden by VITE_DEFAULT_LOCALE
+const defaultLocale = import.meta.env.VITE_DEFAULT_LOCALE || 'en'
+const savedLocale = localStorage.getItem('locale') || defaultLocale
 
 const i18n = createI18n({
   legacy: false,
   locale: savedLocale,
-  fallbackLocale: 'zh',
+  fallbackLocale: defaultLocale,
   messages
 })
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -45,7 +45,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(import.meta.env.VITE_BASE_PATH || '/'),
   routes
 })
 

--- a/frontend/src/store/pendingUpload.js
+++ b/frontend/src/store/pendingUpload.js
@@ -1,6 +1,7 @@
 /**
- * 临时存储待上传的文件和需求
- * 用于首页点击启动引擎后立即跳转，在Process页面再进行API调用
+ * Temporary storage for files and requirements pending upload.
+ * Used so the home page can navigate immediately when the engine is launched,
+ * deferring the actual API call until the Process page.
  */
 import { reactive } from 'vue'
 

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="home-container">
-    <!-- 顶部导航栏 -->
+    <!-- Top navigation bar -->
     <nav class="navbar">
       <div class="nav-brand">MIROFISH</div>
       <div class="nav-links">
@@ -12,7 +12,7 @@
     </nav>
 
     <div class="main-content">
-      <!-- 上半部分：Hero 区域 -->
+      <!-- Top section: hero area -->
       <section class="hero-section">
         <div class="hero-left">
           <div class="tag-row">
@@ -42,7 +42,7 @@
         </div>
         
         <div class="hero-right">
-          <!-- Logo 区域 -->
+          <!-- Logo area -->
           <div class="logo-container">
             <img src="../assets/logo/MiroFish_logo_left.jpeg" alt="MiroFish Logo" class="hero-logo" />
           </div>
@@ -53,9 +53,9 @@
         </div>
       </section>
 
-      <!-- 下半部分：双栏布局 -->
+      <!-- Bottom section: two-column layout -->
       <section class="dashboard-section">
-        <!-- 左栏：状态与步骤 -->
+        <!-- Left column: status and steps -->
         <div class="left-panel">
           <div class="panel-header">
             <span class="status-dot">■</span> {{ $t('home.systemStatus') }}
@@ -66,7 +66,7 @@
             {{ $t('home.systemReadyDesc') }}
           </p>
           
-          <!-- 数据指标卡片 -->
+          <!-- Metric cards -->
           <div class="metrics-row">
             <div class="metric-card">
               <div class="metric-value">{{ $t('home.metricLowCost') }}</div>
@@ -78,7 +78,7 @@
             </div>
           </div>
 
-          <!-- 项目模拟步骤介绍 (新增区域) -->
+          <!-- Project simulation step introduction (new section) -->
           <div class="steps-container">
             <div class="steps-header">
                <span class="diamond-icon">◇</span> {{ $t('home.workflowSequence') }}
@@ -123,10 +123,10 @@
           </div>
         </div>
 
-        <!-- 右栏：交互控制台 -->
+        <!-- Right column: interaction console -->
         <div class="right-panel">
           <div class="console-box">
-            <!-- 上传区域 -->
+            <!-- Upload area -->
             <div class="console-section">
               <div class="console-header">
                 <span class="console-label">{{ $t('home.realitySeed') }}</span>
@@ -167,12 +167,12 @@
               </div>
             </div>
 
-            <!-- 分割线 -->
+            <!-- Divider -->
             <div class="console-divider">
               <span>{{ $t('home.inputParams') }}</span>
             </div>
 
-            <!-- 输入区域 -->
+            <!-- Input area -->
             <div class="console-section">
               <div class="console-header">
                 <span class="console-label">{{ $t('home.simulationPrompt') }}</span>
@@ -189,7 +189,7 @@
               </div>
             </div>
 
-            <!-- 启动按钮 -->
+            <!-- Launch button -->
             <div class="console-section btn-section">
               <button 
                 class="start-engine-btn"
@@ -205,7 +205,7 @@
         </div>
       </section>
 
-      <!-- 历史项目数据库 -->
+      <!-- Historical project database -->
       <HistoryDatabase />
     </div>
   </div>
@@ -219,41 +219,41 @@ import LanguageSwitcher from '../components/LanguageSwitcher.vue'
 
 const router = useRouter()
 
-// 表单数据
+// Form data
 const formData = ref({
   simulationRequirement: ''
 })
 
-// 文件列表
+// File list
 const files = ref([])
 
-// 状态
+// State
 const loading = ref(false)
 const error = ref('')
 const isDragOver = ref(false)
 
-// 文件输入引用
+// File input ref
 const fileInput = ref(null)
 
-// 计算属性:是否可以提交
+// Computed: whether the form can be submitted
 const canSubmit = computed(() => {
   return formData.value.simulationRequirement.trim() !== '' && files.value.length > 0
 })
 
-// 触发文件选择
+// Trigger the file picker
 const triggerFileInput = () => {
   if (!loading.value) {
     fileInput.value?.click()
   }
 }
 
-// 处理文件选择
+// Handle file selection
 const handleFileSelect = (event) => {
   const selectedFiles = Array.from(event.target.files)
   addFiles(selectedFiles)
 }
 
-// 处理拖拽相关
+// Drag-and-drop handlers
 const handleDragOver = (e) => {
   if (!loading.value) {
     isDragOver.value = true
@@ -272,7 +272,7 @@ const handleDrop = (e) => {
   addFiles(droppedFiles)
 }
 
-// 添加文件
+// Add files
 const addFiles = (newFiles) => {
   const validFiles = newFiles.filter(file => {
     const ext = file.name.split('.').pop().toLowerCase()
@@ -281,12 +281,12 @@ const addFiles = (newFiles) => {
   files.value.push(...validFiles)
 }
 
-// 移除文件
+// Remove a file
 const removeFile = (index) => {
   files.value.splice(index, 1)
 }
 
-// 滚动到底部
+// Scroll to bottom
 const scrollToBottom = () => {
   window.scrollTo({
     top: document.body.scrollHeight,
@@ -294,15 +294,15 @@ const scrollToBottom = () => {
   })
 }
 
-// 开始模拟 - 立即跳转，API调用在Process页面进行
+// Start simulation - navigate immediately; the API call is made on the Process page
 const startSimulation = () => {
   if (!canSubmit.value || loading.value) return
   
-  // 存储待上传的数据
+  // Store the data pending upload
   import('../store/pendingUpload.js').then(({ setPendingUpload }) => {
     setPendingUpload(files.value, formData.value.simulationRequirement)
     
-    // 立即跳转到Process页面（使用特殊标识表示新建项目）
+    // Immediately navigate to the Process page (using a special id to indicate a new project)
     router.push({
       name: 'Process',
       params: { projectId: 'new' }
@@ -312,7 +312,7 @@ const startSimulation = () => {
 </script>
 
 <style scoped>
-/* 全局变量与重置 */
+/* Global variables and reset */
 :root {
   --black: #000000;
   --white: #FFFFFF;
@@ -321,8 +321,8 @@ const startSimulation = () => {
   --gray-text: #666666;
   --border: #E5E5E5;
   /* 
-    使用 Space Grotesk 作为主要标题字体，JetBrains Mono 作为代码/标签字体
-    确保已在 index.html 引入这些 Google Fonts 
+    Use Space Grotesk as the primary heading font and JetBrains Mono for code/labels.
+    Make sure these Google Fonts are loaded in index.html.
   */
   --font-mono: 'JetBrains Mono', monospace;
   --font-sans: 'Space Grotesk', 'Noto Sans SC', system-ui, sans-serif;
@@ -336,7 +336,7 @@ const startSimulation = () => {
   color: var(--black);
 }
 
-/* 顶部导航 */
+/* Top navigation */
 .navbar {
   height: 60px;
   background: var(--black);
@@ -380,14 +380,14 @@ const startSimulation = () => {
   font-family: sans-serif;
 }
 
-/* 主要内容区 */
+/* Main content area */
 .main-content {
   max-width: 1400px;
   margin: 0 auto;
   padding: 60px 40px;
 }
 
-/* Hero 区域 */
+/* Hero area */
 .hero-section {
   display: flex;
   justify-content: space-between;
@@ -518,7 +518,7 @@ const startSimulation = () => {
 }
 
 .hero-logo {
-  max-width: 500px; /* 调整logo大小 */
+  max-width: 500px; /* Adjust the logo size */
   width: 100%;
 }
 
@@ -540,7 +540,7 @@ const startSimulation = () => {
   border-color: var(--orange);
 }
 
-/* Dashboard 双栏布局 */
+/* Dashboard two-column layout */
 .dashboard-section {
   display: flex;
   gap: 60px;
@@ -555,7 +555,7 @@ const startSimulation = () => {
   flex-direction: column;
 }
 
-/* 左侧面板 */
+/* Left panel */
 .left-panel {
   flex: 0.8;
 }
@@ -611,7 +611,7 @@ const startSimulation = () => {
   color: #999;
 }
 
-/* 项目模拟步骤介绍 */
+/* Project simulation step introduction */
 .steps-container {
   border: 1px solid var(--border);
   padding: 30px;
@@ -667,14 +667,14 @@ const startSimulation = () => {
   color: var(--gray-text);
 }
 
-/* 右侧交互控制台 */
+/* Right-side interaction console */
 .right-panel {
   flex: 1.2;
 }
 
 .console-box {
-  border: 1px solid #CCC; /* 外部实线 */
-  padding: 8px; /* 内边距形成双重边框感 */
+  border: 1px solid #CCC; /* Outer solid border */
+  padding: 8px; /* Inner padding creates a double-border effect */
 }
 
 .console-section {
@@ -842,7 +842,7 @@ const startSimulation = () => {
   overflow: hidden;
 }
 
-/* 可点击状态（非禁用） */
+/* Clickable state (non-disabled) */
 .start-engine-btn:not(:disabled) {
   background: var(--black);
   border: 1px solid var(--black);
@@ -867,14 +867,14 @@ const startSimulation = () => {
   border: 1px solid #E5E5E5;
 }
 
-/* 引导动画：微妙的边框脉冲 */
+/* Guidance animation: subtle border pulse */
 @keyframes pulse-border {
   0% { box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.2); }
   70% { box-shadow: 0 0 0 6px rgba(0, 0, 0, 0); }
   100% { box-shadow: 0 0 0 0 rgba(0, 0, 0, 0); }
 }
 
-/* 响应式适配 */
+/* Responsive adjustments */
 @media (max-width: 1024px) {
   .dashboard-section {
     flex-direction: column;

--- a/frontend/src/views/InteractionView.vue
+++ b/frontend/src/views/InteractionView.vue
@@ -49,7 +49,7 @@
         />
       </div>
 
-      <!-- Right Panel: Step5 深度互动 -->
+      <!-- Right Panel: Step5 Deep Interaction -->
       <div class="panel-wrapper right" :style="rightPanelStyle">
         <Step5Interaction
           :reportId="currentReportId"
@@ -83,7 +83,7 @@ const props = defineProps({
   reportId: String
 })
 
-// Layout State - 默认切换到工作台视角
+// Layout State - default to the workbench view
 const viewMode = ref('workbench')
 
 // Data State
@@ -147,26 +147,26 @@ const loadReportData = async () => {
   try {
     addLog(t('log.loadReportData', { id: currentReportId.value }))
 
-    // 获取 report 信息以获取 simulation_id
+    // Fetch report info to obtain simulation_id
     const reportRes = await getReport(currentReportId.value)
     if (reportRes.success && reportRes.data) {
       const reportData = reportRes.data
       simulationId.value = reportData.simulation_id
 
       if (simulationId.value) {
-        // 获取 simulation 信息
+        // Fetch simulation info
         const simRes = await getSimulation(simulationId.value)
         if (simRes.success && simRes.data) {
           const simData = simRes.data
 
-          // 获取 project 信息
+          // Fetch project info
           if (simData.project_id) {
             const projRes = await getProject(simData.project_id)
             if (projRes.success && projRes.data) {
               projectData.value = projRes.data
               addLog(t('log.projectLoadSuccess', { id: projRes.data.project_id }))
 
-              // 获取 graph 数据
+              // Fetch graph data
               if (projRes.data.graph_id) {
                 await loadGraph(projRes.data.graph_id)
               }

--- a/frontend/src/views/MainView.vue
+++ b/frontend/src/views/MainView.vue
@@ -50,7 +50,7 @@
 
       <!-- Right Panel: Step Components -->
       <div class="panel-wrapper right" :style="rightPanelStyle">
-        <!-- Step 1: 图谱构建 -->
+        <!-- Step 1: Graph Build -->
         <Step1GraphBuild 
           v-if="currentStep === 1"
           :currentPhase="currentPhase"
@@ -61,7 +61,7 @@
           :systemLogs="systemLogs"
           @next-step="handleNextStep"
         />
-        <!-- Step 2: 环境搭建 -->
+        <!-- Step 2: Environment Setup -->
         <Step2EnvSetup
           v-else-if="currentStep === 2"
           :projectData="projectData"
@@ -95,7 +95,7 @@ const { t, tm } = useI18n()
 const viewMode = ref('split') // graph | split | workbench
 
 // Step State
-const currentStep = ref(1) // 1: 图谱构建, 2: 环境搭建, 3: 开始模拟, 4: 报告生成, 5: 深度互动
+const currentStep = ref(1) // 1: Graph Build, 2: Environment Setup, 3: Start Simulation, 4: Report Generation, 5: Deep Interaction
 const stepNames = computed(() => tm('main.stepNames'))
 
 // Data State
@@ -166,7 +166,7 @@ const handleNextStep = (params = {}) => {
     currentStep.value++
     addLog(t('log.enterStep', { step: currentStep.value, name: stepNames.value[currentStep.value - 1] }))
     
-    // 如果是从 Step 2 进入 Step 3，记录模拟轮数配置
+    // When moving from Step 2 to Step 3, record the simulation round-count config
     if (currentStep.value === 3 && params.maxRounds) {
       addLog(t('log.customSimRounds', { rounds: params.maxRounds }))
     }

--- a/frontend/src/views/Process.vue
+++ b/frontend/src/views/Process.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="process-page">
-    <!-- 顶部导航栏 -->
+    <!-- Top navigation bar -->
     <nav class="navbar">
       <div class="nav-brand" @click="goHome">MIROFISH</div>
-      
-      <!-- 中间步骤指示器 -->
+
+      <!-- Center step indicator -->
       <div class="nav-center">
         <div class="step-badge">STEP 01</div>
-        <div class="step-name">图谱构建</div>
+        <div class="step-name">Graph Build</div>
       </div>
 
       <div class="nav-status">
@@ -16,27 +16,27 @@
       </div>
     </nav>
 
-    <!-- 主内容区 -->
+    <!-- Main content area -->
     <div class="main-content">
-      <!-- 左侧: 实时图谱展示 -->
+      <!-- Left side: real-time graph visualization -->
       <div class="left-panel" :class="{ 'full-screen': isFullScreen }">
         <div class="panel-header">
           <div class="header-left">
             <span class="header-deco">◆</span>
-            <span class="header-title">实时知识图谱</span>
+            <span class="header-title">Real-time Knowledge Graph</span>
           </div>
           <div class="header-right">
             <template v-if="graphData">
-              <span class="stat-item">{{ graphData.node_count || graphData.nodes?.length || 0 }} 节点</span>
+              <span class="stat-item">{{ graphData.node_count || graphData.nodes?.length || 0 }} nodes</span>
               <span class="stat-divider">|</span>
-              <span class="stat-item">{{ graphData.edge_count || graphData.edges?.length || 0 }} 关系</span>
+              <span class="stat-item">{{ graphData.edge_count || graphData.edges?.length || 0 }} relations</span>
               <span class="stat-divider">|</span>
             </template>
             <div class="action-buttons">
-                <button class="action-btn" @click="refreshGraph" :disabled="graphLoading" title="刷新图谱">
+                <button class="action-btn" @click="refreshGraph" :disabled="graphLoading" title="Refresh graph">
                   <span class="icon-refresh" :class="{ 'spinning': graphLoading }">↻</span>
                 </button>
-                <button class="action-btn" @click="toggleFullScreen" :title="isFullScreen ? '退出全屏' : '全屏显示'">
+                <button class="action-btn" @click="toggleFullScreen" :title="isFullScreen ? 'Exit fullscreen' : 'Enter fullscreen'">
                   <span class="icon-fullscreen">{{ isFullScreen ? '↙' : '↗' }}</span>
                 </button>
             </div>
@@ -44,16 +44,16 @@
         </div>
         
         <div class="graph-container" ref="graphContainer">
-          <!-- 图谱可视化（只要有数据就显示） -->
+          <!-- Graph visualization (shown whenever data exists) -->
           <div v-if="graphData" class="graph-view">
             <svg ref="graphSvg" class="graph-svg"></svg>
-            <!-- 构建中提示 -->
+            <!-- Build-in-progress hint -->
             <div v-if="currentPhase === 1" class="graph-building-hint">
               <span class="building-dot"></span>
-              实时更新中...
+              Updating in real time...
             </div>
-            
-            <!-- 节点/边详情面板 -->
+
+            <!-- Node/edge detail panel -->
             <div v-if="selectedItem" class="detail-panel">
               <div class="detail-panel-header">
                 <span class="detail-title">{{ selectedItem.type === 'node' ? 'Node Details' : 'Relationship' }}</span>
@@ -63,7 +63,7 @@
                 <button class="detail-close" @click="closeDetailPanel">×</button>
               </div>
               
-              <!-- 节点详情 -->
+              <!-- Node details -->
               <div v-if="selectedItem.type === 'node'" class="detail-content">
                 <div class="detail-row">
                   <span class="detail-label">Name:</span>
@@ -104,9 +104,9 @@
                 </div>
               </div>
               
-              <!-- 边详情 -->
+              <!-- Edge details -->
               <div v-else class="detail-content">
-                <!-- 关系展示 -->
+                <!-- Relationship display -->
                 <div class="edge-relation">
                   <span class="edge-source">{{ selectedItem.data.source_name || selectedItem.data.source_node_name }}</span>
                   <span class="edge-arrow">→</span>
@@ -164,17 +164,17 @@
             </div>
           </div>
           
-          <!-- 加载状态 -->
+          <!-- Loading state -->
           <div v-else-if="graphLoading" class="graph-loading">
             <div class="loading-animation">
               <div class="loading-ring"></div>
               <div class="loading-ring"></div>
               <div class="loading-ring"></div>
             </div>
-            <p class="loading-text">图谱数据加载中...</p>
+            <p class="loading-text">Loading graph data...</p>
           </div>
-          
-          <!-- 等待构建 -->
+
+          <!-- Awaiting build -->
           <div v-else-if="currentPhase < 1" class="graph-waiting">
             <div class="waiting-icon">
               <svg viewBox="0 0 100 100" class="network-icon">
@@ -189,29 +189,29 @@
                 <line x1="50" y1="72" x2="74" y2="66" stroke="#000" stroke-width="1"/>
               </svg>
             </div>
-            <p class="waiting-text">等待本体生成</p>
-            <p class="waiting-hint">生成完成后将自动开始构建图谱</p>
+            <p class="waiting-text">Waiting for ontology generation</p>
+            <p class="waiting-hint">Graph build will start automatically once generation completes</p>
           </div>
-          
-          <!-- 构建中但还没有数据 -->
+
+          <!-- Building, but no data yet -->
           <div v-else-if="currentPhase === 1 && !graphData" class="graph-waiting">
             <div class="loading-animation">
               <div class="loading-ring"></div>
               <div class="loading-ring"></div>
               <div class="loading-ring"></div>
             </div>
-            <p class="waiting-text">图谱构建中</p>
-            <p class="waiting-hint">数据即将显示...</p>
+            <p class="waiting-text">Building graph</p>
+            <p class="waiting-hint">Data will appear shortly...</p>
           </div>
-          
-          <!-- 错误状态 -->
+
+          <!-- Error state -->
           <div v-else-if="error" class="graph-error">
             <span class="error-icon">⚠</span>
             <p>{{ error }}</p>
           </div>
         </div>
         
-        <!-- 图谱图例 -->
+        <!-- Graph legend -->
         <div v-if="graphData" class="graph-legend">
           <div class="legend-item" v-for="type in entityTypes" :key="type.name">
             <span class="legend-dot" :style="{ background: type.color }"></span>
@@ -221,20 +221,20 @@
         </div>
       </div>
 
-      <!-- 右侧: 构建流程详情 -->
+      <!-- Right side: build pipeline details -->
       <div class="right-panel" :class="{ 'hidden': isFullScreen }">
         <div class="panel-header dark-header">
           <span class="header-icon">▣</span>
-          <span class="header-title">构建流程</span>
+          <span class="header-title">Build Pipeline</span>
         </div>
 
         <div class="process-content">
-          <!-- 阶段1: 本体生成 -->
+          <!-- Phase 1: Ontology Generation -->
           <div class="process-phase" :class="{ 'active': currentPhase === 0, 'completed': currentPhase > 0 }">
             <div class="phase-header">
               <span class="phase-num">01</span>
               <div class="phase-info">
-                <div class="phase-title">本体生成</div>
+                <div class="phase-title">Ontology Generation</div>
                 <div class="phase-api">/api/graph/ontology/generate</div>
               </div>
               <span class="phase-status" :class="getPhaseStatusClass(0)">
@@ -244,24 +244,24 @@
             
             <div class="phase-detail">
               <div class="detail-section">
-                <div class="detail-label">接口说明</div>
+                <div class="detail-label">Endpoint description</div>
                 <div class="detail-content">
-                  上传文档后，LLM分析文档内容，自动生成适合舆论模拟的本体结构（实体类型 + 关系类型）
+                  After documents are uploaded, the LLM analyzes their content and automatically generates an ontology (entity types + relation types) suitable for opinion simulation.
                 </div>
               </div>
-              
-              <!-- 本体生成进度 -->
+
+              <!-- Ontology generation progress -->
               <div class="detail-section" v-if="ontologyProgress && currentPhase === 0">
-                <div class="detail-label">生成进度</div>
+                <div class="detail-label">Generation progress</div>
                 <div class="ontology-progress">
                   <div class="progress-spinner"></div>
                   <span class="progress-text">{{ ontologyProgress.message }}</span>
                 </div>
               </div>
               
-              <!-- 已生成的本体信息 -->
+              <!-- Generated ontology information -->
               <div class="detail-section" v-if="projectData?.ontology">
-                <div class="detail-label">生成的实体类型 ({{ projectData.ontology.entity_types?.length || 0 }})</div>
+                <div class="detail-label">Generated entity types ({{ projectData.ontology.entity_types?.length || 0 }})</div>
                 <div class="entity-tags">
                   <span 
                     v-for="entity in projectData.ontology.entity_types" 
@@ -274,7 +274,7 @@
               </div>
               
               <div class="detail-section" v-if="projectData?.ontology">
-                <div class="detail-label">生成的关系类型 ({{ projectData.ontology.relation_types?.length || 0 }})</div>
+                <div class="detail-label">Generated relation types ({{ projectData.ontology.relation_types?.length || 0 }})</div>
                 <div class="relation-list">
                   <div 
                     v-for="(rel, idx) in projectData.ontology.relation_types?.slice(0, 5) || []" 
@@ -288,24 +288,24 @@
                     <span class="rel-target">{{ rel.target_type }}</span>
                   </div>
                   <div v-if="(projectData.ontology.relation_types?.length || 0) > 5" class="relation-more">
-                    +{{ projectData.ontology.relation_types.length - 5 }} 更多关系...
+                    +{{ projectData.ontology.relation_types.length - 5 }} more relations...
                   </div>
                 </div>
               </div>
-              
-              <!-- 等待状态 -->
+
+              <!-- Waiting state -->
               <div class="detail-section waiting-state" v-if="!projectData?.ontology && currentPhase === 0 && !ontologyProgress">
-                <div class="waiting-hint">等待本体生成...</div>
+                <div class="waiting-hint">Waiting for ontology generation...</div>
               </div>
             </div>
           </div>
 
-          <!-- 阶段2: 图谱构建 -->
+          <!-- Phase 2: Graph Build -->
           <div class="process-phase" :class="{ 'active': currentPhase === 1, 'completed': currentPhase > 1 }">
             <div class="phase-header">
               <span class="phase-num">02</span>
               <div class="phase-info">
-                <div class="phase-title">图谱构建</div>
+                <div class="phase-title">Graph Build</div>
                 <div class="phase-api">/api/graph/build</div>
               </div>
               <span class="phase-status" :class="getPhaseStatusClass(1)">
@@ -315,20 +315,20 @@
             
             <div class="phase-detail">
               <div class="detail-section">
-                <div class="detail-label">接口说明</div>
+                <div class="detail-label">Endpoint description</div>
                 <div class="detail-content">
-                  基于生成的本体，将文档分块后调用 Zep API 构建知识图谱，提取实体和关系
+                  Based on the generated ontology, documents are chunked and the Zep API is called to build the knowledge graph and extract entities and relations.
                 </div>
               </div>
-              
-              <!-- 等待本体完成 -->
+
+              <!-- Waiting for ontology to finish -->
               <div class="detail-section waiting-state" v-if="currentPhase < 1">
-                <div class="waiting-hint">等待本体生成完成...</div>
+                <div class="waiting-hint">Waiting for ontology generation to finish...</div>
               </div>
-              
-              <!-- 构建进度 -->
+
+              <!-- Build progress -->
               <div class="detail-section" v-if="buildProgress && currentPhase >= 1">
-                <div class="detail-label">构建进度</div>
+                <div class="detail-label">Build progress</div>
                 <div class="progress-bar">
                   <div class="progress-fill" :style="{ width: buildProgress.progress + '%' }"></div>
                 </div>
@@ -339,32 +339,32 @@
               </div>
               
               <div class="detail-section" v-if="graphData">
-                <div class="detail-label">构建结果</div>
+                <div class="detail-label">Build results</div>
                 <div class="build-result">
                   <div class="result-item">
                     <span class="result-value">{{ graphData.node_count }}</span>
-                    <span class="result-label">实体节点</span>
+                    <span class="result-label">Entity Nodes</span>
                   </div>
                   <div class="result-item">
                     <span class="result-value">{{ graphData.edge_count }}</span>
-                    <span class="result-label">关系边</span>
+                    <span class="result-label">Relation Edges</span>
                   </div>
                   <div class="result-item">
                     <span class="result-value">{{ entityTypes.length }}</span>
-                    <span class="result-label">实体类型</span>
+                    <span class="result-label">Entity Types</span>
                   </div>
                 </div>
               </div>
             </div>
           </div>
 
-          <!-- 阶段3: 完成 -->
+          <!-- Phase 3: Complete -->
           <div class="process-phase" :class="{ 'active': currentPhase === 2, 'completed': currentPhase > 2 }">
             <div class="phase-header">
               <span class="phase-num">03</span>
               <div class="phase-info">
-                <div class="phase-title">构建完成</div>
-                <div class="phase-api">准备进入下一步骤</div>
+                <div class="phase-title">Build Complete</div>
+                <div class="phase-api">Ready to proceed to the next step</div>
               </div>
               <span class="phase-status" :class="getPhaseStatusClass(2)">
                 {{ getPhaseStatusText(2) }}
@@ -372,36 +372,36 @@
             </div>
           </div>
 
-          <!-- 下一步按钮 -->
+          <!-- Next-step button -->
           <div class="next-step-section" v-if="currentPhase >= 2">
             <button class="next-step-btn" @click="goToNextStep" :disabled="currentPhase < 2">
-              进入环境搭建
+              Enter Environment Setup
               <span class="btn-arrow">→</span>
             </button>
           </div>
         </div>
 
-        <!-- 项目信息面板 -->
+        <!-- Project info panel -->
         <div class="project-panel">
           <div class="project-header">
             <span class="project-icon">◇</span>
-            <span class="project-title">项目信息</span>
+            <span class="project-title">Project Information</span>
           </div>
           <div class="project-details" v-if="projectData">
             <div class="project-item">
-              <span class="item-label">项目名称</span>
+              <span class="item-label">Project Name</span>
               <span class="item-value">{{ projectData.name }}</span>
             </div>
             <div class="project-item">
-              <span class="item-label">项目ID</span>
+              <span class="item-label">Project ID</span>
               <span class="item-value code">{{ projectData.project_id }}</span>
             </div>
             <div class="project-item" v-if="projectData.graph_id">
-              <span class="item-label">图谱ID</span>
+              <span class="item-label">Graph ID</span>
               <span class="item-value code">{{ projectData.graph_id }}</span>
             </div>
             <div class="project-item">
-              <span class="item-label">模拟需求</span>
+              <span class="item-label">Simulation Requirement</span>
               <span class="item-value">{{ projectData.simulation_requirement || '-' }}</span>
             </div>
           </div>
@@ -421,29 +421,29 @@ import * as d3 from 'd3'
 const route = useRoute()
 const router = useRouter()
 
-// 当前项目ID（可能从'new'变为实际ID）
+// Current project ID (may transition from 'new' to the real ID)
 const currentProjectId = ref(route.params.projectId)
 
-// 状态
+// State
 const loading = ref(true)
 const graphLoading = ref(false)
 const error = ref('')
 const projectData = ref(null)
 const graphData = ref(null)
 const buildProgress = ref(null)
-const ontologyProgress = ref(null) // 本体生成进度
-const currentPhase = ref(-1) // -1: 上传中, 0: 本体生成中, 1: 图谱构建, 2: 完成
-const selectedItem = ref(null) // 选中的节点或边
+const ontologyProgress = ref(null) // Ontology generation progress
+const currentPhase = ref(-1) // -1: uploading, 0: generating ontology, 1: building graph, 2: complete
+const selectedItem = ref(null) // Currently selected node or edge
 const isFullScreen = ref(false)
 
-// DOM引用
+// DOM refs
 const graphContainer = ref(null)
 const graphSvg = ref(null)
 
-// 轮询定时器
+// Polling timer
 let pollTimer = null
 
-// 计算属性
+// Computed properties
 const statusClass = computed(() => {
   if (error.value) return 'error'
   if (currentPhase.value >= 2) return 'completed'
@@ -451,11 +451,11 @@ const statusClass = computed(() => {
 })
 
 const statusText = computed(() => {
-  if (error.value) return '构建失败'
-  if (currentPhase.value >= 2) return '构建完成'
-  if (currentPhase.value === 1) return '图谱构建中'
-  if (currentPhase.value === 0) return '本体生成中'
-  return '初始化中'
+  if (error.value) return 'Build failed'
+  if (currentPhase.value >= 2) return 'Build complete'
+  if (currentPhase.value === 1) return 'Building graph'
+  if (currentPhase.value === 0) return 'Generating ontology'
+  return 'Initializing'
 })
 
 const entityTypes = computed(() => {
@@ -475,14 +475,14 @@ const entityTypes = computed(() => {
   return Object.values(typeMap)
 })
 
-// 方法
+// Methods
 const goHome = () => {
   router.push('/')
 }
 
 const goToNextStep = () => {
-  // TODO: 进入环境搭建步骤
-  alert('环境搭建功能开发中...')
+  // TODO: enter the environment-setup step
+  alert('Environment setup feature is under development...')
 }
 
 const toggleFullScreen = () => {
@@ -493,17 +493,17 @@ const toggleFullScreen = () => {
   }, 350) 
 }
 
-// 关闭详情面板
+// Close the detail panel
 const closeDetailPanel = () => {
   selectedItem.value = null
 }
 
-// 格式化日期
+// Format a date
 const formatDate = (dateStr) => {
   if (!dateStr) return '-'
   try {
     const date = new Date(dateStr)
-    return date.toLocaleString('zh-CN', {
+    return date.toLocaleString('en-US', {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
@@ -515,7 +515,7 @@ const formatDate = (dateStr) => {
   }
 }
 
-// 选中节点
+// Select a node
 const selectNode = (nodeData, color) => {
   selectedItem.value = {
     type: 'node',
@@ -525,7 +525,7 @@ const selectNode = (nodeData, color) => {
   }
 }
 
-// 选中边
+// Select an edge
 const selectEdge = (edgeData) => {
   selectedItem.value = {
     type: 'edge',
@@ -540,116 +540,116 @@ const getPhaseStatusClass = (phase) => {
 }
 
 const getPhaseStatusText = (phase) => {
-  if (currentPhase.value > phase) return '已完成'
+  if (currentPhase.value > phase) return 'Completed'
   if (currentPhase.value === phase) {
     if (phase === 1 && buildProgress.value) {
       return `${buildProgress.value.progress}%`
     }
-    return '进行中'
+    return 'In progress'
   }
-  return '等待中'
+  return 'Pending'
 }
 
-// 初始化 - 处理新建项目或加载已有项目
+// Initialize - either create a new project or load an existing one
 const initProject = async () => {
   const paramProjectId = route.params.projectId
-  
+
   if (paramProjectId === 'new') {
-    // 新建项目：从 store 获取待上传的数据
+    // New project: pull pending upload data from the store
     await handleNewProject()
   } else {
-    // 加载已有项目
+    // Load an existing project
     currentProjectId.value = paramProjectId
     await loadProject()
   }
 }
 
-// 处理新建项目 - 调用 ontology/generate API
+// Handle new project - call the ontology/generate API
 const handleNewProject = async () => {
   const pending = getPendingUpload()
-  
+
   if (!pending.isPending || pending.files.length === 0) {
-    error.value = '没有待上传的文件，请返回首页重新操作'
+    error.value = 'No pending files to upload — please go back to the home page and try again.'
     loading.value = false
     return
   }
-  
+
   try {
     loading.value = true
-    currentPhase.value = 0 // 本体生成阶段
-    ontologyProgress.value = { message: '正在上传文件并分析文档...' }
-    
-    // 构建 FormData
+    currentPhase.value = 0 // Ontology generation phase
+    ontologyProgress.value = { message: 'Uploading files and analyzing documents...' }
+
+    // Build FormData
     const formDataObj = new FormData()
     pending.files.forEach(file => {
       formDataObj.append('files', file)
     })
     formDataObj.append('simulation_requirement', pending.simulationRequirement)
-    
-    // 调用本体生成 API
+
+    // Call the ontology generation API
     const response = await generateOntology(formDataObj)
-    
+
     if (response.success) {
-      // 清除待上传数据
+      // Clear pending upload data
       clearPendingUpload()
-      
-      // 更新项目ID和数据
+
+      // Update project ID and data
       currentProjectId.value = response.data.project_id
       projectData.value = response.data
-      
-      // 更新URL（不刷新页面）
+
+      // Update the URL (without a page refresh)
       router.replace({
         name: 'Process',
         params: { projectId: response.data.project_id }
       })
-      
+
       ontologyProgress.value = null
-      
-      // 自动开始图谱构建
+
+      // Automatically start graph building
       await startBuildGraph()
     } else {
-      error.value = response.error || '本体生成失败'
+      error.value = response.error || 'Ontology generation failed'
     }
   } catch (err) {
     console.error('Handle new project error:', err)
-    error.value = '项目初始化失败: ' + (err.message || '未知错误')
+    error.value = 'Project initialization failed: ' + (err.message || 'Unknown error')
   } finally {
     loading.value = false
   }
 }
 
-// 加载已有项目数据
+// Load existing project data
 const loadProject = async () => {
   try {
     loading.value = true
     const response = await getProject(currentProjectId.value)
-    
+
     if (response.success) {
       projectData.value = response.data
       updatePhaseByStatus(response.data.status)
-      
-      // 自动开始图谱构建
+
+      // Automatically start graph building
       if (response.data.status === 'ontology_generated' && !response.data.graph_id) {
         await startBuildGraph()
       }
-      
-      // 继续轮询构建中的任务
+
+      // Continue polling an in-progress build
       if (response.data.status === 'graph_building' && response.data.graph_build_task_id) {
         currentPhase.value = 1
         startPollingTask(response.data.graph_build_task_id)
       }
-      
-      // 加载已完成的图谱
+
+      // Load a completed graph
       if (response.data.status === 'graph_completed' && response.data.graph_id) {
         currentPhase.value = 2
         await loadGraph(response.data.graph_id)
       }
     } else {
-      error.value = response.error || '加载项目失败'
+      error.value = response.error || 'Failed to load project'
     }
   } catch (err) {
     console.error('Load project error:', err)
-    error.value = '加载项目失败: ' + (err.message || '未知错误')
+    error.value = 'Failed to load project: ' + (err.message || 'Unknown error')
   } finally {
     loading.value = false
   }
@@ -668,67 +668,67 @@ const updatePhaseByStatus = (status) => {
       currentPhase.value = 2
       break
     case 'failed':
-      error.value = projectData.value?.error || '处理失败'
+      error.value = projectData.value?.error || 'Processing failed'
       break
   }
 }
 
-// 开始构建图谱
+// Start the graph build
 const startBuildGraph = async () => {
   try {
     currentPhase.value = 1
-    // 设置初始进度
+    // Set initial progress
     buildProgress.value = {
       progress: 0,
-      message: '正在启动图谱构建...'
+      message: 'Starting graph build...'
     }
-    
+
     const response = await buildGraph({ project_id: currentProjectId.value })
-    
+
     if (response.success) {
-      buildProgress.value.message = '图谱构建任务已启动...'
-      
-      // 保存 task_id 用于轮询
+      buildProgress.value.message = 'Graph build task started...'
+
+      // Save task_id for polling
       const taskId = response.data.task_id
-      
-      // 启动图谱数据轮询（独立于任务状态轮询）
+
+      // Start polling graph data (independent of task-status polling)
       startGraphPolling()
-      
-      // 启动任务状态轮询
+
+      // Start task-status polling
       startPollingTask(taskId)
     } else {
-      error.value = response.error || '启动图谱构建失败'
+      error.value = response.error || 'Failed to start graph build'
       buildProgress.value = null
     }
   } catch (err) {
     console.error('Build graph error:', err)
-    error.value = '启动图谱构建失败: ' + (err.message || '未知错误')
+    error.value = 'Failed to start graph build: ' + (err.message || 'Unknown error')
     buildProgress.value = null
   }
 }
 
-// 图谱数据轮询定时器
+// Graph-data polling timer
 let graphPollTimer = null
 
-// 启动图谱数据轮询
+// Start polling graph data
 const startGraphPolling = () => {
-  // 立即获取一次
+  // Fetch immediately once
   fetchGraphData()
-  
-  // 每 10 秒自动获取一次图谱数据
+
+  // Then auto-fetch graph data every 10 seconds
   graphPollTimer = setInterval(async () => {
     await fetchGraphData()
   }, 10000)
 }
 
-// 手动刷新图谱
+// Manually refresh the graph
 const refreshGraph = async () => {
   graphLoading.value = true
   await fetchGraphData()
   graphLoading.value = false
 }
 
-// 停止图谱数据轮询
+// Stop polling graph data
 const stopGraphPolling = () => {
   if (graphPollTimer) {
     clearInterval(graphPollTimer)
@@ -736,27 +736,27 @@ const stopGraphPolling = () => {
   }
 }
 
-// 获取图谱数据
+// Fetch graph data
 const fetchGraphData = async () => {
   try {
-    // 先获取项目信息以获取 graph_id
+    // First fetch project info to obtain graph_id
     const projectResponse = await getProject(currentProjectId.value)
-    
+
     if (projectResponse.success && projectResponse.data.graph_id) {
       const graphId = projectResponse.data.graph_id
       projectData.value = projectResponse.data
-      
-      // 获取图谱数据
+
+      // Fetch graph data
       const graphResponse = await getGraphData(graphId)
-      
+
       if (graphResponse.success && graphResponse.data) {
         const newData = graphResponse.data
         const newNodeCount = newData.node_count || newData.nodes?.length || 0
         const oldNodeCount = graphData.value?.node_count || graphData.value?.nodes?.length || 0
-        
+
         console.log('Fetching graph data, nodes:', newNodeCount, 'edges:', newData.edge_count || newData.edges?.length || 0)
-        
-        // 数据有变化时更新渲染
+
+        // Re-render when the data has changed
         if (newNodeCount !== oldNodeCount || !graphData.value) {
           graphData.value = newData
           await nextTick()
@@ -769,65 +769,65 @@ const fetchGraphData = async () => {
   }
 }
 
-// 轮询任务状态
+// Poll task status
 const startPollingTask = (taskId) => {
-  // 立即执行一次查询
+  // Run an initial query immediately
   pollTaskStatus(taskId)
-  
-  // 然后定时轮询
+
+  // Then poll on a timer
   pollTimer = setInterval(() => {
     pollTaskStatus(taskId)
   }, 2000)
 }
 
-// 查询任务状态
+// Query task status
 const pollTaskStatus = async (taskId) => {
   try {
     const response = await getTaskStatus(taskId)
-    
+
     if (response.success) {
       const task = response.data
-      
-      // 更新进度显示
+
+      // Update the progress display
       buildProgress.value = {
         progress: task.progress || 0,
-        message: task.message || '处理中...'
+        message: task.message || 'Processing...'
       }
-      
+
       console.log('Task status:', task.status, 'Progress:', task.progress)
-      
+
       if (task.status === 'completed') {
-        console.log('✅ 图谱构建完成，正在加载完整数据...')
-        
+        console.log('Graph build complete, loading full data...')
+
         stopPolling()
         stopGraphPolling()
         currentPhase.value = 2
-        
-        // 更新进度显示为完成状态
+
+        // Update the progress display to a completed state
         buildProgress.value = {
           progress: 100,
-          message: '构建完成，正在加载图谱...'
+          message: 'Build complete, loading graph...'
         }
-        
-        // 重新加载项目数据获取 graph_id
+
+        // Reload project data to obtain graph_id
         const projectResponse = await getProject(currentProjectId.value)
         if (projectResponse.success) {
           projectData.value = projectResponse.data
-          
-          // 最终加载完整图谱数据
+
+          // Final load of the full graph data
           if (projectResponse.data.graph_id) {
-            console.log('📊 加载完整图谱:', projectResponse.data.graph_id)
+            console.log('Loading full graph:', projectResponse.data.graph_id)
             await loadGraph(projectResponse.data.graph_id)
-            console.log('✅ 图谱加载完成')
+            console.log('Graph loaded successfully')
           }
         }
-        
-        // 清除进度显示
+
+        // Clear the progress display
         buildProgress.value = null
       } else if (task.status === 'failed') {
         stopPolling()
         stopGraphPolling()
-        error.value = '图谱构建失败: ' + (task.error || '未知错误')
+        error.value = 'Graph build failed: ' + (task.error || 'Unknown error')
         buildProgress.value = null
       }
     }
@@ -843,7 +843,7 @@ const stopPolling = () => {
   }
 }
 
-// 加载图谱数据
+// Load graph data
 const loadGraph = async (graphId) => {
   try {
     graphLoading.value = true
@@ -861,7 +861,7 @@ const loadGraph = async (graphId) => {
   }
 }
 
-// 渲染图谱 (D3.js)
+// Render the graph (D3.js)
 const renderGraph = () => {
   if (!graphSvg.value || !graphData.value) {
     console.log('Cannot render: svg or data missing')
@@ -874,7 +874,7 @@ const renderGraph = () => {
     return
   }
   
-  // 获取容器尺寸
+  // Get container dimensions
   const rect = container.getBoundingClientRect()
   const width = rect.width || 800
   const height = (rect.height || 600) - 60
@@ -893,23 +893,23 @@ const renderGraph = () => {
   
   svg.selectAll('*').remove()
   
-  // 处理节点数据
+  // Process node data
   const nodesData = graphData.value.nodes || []
   const edgesData = graphData.value.edges || []
   
   if (nodesData.length === 0) {
     console.log('No nodes to render')
-    // 显示空状态
+    // Show empty state
     svg.append('text')
       .attr('x', width / 2)
       .attr('y', height / 2)
       .attr('text-anchor', 'middle')
       .attr('fill', '#999')
-      .text('等待图谱数据...')
+      .text('Waiting for graph data...')
     return
   }
   
-  // 创建节点映射用于查找名称
+  // Build a node lookup map by uuid
   const nodeMap = {}
   nodesData.forEach(n => {
     nodeMap[n.uuid] = n
@@ -917,12 +917,12 @@ const renderGraph = () => {
   
   const nodes = nodesData.map(n => ({
     id: n.uuid,
-    name: n.name || '未命名',
+    name: n.name || 'Unnamed',
     type: n.labels?.find(l => l !== 'Entity' && l !== 'Node') || 'Entity',
-    rawData: n // 保存原始数据
+    rawData: n // keep the raw data
   }))
-  
-  // 创建节点ID集合用于过滤有效边
+
+  // Build a Set of node IDs to filter valid edges
   const nodeIds = new Set(nodes.map(n => n.id))
   
   const edges = edgesData
@@ -933,20 +933,20 @@ const renderGraph = () => {
       type: e.fact_type || e.name || 'RELATED_TO',
       rawData: {
         ...e,
-        source_name: nodeMap[e.source_node_uuid]?.name || '未知',
-        target_name: nodeMap[e.target_node_uuid]?.name || '未知'
+        source_name: nodeMap[e.source_node_uuid]?.name || 'Unknown',
+        target_name: nodeMap[e.target_node_uuid]?.name || 'Unknown'
       }
     }))
   
   console.log('Nodes:', nodes.length, 'Edges:', edges.length)
   
-  // 颜色映射
+  // Color scale
   const types = [...new Set(nodes.map(n => n.type))]
   const colorScale = d3.scaleOrdinal()
     .domain(types)
     .range(['#FF6B35', '#004E89', '#7B2D8E', '#1A936F', '#C5283D', '#E9724C', '#2D3436', '#6C5CE7'])
   
-  // 力导向布局
+  // Force-directed layout
   const simulation = d3.forceSimulation(nodes)
     .force('link', d3.forceLink(edges).id(d => d.id).distance(100).strength(0.5))
     .force('charge', d3.forceManyBody().strength(-300))
@@ -955,7 +955,7 @@ const renderGraph = () => {
     .force('x', d3.forceX(width / 2).strength(0.05))
     .force('y', d3.forceY(height / 2).strength(0.05))
   
-  // 添加缩放功能
+  // Add zoom support
   const g = svg.append('g')
   
   svg.call(d3.zoom()
@@ -965,7 +965,7 @@ const renderGraph = () => {
       g.attr('transform', event.transform)
     }))
   
-  // 绘制边（包含可点击的透明宽线）
+  // Draw edges (with clickable transparent wide overlay)
   const linkGroup = g.append('g')
     .attr('class', 'links')
     .selectAll('g')
@@ -978,18 +978,18 @@ const renderGraph = () => {
       selectEdge(d.rawData)
     })
   
-  // 可见的细线
+  // Visible thin line
   const link = linkGroup.append('line')
     .attr('stroke', '#ccc')
     .attr('stroke-width', 1.5)
     .attr('stroke-opacity', 0.6)
   
-  // 透明的宽线用于点击
+  // Transparent wide line for click hit-testing
   linkGroup.append('line')
     .attr('stroke', 'transparent')
     .attr('stroke-width', 10)
   
-  // 边标签
+  // Edge labels
   const linkLabel = g.append('g')
     .attr('class', 'link-labels')
     .selectAll('text')
@@ -1001,7 +1001,7 @@ const renderGraph = () => {
     .attr('text-anchor', 'middle')
     .text(d => d.type.length > 15 ? d.type.substring(0, 12) + '...' : d.type)
   
-  // 绘制节点
+  // Draw nodes
   const node = g.append('g')
     .attr('class', 'nodes')
     .selectAll('g')
@@ -1033,20 +1033,20 @@ const renderGraph = () => {
     .attr('fill', '#333')
     .attr('font-family', 'JetBrains Mono, monospace')
   
-  // 点击空白处关闭详情面板
+  // Click on empty space closes the detail panel
   svg.on('click', () => {
     closeDetailPanel()
   })
   
   simulation.on('tick', () => {
-    // 更新所有边的位置（包括可见线和透明点击区域）
+    // Update positions of all edges (visible line and transparent click area)
     linkGroup.selectAll('line')
       .attr('x1', d => d.source.x)
       .attr('y1', d => d.source.y)
       .attr('x2', d => d.target.x)
       .attr('y2', d => d.target.y)
     
-    // 更新边标签位置
+    // Update edge label positions
     linkLabel
       .attr('x', d => (d.source.x + d.target.x) / 2)
       .attr('y', d => (d.source.y + d.target.y) / 2 - 5)
@@ -1072,14 +1072,14 @@ const renderGraph = () => {
   }
 }
 
-// 监听图谱数据变化
+// Watch for graph data changes
 watch(graphData, () => {
   if (graphData.value) {
     nextTick(() => renderGraph())
   }
 })
 
-// 生命周期
+// Lifecycle
 onMounted(() => {
   initProject()
 })
@@ -1091,7 +1091,7 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-/* 变量 */
+/* Variables */
 :root {
   --black: #000000;
   --white: #FFFFFF;
@@ -1108,7 +1108,7 @@ onUnmounted(() => {
   overflow: hidden; /* Prevent body scroll in fullscreen */
 }
 
-/* 导航栏 */
+/* Navigation bar */
 .navbar {
   display: flex;
   align-items: center;
@@ -1194,14 +1194,14 @@ onUnmounted(() => {
   color: #999;
 }
 
-/* 主内容区 */
+/* Main content area */
 .main-content {
   display: flex;
   height: calc(100vh - 56px);
   position: relative;
 }
 
-/* 左侧面板 - 50% default */
+/* Left panel - 50% default */
 .left-panel {
   width: 50%;
   flex: none; /* Fixed width initially */
@@ -1311,7 +1311,7 @@ onUnmounted(() => {
   to { transform: rotate(360deg); }
 }
 
-/* 图谱容器 */
+/* Graph container */
 .graph-container {
   flex: 1;
   position: relative;
@@ -1427,7 +1427,7 @@ onUnmounted(() => {
   animation: pulse 1s infinite;
 }
 
-/* 节点/边详情面板 */
+/* Node/edge detail panel */
 .detail-panel {
   position: absolute;
   top: 16px;
@@ -1543,7 +1543,7 @@ onUnmounted(() => {
   color: #666;
 }
 
-/* 边详情关系展示 */
+/* Edge detail relationship display */
 .edge-relation {
   display: flex;
   align-items: center;
@@ -1587,7 +1587,7 @@ onUnmounted(() => {
   border-bottom: 1px solid #E0E0E0;
 }
 
-/* Properties 属性列表 */
+/* Properties list */
 .properties-list {
   margin-top: 8px;
   padding: 10px;
@@ -1616,7 +1616,7 @@ onUnmounted(() => {
   word-break: break-word;
 }
 
-/* Episodes 列表 */
+/* Episodes list */
 .episodes-list {
   margin-top: 8px;
   display: flex;
@@ -1641,7 +1641,7 @@ onUnmounted(() => {
   margin-bottom: 10px;
 }
 
-/* 图谱图例 */
+/* Graph legend */
 .graph-legend {
   display: flex;
   flex-wrap: wrap;
@@ -1672,7 +1672,7 @@ onUnmounted(() => {
   color: #999;
 }
 
-/* 右侧面板 - 50% default */
+/* Right panel - 50% default */
 .right-panel {
   width: 50%;
   flex: none;
@@ -1702,14 +1702,14 @@ onUnmounted(() => {
   margin-right: 8px;
 }
 
-/* 流程内容 */
+/* Pipeline content */
 .process-content {
   flex: 1;
   overflow-y: auto;
   padding: 24px;
 }
 
-/* 流程阶段 */
+/* Pipeline phase */
 .process-phase {
   margin-bottom: 24px;
   border: 1px solid #E0E0E0;
@@ -1795,12 +1795,12 @@ onUnmounted(() => {
   color: #fff;
 }
 
-/* 阶段详情 */
+/* Phase detail */
 .phase-detail {
   padding: 16px;
 }
 
-/* 实体标签 */
+/* Entity tags */
 .entity-tags {
   display: flex;
   flex-wrap: wrap;
@@ -1815,7 +1815,7 @@ onUnmounted(() => {
   color: #333;
 }
 
-/* 关系列表 */
+/* Relation list */
 .relation-list {
   font-size: 0.8rem;
 }
@@ -1852,7 +1852,7 @@ onUnmounted(() => {
   font-size: 0.75rem;
 }
 
-/* 本体生成进度 */
+/* Ontology generation progress */
 .ontology-progress {
   display: flex;
   align-items: center;
@@ -1876,7 +1876,7 @@ onUnmounted(() => {
   color: #333;
 }
 
-/* 等待状态 */
+/* Waiting state */
 .waiting-state {
   padding: 16px;
   background: #F9F9F9;
@@ -1889,7 +1889,7 @@ onUnmounted(() => {
   color: #999;
 }
 
-/* 进度条 */
+/* Progress bar */
 .progress-bar {
   height: 6px;
   background: #E0E0E0;
@@ -1918,7 +1918,7 @@ onUnmounted(() => {
   font-weight: 600;
 }
 
-/* 构建结果 */
+/* Build results */
 .build-result {
   display: flex;
   gap: 16px;
@@ -1946,7 +1946,7 @@ onUnmounted(() => {
   letter-spacing: 0.05em;
 }
 
-/* 下一步按钮 */
+/* Next-step button */
 .next-step-section {
   margin-top: 24px;
   padding-top: 24px;
@@ -1983,7 +1983,7 @@ onUnmounted(() => {
   font-size: 1.2rem;
 }
 
-/* 项目信息面板 */
+/* Project info panel */
 .project-panel {
   border-top: 1px solid #E0E0E0;
   background: #FAFAFA;
@@ -2041,7 +2041,7 @@ onUnmounted(() => {
   color: #666;
 }
 
-/* 响应式 */
+/* Responsive */
 @media (max-width: 1024px) {
   .main-content {
     flex-direction: column;

--- a/frontend/src/views/ReportView.vue
+++ b/frontend/src/views/ReportView.vue
@@ -49,7 +49,7 @@
         />
       </div>
 
-      <!-- Right Panel: Step4 报告生成 -->
+      <!-- Right Panel: Step4 Report Generation -->
       <div class="panel-wrapper right" :style="rightPanelStyle">
         <Step4Report
           :reportId="currentReportId"
@@ -83,7 +83,7 @@ const props = defineProps({
   reportId: String
 })
 
-// Layout State - 默认切换到工作台视角
+// Layout State - default to the workbench view
 const viewMode = ref('workbench')
 
 // Data State
@@ -146,26 +146,26 @@ const loadReportData = async () => {
   try {
     addLog(t('log.loadReportData', { id: currentReportId.value }))
 
-    // 获取 report 信息以获取 simulation_id
+    // Fetch report info to obtain simulation_id
     const reportRes = await getReport(currentReportId.value)
     if (reportRes.success && reportRes.data) {
       const reportData = reportRes.data
       simulationId.value = reportData.simulation_id
 
       if (simulationId.value) {
-        // 获取 simulation 信息
+        // Fetch simulation info
         const simRes = await getSimulation(simulationId.value)
         if (simRes.success && simRes.data) {
           const simData = simRes.data
 
-          // 获取 project 信息
+          // Fetch project info
           if (simData.project_id) {
             const projRes = await getProject(simData.project_id)
             if (projRes.success && projRes.data) {
               projectData.value = projRes.data
               addLog(t('log.projectLoadSuccess', { id: projRes.data.project_id }))
 
-              // 获取 graph 数据
+              // Fetch graph data
               if (projRes.data.graph_id) {
                 await loadGraph(projRes.data.graph_id)
               }

--- a/frontend/src/views/SimulationRunView.vue
+++ b/frontend/src/views/SimulationRunView.vue
@@ -49,7 +49,7 @@
         />
       </div>
 
-      <!-- Right Panel: Step3 开始模拟 -->
+      <!-- Right Panel: Step3 Start Simulation -->
       <div class="panel-wrapper right" :style="rightPanelStyle">
         <Step3Simulation
           :simulationId="currentSimulationId"
@@ -92,9 +92,9 @@ const viewMode = ref('split')
 
 // Data State
 const currentSimulationId = ref(route.params.simulationId)
-// 直接在初始化时从 query 参数获取 maxRounds，确保子组件能立即获取到值
+// Read maxRounds from the query parameter at init time so child components can receive it immediately
 const maxRounds = ref(route.query.maxRounds ? parseInt(route.query.maxRounds) : null)
-const minutesPerRound = ref(30) // 默认每轮30分钟
+const minutesPerRound = ref(30) // Default of 30 minutes per round
 const projectData = ref(null)
 const graphData = ref(null)
 const graphLoading = ref(false)
@@ -150,14 +150,14 @@ const toggleMaximize = (target) => {
 }
 
 const handleGoBack = async () => {
-  // 在返回 Step 2 之前，先关闭正在运行的模拟
+  // Before going back to Step 2, close the running simulation first
   addLog(t('log.preparingGoBack'))
-  
-  // 停止轮询
+
+  // Stop polling
   stopGraphRefresh()
-  
+
   try {
-    // 先尝试优雅关闭模拟环境
+    // First, attempt to gracefully close the simulation environment
     const envStatusRes = await getEnvStatus({ simulation_id: currentSimulationId.value })
     
     if (envStatusRes.success && envStatusRes.data?.env_alive) {
@@ -178,7 +178,7 @@ const handleGoBack = async () => {
         }
       }
     } else {
-      // 环境未运行，检查是否需要停止进程
+      // Environment is not running; check whether the process still needs to be stopped
       if (isSimulating.value) {
         addLog(t('log.stoppingSimProcess'))
         try {
@@ -193,13 +193,13 @@ const handleGoBack = async () => {
     addLog(t('log.checkStatusFailed', { error: err.message }))
   }
   
-  // 返回到 Step 2 (环境搭建)
+  // Navigate back to Step 2 (environment setup)
   router.push({ name: 'Simulation', params: { simulationId: currentSimulationId.value } })
 }
 
 const handleNextStep = () => {
-  // Step3Simulation 组件会直接处理报告生成和路由跳转
-  // 这个方法仅作为备用
+  // The Step3Simulation component handles report generation and routing directly.
+  // This method exists only as a fallback.
   addLog(t('log.enterStep4'))
 }
 
@@ -208,12 +208,12 @@ const loadSimulationData = async () => {
   try {
     addLog(t('log.loadingSimData', { id: currentSimulationId.value }))
     
-    // 获取 simulation 信息
+    // Fetch simulation info
     const simRes = await getSimulation(currentSimulationId.value)
     if (simRes.success && simRes.data) {
       const simData = simRes.data
-      
-      // 获取 simulation config 以获取 minutes_per_round
+
+      // Fetch simulation config to read minutes_per_round
       try {
         const configRes = await getSimulationConfig(currentSimulationId.value)
         if (configRes.success && configRes.data?.time_config?.minutes_per_round) {
@@ -224,14 +224,14 @@ const loadSimulationData = async () => {
         addLog(t('log.timeConfigFetchFailed', { minutes: minutesPerRound.value }))
       }
       
-      // 获取 project 信息
+      // Fetch project info
       if (simData.project_id) {
         const projRes = await getProject(simData.project_id)
         if (projRes.success && projRes.data) {
           projectData.value = projRes.data
           addLog(t('log.projectLoadSuccess', { id: projRes.data.project_id }))
-          
-          // 获取 graph 数据
+
+          // Fetch graph data
           if (projRes.data.graph_id) {
             await loadGraph(projRes.data.graph_id)
           }
@@ -246,8 +246,8 @@ const loadSimulationData = async () => {
 }
 
 const loadGraph = async (graphId) => {
-  // 当正在模拟时，自动刷新不显示全屏 loading，以免闪烁
-  // 手动刷新或初始加载时显示 loading
+  // While simulating, auto-refresh skips the full-screen loading indicator to avoid flicker.
+  // Show the loading indicator only on manual refresh or initial load.
   if (!isSimulating.value) {
     graphLoading.value = true
   }
@@ -279,7 +279,7 @@ let graphRefreshTimer = null
 const startGraphRefresh = () => {
   if (graphRefreshTimer) return
   addLog(t('log.graphRealtimeRefreshStart'))
-  // 立即刷新一次，然后每30秒刷新
+  // Refresh once immediately, then every 30 seconds
   graphRefreshTimer = setInterval(refreshGraph, 30000)
 }
 
@@ -302,7 +302,7 @@ watch(isSimulating, (newValue) => {
 onMounted(() => {
   addLog(t('log.simRunViewInit'))
   
-  // 记录 maxRounds 配置（值已在初始化时从 query 参数获取）
+  // Log the maxRounds config (the value was already read from the query param at init time)
   if (maxRounds.value) {
     addLog(t('log.customRounds', { rounds: maxRounds.value }))
   }

--- a/frontend/src/views/SimulationView.vue
+++ b/frontend/src/views/SimulationView.vue
@@ -48,7 +48,7 @@
         />
       </div>
 
-      <!-- Right Panel: Step2 环境搭建 -->
+      <!-- Right Panel: Step2 Environment Setup -->
       <div class="panel-wrapper right" :style="rightPanelStyle">
         <Step2EnvSetup
           :simulationId="currentSimulationId"
@@ -142,7 +142,7 @@ const toggleMaximize = (target) => {
 }
 
 const handleGoBack = () => {
-  // 返回到 process 页面
+  // Navigate back to the process page
   if (projectData.value?.project_id) {
     router.push({ name: 'Process', params: { projectId: projectData.value.project_id } })
   } else {
@@ -153,65 +153,65 @@ const handleGoBack = () => {
 const handleNextStep = (params = {}) => {
   addLog(t('log.enterStep3'))
 
-  // 记录模拟轮数配置
+  // Log the simulation round-count config
   if (params.maxRounds) {
     addLog(t('log.customRoundsConfig', { rounds: params.maxRounds }))
   } else {
     addLog(t('log.useAutoRounds'))
   }
   
-  // 构建路由参数
+  // Build route parameters
   const routeParams = {
     name: 'SimulationRun',
     params: { simulationId: currentSimulationId.value }
   }
   
-  // 如果有自定义轮数，通过 query 参数传递
+  // If a custom round count is provided, pass it via the query parameter
   if (params.maxRounds) {
     routeParams.query = { maxRounds: params.maxRounds }
   }
   
-  // 跳转到 Step 3 页面
+  // Navigate to the Step 3 page
   router.push(routeParams)
 }
 
 // --- Data Logic ---
 
 /**
- * 检查并关闭正在运行的模拟
- * 当用户从 Step 3 返回到 Step 2 时，默认用户要退出模拟
+ * Check for and close any currently-running simulation.
+ * When the user goes back from Step 3 to Step 2, we assume they want to exit the simulation.
  */
 const checkAndStopRunningSimulation = async () => {
   if (!currentSimulationId.value) return
   
   try {
-    // 先检查模拟环境是否存活
+    // First check whether the simulation environment is still alive
     const envStatusRes = await getEnvStatus({ simulation_id: currentSimulationId.value })
     
     if (envStatusRes.success && envStatusRes.data?.env_alive) {
       addLog(t('log.detectedSimEnvRunning'))
       
-      // 尝试优雅关闭模拟环境
+      // Attempt to gracefully close the simulation environment
       try {
         const closeRes = await closeSimulationEnv({ 
           simulation_id: currentSimulationId.value,
-          timeout: 10  // 10秒超时
+          timeout: 10  // 10-second timeout
         })
         
         if (closeRes.success) {
           addLog(t('log.simEnvClosed'))
         } else {
           addLog(t('log.closeSimEnvFailedWithError', { error: closeRes.error || t('common.unknownError') }))
-          // 如果优雅关闭失败，尝试强制停止
+          // If graceful shutdown fails, try a force-stop
           await forceStopSimulation()
         }
       } catch (closeErr) {
         addLog(t('log.closeSimEnvException', { error: closeErr.message }))
-        // 如果优雅关闭异常，尝试强制停止
+        // If graceful shutdown threw, try a force-stop
         await forceStopSimulation()
       }
     } else {
-      // 环境未运行，但可能进程还在，检查模拟状态
+      // Environment is not running, but the process may still be alive — check simulation status
       const simRes = await getSimulation(currentSimulationId.value)
       if (simRes.success && simRes.data?.status === 'running') {
         addLog(t('log.detectedSimRunning'))
@@ -219,13 +219,13 @@ const checkAndStopRunningSimulation = async () => {
       }
     }
   } catch (err) {
-    // 检查环境状态失败不影响后续流程
-    console.warn('检查模拟状态失败:', err)
+    // A failure to check env status should not block the rest of the flow
+    console.warn('Failed to check simulation status:', err)
   }
 }
 
 /**
- * 强制停止模拟
+ * Force-stop the simulation.
  */
 const forceStopSimulation = async () => {
   try {
@@ -244,19 +244,19 @@ const loadSimulationData = async () => {
   try {
     addLog(t('log.loadingSimData', { id: currentSimulationId.value }))
 
-    // 获取 simulation 信息
+    // Fetch simulation info
     const simRes = await getSimulation(currentSimulationId.value)
     if (simRes.success && simRes.data) {
       const simData = simRes.data
 
-      // 获取 project 信息
+      // Fetch project info
       if (simData.project_id) {
         const projRes = await getProject(simData.project_id)
         if (projRes.success && projRes.data) {
           projectData.value = projRes.data
           addLog(t('log.projectLoadSuccess', { id: projRes.data.project_id }))
-          
-          // 获取 graph 数据
+
+          // Fetch graph data
           if (projRes.data.graph_id) {
             await loadGraph(projRes.data.graph_id)
           }
@@ -294,10 +294,10 @@ const refreshGraph = () => {
 onMounted(async () => {
   addLog(t('log.simViewInit'))
   
-  // 检查并关闭正在运行的模拟（用户从 Step 3 返回时）
+  // Check for and close any running simulation (e.g. when the user returns from Step 3)
   await checkAndStopRunningSimulation()
-  
-  // 加载模拟数据
+
+  // Load simulation data
   loadSimulationData()
 })
 </script>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,8 @@ import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
+  // Support deployment at a sub-path (e.g., /mirofish)
+  base: process.env.VITE_BASE_PATH || '/',
   plugins: [vue()],
   resolve: {
     alias: {
@@ -16,7 +18,7 @@ export default defineConfig({
     open: true,
     proxy: {
       '/api': {
-        target: 'http://localhost:5001',
+        target: process.env.VITE_BACKEND_URL || 'http://localhost:5001',
         changeOrigin: true,
         secure: false
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mirofish",
   "version": "0.1.0",
-  "description": "MiroFish - 简洁通用的群体智能引擎，预测万物",
+  "description": "MiroFish - A Simple and Universal Swarm Intelligence Engine, Predicting Anything",
   "scripts": {
     "setup": "npm install && cd frontend && npm install",
     "setup:backend": "cd backend && uv sync",


### PR DESCRIPTION
 ### end-to-end prediction pipeline with API key auth
New: /api/pipeline — Full prediction pipeline endpoint
Adds a single endpoint that orchestrates the entire MiroFish workflow in one call, eliminating the need to chain individual API calls manually:

- Ontology generation — extracts entity/edge types from uploaded documents via LLM
- Graph build — ingests documents into Zep knowledge graph (polled to completion)
- Simulation create — creates the simulation record
- Simulation prepare — generates agent profiles and simulation config
- Simulation run — launches the OASIS subprocess; worker thread polls for completion
- Report generate — automatically runs ReportAgent once simulation finishes

Endpoints:

- POST /api/pipeline/start — accepts same multipart/form-data as ontology/generate; returns 202 immediately with a pipeline_id
- GET /api/pipeline/<pipeline_id>/status — returns full stage breakdown, progress (0–100%), live runner state, and report status (report_id, report_status, report_completed_at)
- GET /api/pipeline/list — lists all persisted pipelines


Pipeline status values: running → simulation_running → completed / failed

