### PR TITLE
fix: handle string attributes in graph ontology to prevent TypeError crash

### DIFF
--- a/backend/app/services/graph_builder.py
+++ b/backend/app/services/graph_builder.py
@@ -233,8 +233,13 @@ class GraphBuilderService:
             annotations = {}
             
             for attr_def in entity_def.get("attributes", []):
-                attr_name = safe_attr_name(attr_def["name"])  # 使用安全名称
-                attr_desc = attr_def.get("description", attr_name)
+                # LLM may return attributes as strings instead of dicts
+                if isinstance(attr_def, str):
+                    attr_name = safe_attr_name(attr_def)
+                    attr_desc = attr_def
+                else:
+                    attr_name = safe_attr_name(attr_def["name"])  # 使用安全名称
+                    attr_desc = attr_def.get("description", attr_name)
                 # Zep API 需要 Field 的 description，这是必需的
                 attrs[attr_name] = Field(description=attr_desc, default=None)
                 annotations[attr_name] = Optional[EntityText]  # 类型注解
@@ -257,8 +262,13 @@ class GraphBuilderService:
             annotations = {}
             
             for attr_def in edge_def.get("attributes", []):
-                attr_name = safe_attr_name(attr_def["name"])  # 使用安全名称
-                attr_desc = attr_def.get("description", attr_name)
+                # LLM may return attributes as strings instead of dicts
+                if isinstance(attr_def, str):
+                    attr_name = safe_attr_name(attr_def)
+                    attr_desc = attr_def
+                else:
+                    attr_name = safe_attr_name(attr_def["name"])  # 使用安全名称
+                    attr_desc = attr_def.get("description", attr_name)
                 # Zep API 需要 Field 的 description，这是必需的
                 attrs[attr_name] = Field(description=attr_desc, default=None)
                 annotations[attr_name] = Optional[str]  # 边属性用str类型

--- a/backend/app/services/ontology_generator.py
+++ b/backend/app/services/ontology_generator.py
@@ -298,6 +298,11 @@ class OntologyGenerator:
                 entity_name_map[original_name] = entity["name"]
             if "attributes" not in entity:
                 entity["attributes"] = []
+            # Normalize attributes: LLM may return strings instead of dicts
+            entity["attributes"] = [
+                attr if isinstance(attr, dict) else {"name": attr, "type": "text", "description": attr}
+                for attr in entity["attributes"]
+            ]
             if "examples" not in entity:
                 entity["examples"] = []
             # 确保description不超过100字符
@@ -322,6 +327,11 @@ class OntologyGenerator:
                 edge["source_targets"] = []
             if "attributes" not in edge:
                 edge["attributes"] = []
+            # Normalize attributes: LLM may return strings instead of dicts
+            edge["attributes"] = [
+                attr if isinstance(attr, dict) else {"name": attr, "type": "text", "description": attr}
+                for attr in edge["attributes"]
+            ]
             if len(edge.get("description", "")) > 100:
                 edge["description"] = edge["description"][:97] + "..."
         


### PR DESCRIPTION
Fixes #135

## Problem

When the LLM returns ontology `attributes` as a plain list of strings (e.g. `["full_name", "role"]`) instead of the expected list of dicts (e.g. `[{"name": "full_name", "type": "text", "description": "..."}]`), `set_ontology()` in `graph_builder.py` crashes with:

```
TypeError: string indices must be integers, not 'str'
```

at `attr_def["name"]` for both entity and edge attribute loops.

## Solution

**Two-layer fix:**

1. **`ontology_generator.py` (primary fix):** Normalize string attributes to properly-structured dicts during `_validate_ontology_result()`. Any attribute that arrives as a bare string `s` is converted to `{"name": s, "type": "text", "description": s}` before it reaches downstream code.

2. **`graph_builder.py` (safety net):** Add `isinstance(attr_def, str)` guard in both the entity and edge attribute loops inside `set_ontology()`. This ensures the crash cannot occur even if the ontology was built through a path that skips the generator's validation.

## Testing

Tested with an ontology payload where `attributes` is a list of strings — graph build now completes without error. Existing dict-format attributes continue to work as before.