### PR TITLE
ci: build Docker image for arm64

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,5 +45,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- add linux/arm64 to the Docker build platforms
- keep the existing linux/amd64 image build
- reuse the existing QEMU and Buildx setup already present in the workflow

Fixes #99

## Test plan
- git diff --check
- workflow-only change; GitHub Actions will validate the multi-arch build on tag/workflow dispatch