### PR TITLE
Pluggable memory backend, subprocess watchdog, and live cost tracker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,55 @@
-# LLM API配置（支持 OpenAI SDK 格式的任意 LLM API）
-# 推荐使用阿里百炼平台qwen-plus模型：https://bailian.console.aliyun.com/
-# 注意消耗较大，可先进行小于40轮的模拟尝试
+# =====================================================================
+# LLM API (OpenAI-compatible)
+# =====================================================================
+# Recommended: Alibaba Bailian Qwen-plus — https://bailian.console.aliyun.com/
+# Also works: OpenRouter, OpenAI, DeepSeek, any OpenAI-compatible endpoint.
+# Keep early simulation rounds under ~40 to control spend.
 LLM_API_KEY=your_api_key_here
 LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 LLM_MODEL_NAME=qwen-plus
 
-# ===== ZEP记忆图谱配置 =====
-# 每月免费额度即可支撑简单使用：https://app.getzep.com/
+# =====================================================================
+# Memory backend
+# =====================================================================
+# Choose where the temporal knowledge graph is stored.
+#   zep      — Zep Cloud (managed, paid above the free tier)
+#   graphiti — self-hosted Graphiti + Neo4j (free, unlimited)
+# Default: zep, for backward compatibility.
+MEMORY_BACKEND=zep
+
+# ----- Zep Cloud (only required when MEMORY_BACKEND=zep) -----
+# Free tier is enough for short simulations: https://app.getzep.com/
 ZEP_API_KEY=your_zep_api_key_here
 
-# ===== 加速 LLM 配置（可选）=====
-# 注意如果不使用加速配置，env文件中就不要出现下面的配置项
-LLM_BOOST_API_KEY=your_api_key_here
-LLM_BOOST_BASE_URL=your_base_url_here
-LLM_BOOST_MODEL_NAME=your_model_name_here
+# ----- Self-hosted Graphiti (only required when MEMORY_BACKEND=graphiti) -----
+# Local Neo4j is provided by docker-compose under the 'graphiti' profile:
+#   docker compose --profile graphiti up -d
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=mirofish-local
+
+# Graphiti uses an LLM for entity extraction. By default it reuses
+# LLM_API_KEY / LLM_BASE_URL / LLM_MODEL_NAME above so no extra key
+# is needed. To override (e.g. use a cheaper model just for extraction),
+# uncomment and set:
+# GRAPHITI_LLM_API_KEY=
+# GRAPHITI_LLM_BASE_URL=
+# GRAPHITI_LLM_MODEL=
+# GRAPHITI_EMBEDDING_MODEL=text-embedding-3-small
+
+# =====================================================================
+# Cost guardrails
+# =====================================================================
+# Optional hard cap on cumulative LLM spend per simulation. If the
+# UsageTracker observes spend reaching this many USD, the simulation
+# is auto-aborted and the report agent is skipped. Leave unset to
+# disable. The UI still shows live spend regardless.
+# MAX_SIMULATION_COST_USD=5.00
+
+# =====================================================================
+# Optional accelerator LLM (kept for backward compatibility)
+# =====================================================================
+# Leave commented out if not using a separate fast model.
+# LLM_BOOST_API_KEY=
+# LLM_BOOST_BASE_URL=
+# LLM_BOOST_MODEL_NAME=

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -42,11 +42,21 @@ def create_app(config_class=Config):
     # 启用CORS
     CORS(app, resources={r"/api/*": {"origins": "*"}})
     
-    # 注册模拟进程清理函数（确保服务器关闭时终止所有模拟进程）
+    # Register subprocess cleanup hooks (best-effort SIGTERM path).
     from .services.simulation_runner import SimulationRunner
     SimulationRunner.register_cleanup()
     if should_log_startup:
-        logger.info("已注册模拟进程清理函数")
+        logger.info("Registered simulation-process cleanup hooks")
+
+    # Start the parent-liveness heartbeat. Children spawned by the
+    # simulation runner monitor this file and abort themselves if the
+    # backend dies ungracefully — this is the safety net that prevents
+    # leaked simulation subprocesses from burning LLM credits after a
+    # SIGKILL, system sleep, or unclean shutdown.
+    from .services import parent_heartbeat
+    heartbeat_path = parent_heartbeat.start()
+    if should_log_startup and heartbeat_path:
+        logger.info("Parent heartbeat active: %s", heartbeat_path)
     
     # 请求日志中间件
     @app.before_request

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4,6 +4,7 @@ Step2: Zep实体读取与过滤、OASIS模拟准备与运行（全程自动化�
 """
 
 import os
+import time
 import traceback
 from flask import request, jsonify, send_file
 
@@ -1638,6 +1639,150 @@ def start_simulation():
             "success": False,
             "error": str(e),
             "traceback": traceback.format_exc()
+        }), 500
+
+
+@simulation_bp.route('/usage/global', methods=['GET'])
+def get_usage_global():
+    """Return aggregate LLM usage across every simulation on this host.
+
+    Useful for the always-visible usage indicator in the UI footer
+    so users can see total spend even when no specific simulation
+    page is open.
+    """
+    try:
+        from ..services.usage_tracker import get_usage_tracker
+
+        tracker = get_usage_tracker()
+        return jsonify({
+            "success": True,
+            "data": {
+                "global": tracker.global_snapshot().to_dict(),
+                "per_simulation": [s.to_dict() for s in tracker.all_simulations()],
+            },
+        })
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@simulation_bp.route('/<simulation_id>/usage', methods=['GET'])
+def get_usage_for_simulation(simulation_id: str):
+    """Return live LLM usage for one simulation.
+
+    Polled every few seconds by the UI usage bar. Returns token
+    counts, cumulative cost, and (if a cost cap is configured)
+    whether the cap has been breached.
+    """
+    try:
+        from ..services.usage_tracker import get_usage_tracker
+
+        tracker = get_usage_tracker()
+        return jsonify({
+            "success": True,
+            "data": tracker.snapshot(simulation_id).to_dict(),
+        })
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@simulation_bp.route('/<simulation_id>/usage/cap', methods=['POST'])
+def set_usage_cap(simulation_id: str):
+    """Set or clear the cost cap for a single simulation.
+
+    Body: ``{"cap_usd": <number|null>}``. ``null`` clears any
+    explicit cap and falls back to the env-var default.
+    """
+    try:
+        from ..services.usage_tracker import get_usage_tracker
+
+        body = request.get_json(silent=True) or {}
+        cap_raw = body.get("cap_usd")
+        cap = None if cap_raw is None else float(cap_raw)
+
+        get_usage_tracker().set_cap(simulation_id, cap)
+        snap = get_usage_tracker().snapshot(simulation_id)
+        return jsonify({"success": True, "data": snap.to_dict()})
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 400
+
+
+@simulation_bp.route('/emergency-stop', methods=['POST'])
+def emergency_stop_all():
+    """Force-terminate every simulation subprocess on this host.
+
+    Unlike :func:`stop_simulation` which gracefully ends a single
+    simulation, this endpoint is the user-visible "panic button":
+    it iterates every tracked subprocess, sends ``SIGTERM`` to its
+    process group with a short grace period, then ``SIGKILL`` to
+    anything still alive. Any orphaned ``run_parallel_simulation.py``
+    that is no longer in our tracking dict is also reaped via
+    process-name matching, because the leak we fixed was exactly
+    that — children outliving the backend that spawned them.
+
+    Returns a summary so the UI can show "killed N processes" toast.
+    """
+    try:
+        # First pass: terminate everything we know about. The runner
+        # already has a battle-tested process-group cleanup path.
+        before_known = list(SimulationRunner._processes.keys())  # noqa: SLF001
+        SimulationRunner.cleanup_all_simulations()
+
+        # Second pass: hunt down any orphaned children that escaped
+        # tracking — typically the leaked ones from previous backend
+        # crashes.
+        import signal as _signal
+        import subprocess as _subprocess
+
+        orphans_killed = 0
+        try:
+            ps_out = _subprocess.run(
+                ["pgrep", "-f", "run_parallel_simulation.py"],
+                capture_output=True, text=True, timeout=5,
+            ).stdout.strip().splitlines()
+            for pid_str in ps_out:
+                try:
+                    pid = int(pid_str)
+                    # Skip ourselves and our parents — pgrep can match
+                    # the API request log line in our own command line.
+                    if pid in (os.getpid(), os.getppid()):
+                        continue
+                    try:
+                        os.kill(pid, _signal.SIGTERM)
+                    except ProcessLookupError:
+                        continue
+                    orphans_killed += 1
+                except ValueError:
+                    pass
+            # Give SIGTERM a brief moment, then SIGKILL stragglers.
+            time.sleep(2)
+            for pid_str in ps_out:
+                try:
+                    pid = int(pid_str)
+                    if pid in (os.getpid(), os.getppid()):
+                        continue
+                    os.kill(pid, _signal.SIGKILL)
+                except (ValueError, ProcessLookupError):
+                    pass
+        except Exception as _e:  # noqa: BLE001
+            logger.warning(f"orphan sweep failed (non-fatal): {_e}")
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "tracked_simulations_stopped": before_known,
+                "orphans_killed": orphans_killed,
+                "message": (
+                    f"Stopped {len(before_known)} tracked simulation(s) "
+                    f"and killed {orphans_killed} orphan process(es)."
+                ),
+            },
+        })
+    except Exception as e:
+        logger.error(f"Emergency stop failed: {e}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc(),
         }), 500
 
 

--- a/backend/app/services/graph_builder.py
+++ b/backend/app/services/graph_builder.py
@@ -1,6 +1,10 @@
 """
 图谱构建服务
-接口2：使用Zep API构建Standalone Graph
+Builds the standalone knowledge graph through the abstract memory backend.
+
+Backend selection (Zep Cloud / self-hosted Graphiti) happens via the
+``MEMORY_BACKEND`` environment variable; this service does not care
+which one is active.
 """
 
 import os
@@ -10,14 +14,16 @@ import threading
 from typing import Dict, Any, List, Optional, Callable
 from dataclasses import dataclass
 
-from zep_cloud.client import Zep
-from zep_cloud import EpisodeData, EntityEdgeSourceTarget
-
 from ..config import Config
 from ..models.task import TaskManager, TaskStatus
-from ..utils.zep_paging import fetch_all_nodes, fetch_all_edges
-from .text_processor import TextProcessor
 from ..utils.locale import t, get_locale, set_locale
+from .memory import (
+    EpisodeInput,
+    MemoryBackend,
+    OntologySpec,
+    get_memory_backend,
+)
+from .text_processor import TextProcessor
 
 
 @dataclass
@@ -43,12 +49,14 @@ class GraphBuilderService:
     负责调用Zep API构建知识图谱
     """
     
-    def __init__(self, api_key: Optional[str] = None):
-        self.api_key = api_key or Config.ZEP_API_KEY
-        if not self.api_key:
-            raise ValueError("ZEP_API_KEY 未配置")
-        
-        self.client = Zep(api_key=self.api_key)
+    def __init__(self, backend: Optional[MemoryBackend] = None):
+        # Backwards compatible: legacy callers passed ``api_key`` as the
+        # first positional arg. Accept that for one release while
+        # callers migrate to the abstract backend.
+        if isinstance(backend, str):  # type: ignore[unreachable]
+            os.environ.setdefault("ZEP_API_KEY", backend)
+            backend = None
+        self.backend: MemoryBackend = backend or get_memory_backend()
         self.task_manager = TaskManager()
     
     def build_graph_async(
@@ -191,105 +199,26 @@ class GraphBuilderService:
             self.task_manager.fail_task(task_id, error_msg)
     
     def create_graph(self, name: str) -> str:
-        """创建Zep图谱（公开方法）"""
+        """Create a new memory graph and return its id."""
         graph_id = f"mirofish_{uuid.uuid4().hex[:16]}"
-        
-        self.client.graph.create(
-            graph_id=graph_id,
-            name=name,
-            description="MiroFish Social Simulation Graph"
+        self.backend.create_graph(
+            graph_id,
+            display_name=name,
+            description="MiroFish Social Simulation Graph",
         )
-        
         return graph_id
     
     def set_ontology(self, graph_id: str, ontology: Dict[str, Any]):
-        """设置图谱本体（公开方法）"""
-        import warnings
-        from typing import Optional
-        from pydantic import Field
-        from zep_cloud.external_clients.ontology import EntityModel, EntityText, EdgeModel
-        
-        # 抑制 Pydantic v2 关于 Field(default=None) 的警告
-        # 这是 Zep SDK 要求的用法，警告来自动态类创建，可以安全忽略
-        warnings.filterwarnings('ignore', category=UserWarning, module='pydantic')
-        
-        # Zep 保留名称，不能作为属性名
-        RESERVED_NAMES = {'uuid', 'name', 'group_id', 'name_embedding', 'summary', 'created_at'}
-        
-        def safe_attr_name(attr_name: str) -> str:
-            """将保留名称转换为安全名称"""
-            if attr_name.lower() in RESERVED_NAMES:
-                return f"entity_{attr_name}"
-            return attr_name
-        
-        # 动态创建实体类型
-        entity_types = {}
-        for entity_def in ontology.get("entity_types", []):
-            name = entity_def["name"]
-            description = entity_def.get("description", f"A {name} entity.")
-            
-            # 创建属性字典和类型注解（Pydantic v2 需要）
-            attrs = {"__doc__": description}
-            annotations = {}
-            
-            for attr_def in entity_def.get("attributes", []):
-                attr_name = safe_attr_name(attr_def["name"])  # 使用安全名称
-                attr_desc = attr_def.get("description", attr_name)
-                # Zep API 需要 Field 的 description，这是必需的
-                attrs[attr_name] = Field(description=attr_desc, default=None)
-                annotations[attr_name] = Optional[EntityText]  # 类型注解
-            
-            attrs["__annotations__"] = annotations
-            
-            # 动态创建类
-            entity_class = type(name, (EntityModel,), attrs)
-            entity_class.__doc__ = description
-            entity_types[name] = entity_class
-        
-        # 动态创建边类型
-        edge_definitions = {}
-        for edge_def in ontology.get("edge_types", []):
-            name = edge_def["name"]
-            description = edge_def.get("description", f"A {name} relationship.")
-            
-            # 创建属性字典和类型注解
-            attrs = {"__doc__": description}
-            annotations = {}
-            
-            for attr_def in edge_def.get("attributes", []):
-                attr_name = safe_attr_name(attr_def["name"])  # 使用安全名称
-                attr_desc = attr_def.get("description", attr_name)
-                # Zep API 需要 Field 的 description，这是必需的
-                attrs[attr_name] = Field(description=attr_desc, default=None)
-                annotations[attr_name] = Optional[str]  # 边属性用str类型
-            
-            attrs["__annotations__"] = annotations
-            
-            # 动态创建类
-            class_name = ''.join(word.capitalize() for word in name.split('_'))
-            edge_class = type(class_name, (EdgeModel,), attrs)
-            edge_class.__doc__ = description
-            
-            # 构建source_targets
-            source_targets = []
-            for st in edge_def.get("source_targets", []):
-                source_targets.append(
-                    EntityEdgeSourceTarget(
-                        source=st.get("source", "Entity"),
-                        target=st.get("target", "Entity")
-                    )
-                )
-            
-            if source_targets:
-                edge_definitions[name] = (edge_class, source_targets)
-        
-        # 调用Zep API设置本体
-        if entity_types or edge_definitions:
-            self.client.graph.set_ontology(
-                graph_ids=[graph_id],
-                entities=entity_types if entity_types else None,
-                edges=edge_definitions if edge_definitions else None,
-            )
+        """Set the entity / edge type schema for ``graph_id``.
+
+        The dynamic Pydantic class construction that used to live here
+        moved into the backend implementations, so this service stays
+        free of any provider-specific concerns.
+        """
+        spec = OntologySpec.from_dict(ontology)
+        if not spec.entity_types and not spec.edge_types:
+            return
+        self.backend.set_ontology(graph_id, spec)
     
     def add_text_batches(
         self,
@@ -314,29 +243,25 @@ class GraphBuilderService:
                     progress
                 )
             
-            # 构建episode数据
+            # Build provider-neutral episode payload
             episodes = [
-                EpisodeData(data=chunk, type="text")
+                EpisodeInput(content=chunk, episode_type="text")
                 for chunk in batch_chunks
             ]
-            
-            # 发送到Zep
+
             try:
-                batch_result = self.client.graph.add_batch(
+                batch_result = self.backend.add_episodes_bulk(
                     graph_id=graph_id,
-                    episodes=episodes
+                    episodes=episodes,
                 )
-                
-                # 收集返回的 episode uuid
-                if batch_result and isinstance(batch_result, list):
-                    for ep in batch_result:
-                        ep_uuid = getattr(ep, 'uuid_', None) or getattr(ep, 'uuid', None)
-                        if ep_uuid:
-                            episode_uuids.append(ep_uuid)
-                
-                # 避免请求过快
+
+                for ep in batch_result:
+                    if ep.uuid:
+                        episode_uuids.append(ep.uuid)
+
+                # Friendly throttle for cloud backends with low rate limits.
                 time.sleep(1)
-                
+
             except Exception as e:
                 if progress_callback:
                     progress_callback(t('progress.batchFailed', batch=batch_num, error=str(e)), 0)
@@ -373,18 +298,16 @@ class GraphBuilderService:
                     )
                 break
             
-            # 检查每个 episode 的处理状态
+            # Poll each pending episode for processing completion.
             for ep_uuid in list(pending_episodes):
                 try:
-                    episode = self.client.graph.episode.get(uuid_=ep_uuid)
-                    is_processed = getattr(episode, 'processed', False)
-                    
-                    if is_processed:
+                    episode = self.backend.get_episode(ep_uuid)
+                    if episode is not None and episode.processed:
                         pending_episodes.remove(ep_uuid)
                         completed_count += 1
-                        
-                except Exception as e:
-                    # 忽略单个查询错误，继续
+                except Exception:
+                    # Per-episode lookup failures are expected during
+                    # transient rate limiting; carry on.
                     pass
             
             elapsed = int(time.time() - start_time)
@@ -401,97 +324,37 @@ class GraphBuilderService:
             progress_callback(t('progress.processingComplete', completed=completed_count, total=total_episodes), 1.0)
     
     def _get_graph_info(self, graph_id: str) -> GraphInfo:
-        """获取图谱信息"""
-        # 获取节点（分页）
-        nodes = fetch_all_nodes(self.client, graph_id)
+        """Summarise a graph's node count, edge count and entity types."""
+        nodes = self.backend.get_all_nodes(graph_id)
+        edges = self.backend.get_all_edges(graph_id)
 
-        # 获取边（分页）
-        edges = fetch_all_edges(self.client, graph_id)
-
-        # 统计实体类型
-        entity_types = set()
+        entity_types: set[str] = set()
         for node in nodes:
-            if node.labels:
-                for label in node.labels:
-                    if label not in ["Entity", "Node"]:
-                        entity_types.add(label)
+            entity_types.update(node.custom_labels())
 
         return GraphInfo(
             graph_id=graph_id,
             node_count=len(nodes),
             edge_count=len(edges),
-            entity_types=list(entity_types)
+            entity_types=list(entity_types),
         )
     
     def get_graph_data(self, graph_id: str) -> Dict[str, Any]:
-        """
-        获取完整图谱数据（包含详细信息）
-        
-        Args:
-            graph_id: 图谱ID
-            
-        Returns:
-            包含nodes和edges的字典，包括时间信息、属性等详细数据
-        """
-        nodes = fetch_all_nodes(self.client, graph_id)
-        edges = fetch_all_edges(self.client, graph_id)
+        """Return the full graph contents in the JSON shape the UI expects."""
+        nodes = self.backend.get_all_nodes(graph_id)
+        edges = self.backend.get_all_edges(graph_id)
 
-        # 创建节点映射用于获取节点名称
-        node_map = {}
-        for node in nodes:
-            node_map[node.uuid_] = node.name or ""
-        
-        nodes_data = []
-        for node in nodes:
-            # 获取创建时间
-            created_at = getattr(node, 'created_at', None)
-            if created_at:
-                created_at = str(created_at)
-            
-            nodes_data.append({
-                "uuid": node.uuid_,
-                "name": node.name,
-                "labels": node.labels or [],
-                "summary": node.summary or "",
-                "attributes": node.attributes or {},
-                "created_at": created_at,
-            })
-        
+        node_map: Dict[str, str] = {n.uuid: n.name or "" for n in nodes}
+
+        nodes_data = [n.to_dict() for n in nodes]
+
         edges_data = []
         for edge in edges:
-            # 获取时间信息
-            created_at = getattr(edge, 'created_at', None)
-            valid_at = getattr(edge, 'valid_at', None)
-            invalid_at = getattr(edge, 'invalid_at', None)
-            expired_at = getattr(edge, 'expired_at', None)
-            
-            # 获取 episodes
-            episodes = getattr(edge, 'episodes', None) or getattr(edge, 'episode_ids', None)
-            if episodes and not isinstance(episodes, list):
-                episodes = [str(episodes)]
-            elif episodes:
-                episodes = [str(e) for e in episodes]
-            
-            # 获取 fact_type
-            fact_type = getattr(edge, 'fact_type', None) or edge.name or ""
-            
-            edges_data.append({
-                "uuid": edge.uuid_,
-                "name": edge.name or "",
-                "fact": edge.fact or "",
-                "fact_type": fact_type,
-                "source_node_uuid": edge.source_node_uuid,
-                "target_node_uuid": edge.target_node_uuid,
-                "source_node_name": node_map.get(edge.source_node_uuid, ""),
-                "target_node_name": node_map.get(edge.target_node_uuid, ""),
-                "attributes": edge.attributes or {},
-                "created_at": str(created_at) if created_at else None,
-                "valid_at": str(valid_at) if valid_at else None,
-                "invalid_at": str(invalid_at) if invalid_at else None,
-                "expired_at": str(expired_at) if expired_at else None,
-                "episodes": episodes or [],
-            })
-        
+            edge_dict = edge.to_dict()
+            edge_dict["source_node_name"] = node_map.get(edge.source_node_uuid, "")
+            edge_dict["target_node_name"] = node_map.get(edge.target_node_uuid, "")
+            edges_data.append(edge_dict)
+
         return {
             "graph_id": graph_id,
             "nodes": nodes_data,
@@ -499,8 +362,8 @@ class GraphBuilderService:
             "node_count": len(nodes_data),
             "edge_count": len(edges_data),
         }
-    
+
     def delete_graph(self, graph_id: str):
-        """删除图谱"""
-        self.client.graph.delete(graph_id=graph_id)
+        """Delete the graph and every entity / edge / episode under it."""
+        self.backend.delete_graph(graph_id)
 

--- a/backend/app/services/memory/README.md
+++ b/backend/app/services/memory/README.md
@@ -1,0 +1,79 @@
+# Memory backend abstraction
+
+This package decouples MiroFish's simulation pipeline from any specific
+graph-memory provider. Application code depends only on the abstract
+`MemoryBackend` interface and the provider-neutral DTOs (`Episode`,
+`Node`, `Edge`, `SearchResult`, `OntologySpec`). The concrete backend is
+selected at runtime via the `MEMORY_BACKEND` environment variable.
+
+## Available backends
+
+| `MEMORY_BACKEND=` | Provider | Cost | Setup |
+|---|---|---|---|
+| `zep` *(default)* | [Zep Cloud](https://www.getzep.com/) | Free tier with quota; paid above | Just set `ZEP_API_KEY` |
+| `graphiti` | [Graphiti](https://github.com/getzep/graphiti) on local Neo4j | Free, unlimited | `docker compose --profile graphiti up -d` |
+
+The default is `zep` for backward compatibility — existing deployments
+need no changes after this refactor lands.
+
+## Switching to self-hosted Graphiti
+
+```bash
+# 1. Start Neo4j
+docker compose --profile graphiti up -d
+
+# 2. Configure the backend
+echo "MEMORY_BACKEND=graphiti" >> .env
+echo "NEO4J_URI=bolt://localhost:7687" >> .env
+echo "NEO4J_USER=neo4j" >> .env
+echo "NEO4J_PASSWORD=mirofish-local" >> .env
+
+# 3. Restart the backend
+npm run dev
+```
+
+Graphiti reuses your existing `LLM_API_KEY` / `LLM_BASE_URL` /
+`LLM_MODEL_NAME` for entity extraction, so no extra LLM key is needed.
+Override per-task via `GRAPHITI_LLM_*` env vars if you want a cheaper
+model just for extraction.
+
+## Architecture
+
+```
+backend/app/services/memory/
+├── __init__.py             # public API surface
+├── base.py                 # MemoryBackend ABC + DTOs
+├── exceptions.py           # MemoryBackendError + typed subclasses
+├── factory.py              # MEMORY_BACKEND env var → backend instance
+├── zep_cloud_backend.py    # Zep Cloud implementation (default)
+└── graphiti_backend.py     # Self-hosted Graphiti implementation
+```
+
+The abstraction follows SOLID:
+
+- **S**ingle Responsibility — each backend file implements exactly one
+  provider; the ABC carries only the contract.
+- **O**pen/Closed — adding a new backend (Mem0, Memgraph, etc.) means
+  dropping a new file and registering it in `factory.py`. Existing
+  backends and consumers are unchanged.
+- **L**iskov Substitution — both backends produce the same DTO types so
+  consumers cannot tell them apart.
+- **I**nterface Segregation — `MemoryBackend` exposes only the 11
+  operations MiroFish actually uses, not the 50+ surface of the Zep SDK.
+- **D**ependency Inversion — services like `GraphBuilderService`,
+  `ZepGraphMemoryUpdater`, `ZepToolsService`, `ZepEntityReader`, and
+  `OasisProfileGenerator` depend on the abstract `MemoryBackend`, not
+  the concrete `Zep` SDK class.
+
+## Adding a new backend
+
+1. Create `app/services/memory/<provider>_backend.py`.
+2. Subclass `MemoryBackend` and implement all abstract methods.
+3. Translate provider exceptions into `MemoryBackendError` /
+   `MemoryBackendRateLimited` / `MemoryBackendQuotaExceeded` so callers
+   can handle them uniformly.
+4. Register your loader in `factory._REGISTRY`.
+5. Add the dep to `pyproject.toml` and document the env vars in
+   `.env.example`.
+
+That is the entire integration surface — no consumer-side changes.

--- a/backend/app/services/memory/__init__.py
+++ b/backend/app/services/memory/__init__.py
@@ -1,0 +1,60 @@
+"""Memory backend abstraction for MiroFish.
+
+This package decouples MiroFish from any specific graph-memory provider.
+Consumers depend only on the abstract :class:`MemoryBackend` and the
+DTOs defined in :mod:`app.services.memory.base`. The concrete backend
+is selected at runtime via the ``MEMORY_BACKEND`` environment variable
+(default: ``zep``).
+
+Available backends:
+
+* ``zep``       — Zep Cloud (managed, paid above free tier).
+* ``graphiti``  — Self-hosted Graphiti + Neo4j (free, unlimited).
+
+Switching backend is a config change; no application code needs to be
+modified. Adding a new backend means dropping a new module that
+implements :class:`MemoryBackend` and registering it in
+:mod:`app.services.memory.factory`.
+"""
+
+from .base import (
+    Edge,
+    EpisodeRef,
+    EpisodeInput,
+    EpisodeType,
+    MemoryBackend,
+    Node,
+    OntologySpec,
+    SearchResult,
+)
+from .exceptions import (
+    MemoryBackendError,
+    MemoryBackendNotConfigured,
+    MemoryBackendQuotaExceeded,
+    MemoryBackendRateLimited,
+    MemoryBackendUnavailable,
+)
+from .factory import build_memory_backend, get_memory_backend, reset_memory_backend
+
+__all__ = [
+    # DTOs
+    "Edge",
+    "EpisodeInput",
+    "EpisodeRef",
+    "EpisodeType",
+    "Node",
+    "OntologySpec",
+    "SearchResult",
+    # Abstract base
+    "MemoryBackend",
+    # Factory
+    "build_memory_backend",
+    "get_memory_backend",
+    "reset_memory_backend",
+    # Exceptions
+    "MemoryBackendError",
+    "MemoryBackendNotConfigured",
+    "MemoryBackendQuotaExceeded",
+    "MemoryBackendRateLimited",
+    "MemoryBackendUnavailable",
+]

--- a/backend/app/services/memory/base.py
+++ b/backend/app/services/memory/base.py
@@ -1,0 +1,356 @@
+"""Memory backend abstract base class and provider-neutral DTOs.
+
+This module defines the contract every memory backend must satisfy.
+Consumers depend on these types only — never on Zep / Graphiti / Neo4j
+SDK objects directly.
+
+Design notes
+------------
+* All DTOs are :func:`@dataclass` instances with explicit fields. They
+  carry the union of fields that any consumer in the codebase reads,
+  so backends can populate them without forcing callers to do
+  provider-specific attribute lookups.
+* The :class:`MemoryBackend` ABC exposes only the operations MiroFish
+  actually uses (Interface Segregation Principle). New operations are
+  added here only when a real consumer requires them.
+* All methods are synchronous from the caller's perspective. Backends
+  that wrap an async client are responsible for hiding that fact (for
+  example by running async calls in a per-call event loop).
+* Bitemporal fields (``valid_at`` / ``invalid_at`` / ``expired_at``)
+  are present on :class:`Edge` because some consumers display them in
+  the report UI. Backends that lack temporal validity may set them to
+  ``None``.
+"""
+
+from __future__ import annotations
+
+import abc
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal, Optional
+
+EpisodeType = Literal["text", "message", "json"]
+
+
+@dataclass(frozen=True)
+class EpisodeInput:
+    """A single episode (raw text or message) to be ingested.
+
+    ``content`` is the body to extract entities from. ``source_description``
+    is shown in the UI and used by some retrieval paths to disambiguate
+    where a fact came from. ``reference_time`` is optional; if absent
+    the backend uses ingest time.
+    """
+
+    content: str
+    episode_type: EpisodeType = "text"
+    source_description: str = ""
+    reference_time: Optional[datetime] = None
+
+
+@dataclass
+class EpisodeRef:
+    """Lightweight handle to an ingested episode.
+
+    Consumers poll ``processed`` to know when downstream entity / edge
+    extraction has finished. Backends that ingest synchronously set
+    ``processed=True`` on first return.
+    """
+
+    uuid: str
+    processed: bool = True
+    content: Optional[str] = None
+    source_description: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+@dataclass
+class Node:
+    """An entity node in the memory graph.
+
+    ``labels`` is the list of entity types attached to the node.
+    Provider conventions vary (Zep adds ``"Entity"``, ``"Node"``;
+    Graphiti adds ``"Entity"``); call :meth:`custom_labels` to get
+    only the user-defined types.
+    """
+
+    uuid: str
+    name: str
+    labels: list[str] = field(default_factory=list)
+    summary: str = ""
+    attributes: dict[str, Any] = field(default_factory=dict)
+    created_at: Optional[str] = None
+
+    _GENERIC_LABELS = frozenset({"Entity", "Node"})
+
+    def custom_labels(self) -> list[str]:
+        """Return labels excluding the generic ``Entity`` / ``Node`` markers."""
+        return [label for label in self.labels if label not in self._GENERIC_LABELS]
+
+    def primary_type(self) -> Optional[str]:
+        """Return the first user-defined entity type, or ``None``."""
+        custom = self.custom_labels()
+        return custom[0] if custom else None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "uuid": self.uuid,
+            "name": self.name,
+            "labels": list(self.labels),
+            "summary": self.summary,
+            "attributes": dict(self.attributes),
+            "created_at": self.created_at,
+        }
+
+
+@dataclass
+class Edge:
+    """A fact / relationship edge in the memory graph.
+
+    ``name`` is the relation type (e.g. ``COMPETES_WITH``).
+    ``fact`` is the natural-language statement extracted from text
+    (e.g. ``"Chordinia competes with Chordify"``).
+
+    Bitemporal fields (``valid_at`` / ``invalid_at`` / ``expired_at``)
+    track when the fact became true and when it stopped being true.
+    They may be ``None`` when the backend does not track validity.
+    """
+
+    uuid: str
+    name: str
+    fact: str
+    source_node_uuid: str
+    target_node_uuid: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+    fact_type: Optional[str] = None
+    created_at: Optional[str] = None
+    valid_at: Optional[str] = None
+    invalid_at: Optional[str] = None
+    expired_at: Optional[str] = None
+    episodes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "uuid": self.uuid,
+            "name": self.name,
+            "fact": self.fact,
+            "fact_type": self.fact_type or self.name,
+            "source_node_uuid": self.source_node_uuid,
+            "target_node_uuid": self.target_node_uuid,
+            "attributes": dict(self.attributes),
+            "created_at": self.created_at,
+            "valid_at": self.valid_at,
+            "invalid_at": self.invalid_at,
+            "expired_at": self.expired_at,
+            "episodes": list(self.episodes),
+        }
+
+
+@dataclass
+class SearchResult:
+    """Result of a graph search query."""
+
+    edges: list[Edge] = field(default_factory=list)
+    nodes: list[Node] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _AttributeSpec:
+    name: str
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class _EntityTypeSpec:
+    name: str
+    description: str = ""
+    attributes: tuple[_AttributeSpec, ...] = ()
+
+
+@dataclass(frozen=True)
+class _SourceTargetSpec:
+    source: str = "Entity"
+    target: str = "Entity"
+
+
+@dataclass(frozen=True)
+class _EdgeTypeSpec:
+    name: str
+    description: str = ""
+    attributes: tuple[_AttributeSpec, ...] = ()
+    source_targets: tuple[_SourceTargetSpec, ...] = ()
+
+
+@dataclass(frozen=True)
+class OntologySpec:
+    """Provider-neutral description of the entity / edge type schema.
+
+    Built from the dict shape MiroFish already uses:
+
+    .. code-block:: python
+
+        {
+            "entity_types": [
+                {"name": "Person", "description": "...",
+                 "attributes": [{"name": "occupation", "description": "..."}]},
+            ],
+            "edge_types": [
+                {"name": "COMPETES_WITH", "description": "...",
+                 "attributes": [...],
+                 "source_targets": [{"source": "App", "target": "App"}]},
+            ],
+        }
+    """
+
+    entity_types: tuple[_EntityTypeSpec, ...] = ()
+    edge_types: tuple[_EdgeTypeSpec, ...] = ()
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> OntologySpec:
+        """Build an :class:`OntologySpec` from the dict format used in callers."""
+
+        def _attrs(items: list[dict[str, Any]] | None) -> tuple[_AttributeSpec, ...]:
+            if not items:
+                return ()
+            return tuple(
+                _AttributeSpec(name=a["name"], description=a.get("description", ""))
+                for a in items
+            )
+
+        entity_types = tuple(
+            _EntityTypeSpec(
+                name=e["name"],
+                description=e.get("description", ""),
+                attributes=_attrs(e.get("attributes")),
+            )
+            for e in raw.get("entity_types", [])
+        )
+        edge_types = tuple(
+            _EdgeTypeSpec(
+                name=e["name"],
+                description=e.get("description", ""),
+                attributes=_attrs(e.get("attributes")),
+                source_targets=tuple(
+                    _SourceTargetSpec(
+                        source=st.get("source", "Entity"),
+                        target=st.get("target", "Entity"),
+                    )
+                    for st in e.get("source_targets", [])
+                ),
+            )
+            for e in raw.get("edge_types", [])
+        )
+        return cls(entity_types=entity_types, edge_types=edge_types)
+
+
+class MemoryBackend(abc.ABC):
+    """Abstract base class every memory backend must implement.
+
+    Implementations MUST:
+
+    * Translate provider-specific exceptions into the typed errors in
+      :mod:`app.services.memory.exceptions`.
+    * Return :class:`Node`, :class:`Edge`, :class:`EpisodeRef` and
+      :class:`SearchResult` instances — never raw SDK objects.
+    * Be safe to construct lazily (defer connection until first use
+      where possible) so import-time failure is avoided.
+    """
+
+    # ---- Lifecycle ------------------------------------------------------
+
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Return the backend identifier (``"zep"`` / ``"graphiti"``)."""
+
+    @abc.abstractmethod
+    def create_graph(
+        self,
+        graph_id: str,
+        *,
+        display_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        """Create a new graph / namespace.
+
+        Backends that do not have an explicit graph creation step (e.g.
+        Graphiti, where ``group_id`` is just a tag attached at write
+        time) MAY make this a no-op.
+        """
+
+    @abc.abstractmethod
+    def delete_graph(self, graph_id: str) -> None:
+        """Delete the graph and every node / edge / episode under it."""
+
+    @abc.abstractmethod
+    def set_ontology(self, graph_id: str, ontology: OntologySpec) -> None:
+        """Set the entity / edge type schema for ``graph_id``.
+
+        Backends that pass ontology per-call (Graphiti) MUST store the
+        spec internally and apply it on every subsequent write.
+        """
+
+    # ---- Episode ingest -------------------------------------------------
+
+    @abc.abstractmethod
+    def add_episode(self, graph_id: str, episode: EpisodeInput) -> EpisodeRef:
+        """Ingest a single episode."""
+
+    @abc.abstractmethod
+    def add_episodes_bulk(
+        self, graph_id: str, episodes: list[EpisodeInput]
+    ) -> list[EpisodeRef]:
+        """Ingest a batch of episodes. Order of return matches input."""
+
+    @abc.abstractmethod
+    def get_episode(self, episode_uuid: str) -> Optional[EpisodeRef]:
+        """Fetch a single episode by uuid, or return ``None`` if absent."""
+
+    # ---- Graph reads ----------------------------------------------------
+
+    @abc.abstractmethod
+    def search(
+        self,
+        graph_id: str,
+        query: str,
+        *,
+        limit: int = 10,
+        scope: Literal["edges", "nodes"] = "edges",
+    ) -> SearchResult:
+        """Search the graph by natural-language query.
+
+        ``scope`` selects whether to return matching edges (facts) or
+        matching nodes (entities). Some backends may populate both
+        regardless of the value; consumers should check the field
+        relevant to them.
+        """
+
+    @abc.abstractmethod
+    def get_node(self, node_uuid: str) -> Optional[Node]:
+        """Fetch a single node by uuid, or return ``None`` if absent."""
+
+    @abc.abstractmethod
+    def get_nodes_by_graph(
+        self, graph_id: str, *, page_size: int = 100, max_items: int = 2000
+    ) -> Iterator[Node]:
+        """Yield every node in ``graph_id`` (paged)."""
+
+    @abc.abstractmethod
+    def get_edges_by_graph(
+        self, graph_id: str, *, page_size: int = 100
+    ) -> Iterator[Edge]:
+        """Yield every edge in ``graph_id`` (paged)."""
+
+    @abc.abstractmethod
+    def get_node_edges(self, node_uuid: str) -> list[Edge]:
+        """Return every edge incident to the node with ``node_uuid``."""
+
+    # ---- Convenience ----------------------------------------------------
+
+    def get_all_nodes(self, graph_id: str) -> list[Node]:
+        """Materialise :meth:`get_nodes_by_graph` into a list."""
+        return list(self.get_nodes_by_graph(graph_id))
+
+    def get_all_edges(self, graph_id: str) -> list[Edge]:
+        """Materialise :meth:`get_edges_by_graph` into a list."""
+        return list(self.get_edges_by_graph(graph_id))

--- a/backend/app/services/memory/exceptions.py
+++ b/backend/app/services/memory/exceptions.py
@@ -1,0 +1,28 @@
+"""Typed exceptions raised by memory backend implementations.
+
+Concrete backends translate provider-specific errors into these so that
+callers can handle them uniformly without depending on Zep / Graphiti /
+Neo4j exception types.
+"""
+
+from __future__ import annotations
+
+
+class MemoryBackendError(Exception):
+    """Base class for all memory backend errors."""
+
+
+class MemoryBackendNotConfigured(MemoryBackendError):
+    """Required configuration (API key, Neo4j URL, etc.) is missing."""
+
+
+class MemoryBackendUnavailable(MemoryBackendError):
+    """The backend is reachable but failed to serve the request."""
+
+
+class MemoryBackendRateLimited(MemoryBackendUnavailable):
+    """The backend rejected the call due to rate limiting."""
+
+
+class MemoryBackendQuotaExceeded(MemoryBackendUnavailable):
+    """The backend rejected the call because account quota is exhausted."""

--- a/backend/app/services/memory/factory.py
+++ b/backend/app/services/memory/factory.py
@@ -1,0 +1,84 @@
+"""Memory backend factory and process-level singleton.
+
+Selection happens via the ``MEMORY_BACKEND`` environment variable.
+The default is ``zep`` so existing deployments continue to work
+unchanged after this refactor lands. Switching to a self-hosted
+Graphiti is a pure configuration change.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Optional
+
+from .base import MemoryBackend
+from .exceptions import MemoryBackendNotConfigured
+
+_BACKEND_ENV = "MEMORY_BACKEND"
+_DEFAULT_BACKEND = "zep"
+
+_lock = threading.Lock()
+_singleton: Optional[MemoryBackend] = None
+
+
+def _import_zep_backend() -> type[MemoryBackend]:
+    from .zep_cloud_backend import ZepCloudBackend
+
+    return ZepCloudBackend
+
+
+def _import_graphiti_backend() -> type[MemoryBackend]:
+    from .graphiti_backend import GraphitiBackend
+
+    return GraphitiBackend
+
+
+_REGISTRY: dict[str, callable] = {
+    "zep": _import_zep_backend,
+    "zep_cloud": _import_zep_backend,
+    "graphiti": _import_graphiti_backend,
+}
+
+
+def build_memory_backend(name: Optional[str] = None) -> MemoryBackend:
+    """Construct a fresh :class:`MemoryBackend` instance.
+
+    Tests and one-off scripts use this to get an isolated backend.
+    Long-running services should prefer :func:`get_memory_backend`,
+    which returns a process-level singleton.
+    """
+    backend_name = (name or os.environ.get(_BACKEND_ENV) or _DEFAULT_BACKEND).lower()
+
+    loader = _REGISTRY.get(backend_name)
+    if loader is None:
+        raise MemoryBackendNotConfigured(
+            f"Unknown MEMORY_BACKEND={backend_name!r}; "
+            f"valid options: {', '.join(sorted(set(_REGISTRY)))}"
+        )
+    cls = loader()
+    return cls()
+
+
+def get_memory_backend() -> MemoryBackend:
+    """Return the process-level memory backend singleton.
+
+    First call constructs the backend, subsequent calls reuse it.
+    Thread-safe.
+    """
+    global _singleton
+    if _singleton is None:
+        with _lock:
+            if _singleton is None:
+                _singleton = build_memory_backend()
+    return _singleton
+
+
+def reset_memory_backend() -> None:
+    """Drop the singleton so the next call rebuilds.
+
+    Useful in tests and when env vars change at runtime.
+    """
+    global _singleton
+    with _lock:
+        _singleton = None

--- a/backend/app/services/memory/graphiti_backend.py
+++ b/backend/app/services/memory/graphiti_backend.py
@@ -1,0 +1,731 @@
+"""Self-hosted Graphiti implementation of :class:`MemoryBackend`.
+
+Talks to a local Neo4j database via the ``graphiti-core`` library so
+MiroFish can run with no external memory provider. Designed to be a
+drop-in replacement for :class:`ZepCloudBackend`: the same DTOs come
+out, the same ontology dict goes in, and the same call sites work.
+
+The Graphiti library is async-only. We hide that behind a private
+event loop running on a daemon thread, so callers continue to use a
+synchronous interface. One loop per backend instance keeps the cost
+of marshaling minimal.
+
+Environment variables (all read at construction time):
+
+* ``NEO4J_URI``       – default ``bolt://localhost:7687``
+* ``NEO4J_USER``      – default ``neo4j``
+* ``NEO4J_PASSWORD``  – default ``mirofish-local``
+* ``GRAPHITI_LLM_API_KEY``  – optional override; falls back to
+  ``LLM_API_KEY`` (the existing OpenRouter / OpenAI-compatible key)
+* ``GRAPHITI_LLM_BASE_URL`` – optional override; falls back to ``LLM_BASE_URL``
+* ``GRAPHITI_LLM_MODEL``    – optional override; falls back to ``LLM_MODEL_NAME``
+* ``GRAPHITI_EMBEDDING_MODEL`` – default ``text-embedding-3-small``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import uuid as uuid_lib
+from collections.abc import Iterator
+from concurrent.futures import Future
+from datetime import datetime, timezone
+from typing import Any, Literal, Optional
+
+from ...config import Config
+from ...utils.logger import get_logger
+from .base import (
+    Edge,
+    EpisodeInput,
+    EpisodeRef,
+    MemoryBackend,
+    Node,
+    OntologySpec,
+    SearchResult,
+)
+from .exceptions import (
+    MemoryBackendError,
+    MemoryBackendNotConfigured,
+    MemoryBackendUnavailable,
+)
+
+logger = get_logger("mirofish.memory.graphiti")
+
+_DEFAULT_NEO4J_URI = "bolt://localhost:7687"
+_DEFAULT_NEO4J_USER = "neo4j"
+_DEFAULT_NEO4J_PASSWORD = "mirofish-local"
+_DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
+_DEFAULT_LOCAL_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+# --------------------------------------------------------------------------
+# Async-to-sync adapter
+# --------------------------------------------------------------------------
+
+
+class _LoopThread:
+    """Owns a background asyncio event loop on a daemon thread.
+
+    Provides :meth:`run` which submits a coroutine and blocks on the
+    result. We keep one loop per backend instance so successive Cypher
+    queries reuse the same Neo4j connection pool.
+    """
+
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._run_loop, name="graphiti-loop", daemon=True
+        )
+        self._thread.start()
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def run(self, coro: Any, *, timeout: Optional[float] = None) -> Any:
+        """Submit a coroutine to the background loop and block on its result.
+
+        ``timeout`` (seconds) bounds the wait. ``None`` means wait
+        forever. Always pass a finite timeout from cleanup paths to
+        avoid hanging interpreter shutdown if the loop is wedged.
+        """
+        future: Future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result(timeout=timeout)
+
+    def close(self) -> None:
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=5)
+        try:
+            self._loop.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+# --------------------------------------------------------------------------
+# Pydantic ontology builders
+# --------------------------------------------------------------------------
+
+
+def _build_ontology_models(
+    ontology: OntologySpec,
+) -> tuple[dict[str, type], dict[str, type], dict[tuple[str, str], list[str]]]:
+    """Translate :class:`OntologySpec` into Graphiti-shaped types.
+
+    Returns ``(entity_types, edge_types, edge_type_map)`` where:
+
+    * ``entity_types`` maps type name → dynamic Pydantic model.
+    * ``edge_types`` maps relation name → dynamic Pydantic model.
+    * ``edge_type_map`` constrains which edges may exist between which
+      entity-type pairs (``(source, target) → [edge names]``).
+    """
+    from pydantic import BaseModel, Field
+
+    reserved = {"uuid", "name", "group_id", "name_embedding", "summary", "created_at"}
+
+    def safe_attr(name: str) -> str:
+        return f"entity_{name}" if name.lower() in reserved else name
+
+    entity_types: dict[str, type] = {}
+    for ent in ontology.entity_types:
+        attrs: dict[str, Any] = {"__doc__": ent.description or f"A {ent.name} entity."}
+        annotations: dict[str, Any] = {}
+        for a in ent.attributes:
+            key = safe_attr(a.name)
+            attrs[key] = Field(description=a.description or key, default=None)
+            annotations[key] = Optional[str]
+        attrs["__annotations__"] = annotations
+        entity_types[ent.name] = type(ent.name, (BaseModel,), attrs)
+
+    edge_types: dict[str, type] = {}
+    edge_type_map: dict[tuple[str, str], list[str]] = {}
+    for edge in ontology.edge_types:
+        attrs = {"__doc__": edge.description or f"A {edge.name} relationship."}
+        annotations = {}
+        for a in edge.attributes:
+            key = safe_attr(a.name)
+            attrs[key] = Field(description=a.description or key, default=None)
+            annotations[key] = Optional[str]
+        attrs["__annotations__"] = annotations
+        cls_name = "".join(w.capitalize() for w in edge.name.split("_"))
+        edge_types[edge.name] = type(cls_name, (BaseModel,), attrs)
+
+        for st in edge.source_targets:
+            edge_type_map.setdefault((st.source, st.target), []).append(edge.name)
+
+    return entity_types, edge_types, edge_type_map
+
+
+# --------------------------------------------------------------------------
+# Backend
+# --------------------------------------------------------------------------
+
+
+class GraphitiBackend(MemoryBackend):
+    """Self-hosted Graphiti + Neo4j-backed implementation."""
+
+    # Per-graph ontology cache: graph_id -> (entity_types, edge_types, edge_type_map)
+    _ontology_cache: dict[str, tuple[dict[str, type], dict[str, type], dict[tuple[str, str], list[str]]]]
+
+    def __init__(self) -> None:
+        self._neo4j_uri = os.environ.get("NEO4J_URI", _DEFAULT_NEO4J_URI)
+        self._neo4j_user = os.environ.get("NEO4J_USER", _DEFAULT_NEO4J_USER)
+        self._neo4j_password = os.environ.get(
+            "NEO4J_PASSWORD", _DEFAULT_NEO4J_PASSWORD
+        )
+
+        # Defer heavy imports until first construction so callers using
+        # the Zep backend never need graphiti-core installed.
+        try:
+            from graphiti_core import Graphiti
+        except ImportError as e:
+            raise MemoryBackendNotConfigured(
+                "graphiti-core is not installed. Run `uv add graphiti-core` "
+                "(or pip install graphiti-core) to use MEMORY_BACKEND=graphiti."
+            ) from e
+
+        self._loop = _LoopThread()
+        self._ontology_cache = {}
+
+        llm_client, embedder, cross_encoder = self._build_llm_clients()
+
+        try:
+            self._graphiti = Graphiti(
+                uri=self._neo4j_uri,
+                user=self._neo4j_user,
+                password=self._neo4j_password,
+                llm_client=llm_client,
+                embedder=embedder,
+                cross_encoder=cross_encoder,
+            )
+        except Exception as e:  # noqa: BLE001
+            raise MemoryBackendUnavailable(
+                f"Failed to connect to Neo4j at {self._neo4j_uri}: {e}"
+            ) from e
+
+        # Build indices / constraints on first use. This is idempotent
+        # and cheap when the schema already exists.
+        try:
+            self._loop.run(self._graphiti.build_indices_and_constraints())
+        except Exception as e:  # noqa: BLE001
+            logger.warning("build_indices_and_constraints failed (non-fatal): %s", e)
+
+        logger.info(
+            "GraphitiBackend ready: neo4j=%s user=%s", self._neo4j_uri, self._neo4j_user
+        )
+
+    # ------------------------------------------------------------------
+    # LLM / embedder configuration
+    # ------------------------------------------------------------------
+
+    def _build_llm_clients(self) -> tuple[Any, Any, Any]:
+        """Build LLM + embedder + cross-encoder clients all pointing at
+        our existing OpenAI-compatible setup, so operators don't need a
+        separate ``OPENAI_API_KEY``.
+
+        Returns ``(llm_client, embedder, cross_encoder)``. Any of them
+        may be ``None`` to fall back to Graphiti's library defaults
+        (which require ``OPENAI_API_KEY``).
+        """
+        api_key = (
+            os.environ.get("GRAPHITI_LLM_API_KEY")
+            or Config.LLM_API_KEY
+            or os.environ.get("OPENAI_API_KEY")
+        )
+        base_url = (
+            os.environ.get("GRAPHITI_LLM_BASE_URL")
+            or Config.LLM_BASE_URL
+            or "https://api.openai.com/v1"
+        )
+        model = (
+            os.environ.get("GRAPHITI_LLM_MODEL")
+            or Config.LLM_MODEL_NAME
+            or "gpt-4o-mini"
+        )
+        embedding_model = os.environ.get(
+            "GRAPHITI_EMBEDDING_MODEL", _DEFAULT_EMBEDDING_MODEL
+        )
+
+        if not api_key:
+            logger.warning(
+                "No LLM API key configured; Graphiti will fall back to "
+                "OPENAI_API_KEY environment variable for entity extraction."
+            )
+            return None, None, None
+
+        # Embedding source selection.
+        #
+        # Most OpenAI-compatible chat providers (OpenRouter included)
+        # do NOT expose ``/embeddings``. Default to a fully local
+        # sentence-transformers embedder so the self-hosted setup
+        # works without an external embedding key. Operators who do
+        # have a real embedding endpoint can opt back in by setting
+        # ``GRAPHITI_EMBEDDING_PROVIDER=openai``.
+        embedding_provider = os.environ.get(
+            "GRAPHITI_EMBEDDING_PROVIDER", "local"
+        ).lower()
+
+        try:
+            from graphiti_core.cross_encoder.openai_reranker_client import (
+                OpenAIRerankerClient,
+            )
+            from graphiti_core.llm_client.config import LLMConfig
+            from graphiti_core.llm_client.openai_generic_client import (
+                OpenAIGenericClient,
+            )
+
+            llm_config = LLMConfig(
+                api_key=api_key,
+                base_url=base_url,
+                model=model,
+            )
+            llm_client = OpenAIGenericClient(config=llm_config)
+
+            if embedding_provider == "openai":
+                from graphiti_core.embedder.openai import (
+                    OpenAIEmbedder,
+                    OpenAIEmbedderConfig,
+                )
+
+                embedder_config = OpenAIEmbedderConfig(
+                    api_key=api_key,
+                    base_url=base_url,
+                    embedding_model=embedding_model,
+                )
+                embedder = OpenAIEmbedder(config=embedder_config)
+            else:
+                from .local_embedder import (
+                    LocalEmbedderConfig,
+                    LocalSentenceTransformerEmbedder,
+                )
+
+                local_model = os.environ.get(
+                    "GRAPHITI_LOCAL_EMBEDDING_MODEL",
+                    _DEFAULT_LOCAL_EMBEDDING_MODEL,
+                )
+                embedder = LocalSentenceTransformerEmbedder(
+                    config=LocalEmbedderConfig(embedding_model=local_model)
+                )
+                logger.info(
+                    "Using local sentence-transformers embedder: %s", local_model
+                )
+
+            # The cross-encoder reranker also defaults to OpenAI direct,
+            # which fails for self-hosted users without OPENAI_API_KEY.
+            # Wire it through the same config so reranking uses our LLM.
+            cross_encoder = OpenAIRerankerClient(config=llm_config)
+
+            return llm_client, embedder, cross_encoder
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Could not build OpenAI-compatible Graphiti clients (%s); "
+                "falling back to library defaults.",
+                e,
+            )
+            return None, None, None
+
+    # ------------------------------------------------------------------
+    # Identification
+    # ------------------------------------------------------------------
+
+    def name(self) -> str:
+        return "graphiti"
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def create_graph(
+        self,
+        graph_id: str,
+        *,
+        display_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        # Graphiti has no explicit graph creation step — group_id is a
+        # property attached to nodes/edges at write time. This call is
+        # intentionally a no-op so the surrounding refactor does not
+        # need a special case.
+        logger.debug(
+            "Graphiti create_graph(%s) is a no-op; group_id assigned at write time",
+            graph_id,
+        )
+
+    def delete_graph(self, graph_id: str) -> None:
+        async def _delete() -> None:
+            for label in ("Entity", "Episodic", "Community"):
+                await self._graphiti.driver.execute_query(
+                    f"MATCH (n:{label} {{group_id: $group_id}}) DETACH DELETE n",
+                    group_id=graph_id,
+                )
+
+        try:
+            self._loop.run(_delete())
+        except Exception as e:  # noqa: BLE001
+            raise MemoryBackendUnavailable(f"delete_graph failed: {e}") from e
+        self._ontology_cache.pop(graph_id, None)
+
+    def set_ontology(self, graph_id: str, ontology: OntologySpec) -> None:
+        # Graphiti accepts ontology per-call to add_episode rather than
+        # storing it server-side. We cache the compiled types and apply
+        # them on every subsequent ingest.
+        self._ontology_cache[graph_id] = _build_ontology_models(ontology)
+
+    # ------------------------------------------------------------------
+    # Episode ingest
+    # ------------------------------------------------------------------
+
+    def add_episode(self, graph_id: str, episode: EpisodeInput) -> EpisodeRef:
+        return self._add_episode_blocking(graph_id, episode)
+
+    def add_episodes_bulk(
+        self, graph_id: str, episodes: list[EpisodeInput]
+    ) -> list[EpisodeRef]:
+        # Graphiti's add_episode_bulk has stricter input shape; the
+        # naive per-episode loop is identical in cost because the
+        # library serialises LLM extraction internally anyway, and
+        # this approach avoids a partial-failure cliff.
+        return [self._add_episode_blocking(graph_id, ep) for ep in episodes]
+
+    def _add_episode_blocking(self, graph_id: str, episode: EpisodeInput) -> EpisodeRef:
+        from graphiti_core.nodes import EpisodeType as GraphitiEpisodeType
+
+        type_map = {
+            "text": GraphitiEpisodeType.text,
+            "message": GraphitiEpisodeType.message,
+            "json": GraphitiEpisodeType.json,
+        }
+        graphiti_type = type_map.get(episode.episode_type, GraphitiEpisodeType.message)
+
+        ontology = self._ontology_cache.get(graph_id)
+        entity_types = ontology[0] if ontology else None
+        edge_types = ontology[1] if ontology else None
+        edge_type_map = ontology[2] if ontology else None
+
+        ref_time = episode.reference_time or datetime.now(timezone.utc)
+        episode_name = f"episode-{uuid_lib.uuid4().hex[:8]}"
+
+        async def _ingest() -> Any:
+            # graphiti-core 0.9.x supports entity_types only; the
+            # edge_types / edge_type_map parameters were added in 0.20+
+            # which is currently incompatible with camel-oasis. Edge
+            # type guidance is therefore communicated to the LLM only
+            # via the system prompts that include the ontology summary.
+            return await self._graphiti.add_episode(
+                name=episode_name,
+                episode_body=episode.content,
+                source=graphiti_type,
+                source_description=episode.source_description or "",
+                reference_time=ref_time,
+                group_id=graph_id,
+                entity_types=entity_types,
+            )
+
+        try:
+            result = self._loop.run(_ingest())
+        except Exception as e:  # noqa: BLE001
+            raise MemoryBackendUnavailable(f"add_episode failed: {e}") from e
+
+        ep_node = getattr(result, "episode", None) or result
+        ep_uuid = getattr(ep_node, "uuid", "") or ""
+        return EpisodeRef(
+            uuid=ep_uuid,
+            processed=True,  # Graphiti is synchronous — done when returned
+            content=episode.content,
+            source_description=episode.source_description,
+            created_at=ref_time.isoformat(),
+        )
+
+    def get_episode(self, episode_uuid: str) -> Optional[EpisodeRef]:
+        async def _get() -> Optional[dict[str, Any]]:
+            records, _, _ = await self._graphiti.driver.execute_query(
+                """
+                MATCH (e:Episodic {uuid: $uuid})
+                RETURN e.uuid AS uuid, e.content AS content,
+                       e.source_description AS source_description,
+                       e.created_at AS created_at
+                """,
+                uuid=episode_uuid,
+            )
+            return records[0] if records else None
+
+        try:
+            row = self._loop.run(_get())
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Graphiti get_episode(%s) failed: %s", episode_uuid, e)
+            return None
+        if not row:
+            return None
+        return EpisodeRef(
+            uuid=row.get("uuid") or "",
+            processed=True,
+            content=row.get("content"),
+            source_description=row.get("source_description"),
+            created_at=str(row.get("created_at")) if row.get("created_at") else None,
+        )
+
+    # ------------------------------------------------------------------
+    # Graph reads
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        graph_id: str,
+        query: str,
+        *,
+        limit: int = 10,
+        scope: Literal["edges", "nodes"] = "edges",
+    ) -> SearchResult:
+        async def _search() -> Any:
+            return await self._graphiti.search(
+                query=query,
+                group_ids=[graph_id],
+                num_results=limit,
+            )
+
+        try:
+            edge_objs = self._loop.run(_search())
+        except Exception as e:  # noqa: BLE001
+            raise MemoryBackendUnavailable(f"search failed: {e}") from e
+
+        edges = [self._edge_from_graphiti(e) for e in (edge_objs or [])]
+        # Graphiti's basic search returns edges only. If the caller
+        # asked for nodes specifically, derive them from the edge
+        # endpoints to satisfy the contract.
+        nodes: list[Node] = []
+        if scope == "nodes" and edges:
+            uuids = {uid for e in edges for uid in (e.source_node_uuid, e.target_node_uuid) if uid}
+            for uid in uuids:
+                node = self.get_node(uid)
+                if node is not None:
+                    nodes.append(node)
+        return SearchResult(edges=edges, nodes=nodes)
+
+    def get_node(self, node_uuid: str) -> Optional[Node]:
+        async def _get() -> Optional[dict[str, Any]]:
+            records, _, _ = await self._graphiti.driver.execute_query(
+                """
+                MATCH (n:Entity {uuid: $uuid})
+                RETURN n.uuid AS uuid, n.name AS name, labels(n) AS labels,
+                       n.summary AS summary, n.attributes AS attributes,
+                       n.created_at AS created_at
+                """,
+                uuid=node_uuid,
+            )
+            return records[0] if records else None
+
+        try:
+            row = self._loop.run(_get())
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Graphiti get_node(%s) failed: %s", node_uuid, e)
+            return None
+        return self._node_from_record(row) if row else None
+
+    def get_nodes_by_graph(
+        self, graph_id: str, *, page_size: int = 100, max_items: int = 2000
+    ) -> Iterator[Node]:
+        async def _all() -> list[dict[str, Any]]:
+            records, _, _ = await self._graphiti.driver.execute_query(
+                """
+                MATCH (n:Entity {group_id: $group_id})
+                RETURN n.uuid AS uuid, n.name AS name, labels(n) AS labels,
+                       n.summary AS summary, n.attributes AS attributes,
+                       n.created_at AS created_at
+                LIMIT $max
+                """,
+                group_id=graph_id,
+                max=max_items,
+            )
+            return list(records)
+
+        try:
+            rows = self._loop.run(_all())
+        except Exception as e:  # noqa: BLE001
+            raise MemoryBackendUnavailable(f"get_nodes_by_graph failed: {e}") from e
+
+        for row in rows:
+            node = self._node_from_record(row)
+            if node is not None:
+                yield node
+
+    def get_edges_by_graph(
+        self, graph_id: str, *, page_size: int = 100
+    ) -> Iterator[Edge]:
+        async def _all() -> list[dict[str, Any]]:
+            records, _, _ = await self._graphiti.driver.execute_query(
+                """
+                MATCH (s:Entity)-[r:RELATES_TO {group_id: $group_id}]->(t:Entity)
+                RETURN r.uuid AS uuid, r.name AS name, r.fact AS fact,
+                       r.fact_type AS fact_type,
+                       s.uuid AS source_node_uuid, t.uuid AS target_node_uuid,
+                       r.attributes AS attributes,
+                       r.created_at AS created_at, r.valid_at AS valid_at,
+                       r.invalid_at AS invalid_at, r.expired_at AS expired_at,
+                       r.episodes AS episodes
+                """,
+                group_id=graph_id,
+            )
+            return list(records)
+
+        try:
+            rows = self._loop.run(_all())
+        except Exception as e:  # noqa: BLE001
+            raise MemoryBackendUnavailable(f"get_edges_by_graph failed: {e}") from e
+
+        for row in rows:
+            yield self._edge_from_record(row)
+
+    def get_node_edges(self, node_uuid: str) -> list[Edge]:
+        async def _all() -> list[dict[str, Any]]:
+            records, _, _ = await self._graphiti.driver.execute_query(
+                """
+                MATCH (n:Entity {uuid: $uuid})-[r:RELATES_TO]-(other:Entity)
+                RETURN r.uuid AS uuid, r.name AS name, r.fact AS fact,
+                       r.fact_type AS fact_type,
+                       startNode(r).uuid AS source_node_uuid,
+                       endNode(r).uuid AS target_node_uuid,
+                       r.attributes AS attributes,
+                       r.created_at AS created_at, r.valid_at AS valid_at,
+                       r.invalid_at AS invalid_at, r.expired_at AS expired_at,
+                       r.episodes AS episodes
+                """,
+                uuid=node_uuid,
+            )
+            return list(records)
+
+        try:
+            rows = self._loop.run(_all())
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Graphiti get_node_edges(%s) failed: %s", node_uuid, e)
+            return []
+        return [self._edge_from_record(row) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Record / SDK → DTO mappers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _node_from_record(row: dict[str, Any]) -> Optional[Node]:
+        if not row or not row.get("uuid"):
+            return None
+        attributes = row.get("attributes") or {}
+        if isinstance(attributes, str):
+            # Neo4j may return JSON-as-string for free-form attribute maps
+            import json
+
+            try:
+                attributes = json.loads(attributes)
+            except Exception:  # noqa: BLE001
+                attributes = {}
+        labels = row.get("labels") or []
+        return Node(
+            uuid=row["uuid"],
+            name=row.get("name") or "",
+            labels=list(labels),
+            summary=row.get("summary") or "",
+            attributes=dict(attributes),
+            created_at=str(row["created_at"]) if row.get("created_at") else None,
+        )
+
+    @staticmethod
+    def _edge_from_record(row: dict[str, Any]) -> Edge:
+        attributes = row.get("attributes") or {}
+        if isinstance(attributes, str):
+            import json
+
+            try:
+                attributes = json.loads(attributes)
+            except Exception:  # noqa: BLE001
+                attributes = {}
+
+        episodes_raw = row.get("episodes")
+        if episodes_raw is None:
+            episode_list: list[str] = []
+        elif isinstance(episodes_raw, list):
+            episode_list = [str(e) for e in episodes_raw]
+        else:
+            episode_list = [str(episodes_raw)]
+
+        return Edge(
+            uuid=row.get("uuid") or "",
+            name=row.get("name") or "",
+            fact=row.get("fact") or "",
+            fact_type=row.get("fact_type") or row.get("name") or "",
+            source_node_uuid=row.get("source_node_uuid") or "",
+            target_node_uuid=row.get("target_node_uuid") or "",
+            attributes=dict(attributes),
+            created_at=str(row["created_at"]) if row.get("created_at") else None,
+            valid_at=str(row["valid_at"]) if row.get("valid_at") else None,
+            invalid_at=str(row["invalid_at"]) if row.get("invalid_at") else None,
+            expired_at=str(row["expired_at"]) if row.get("expired_at") else None,
+            episodes=episode_list,
+        )
+
+    @staticmethod
+    def _edge_from_graphiti(edge_obj: Any) -> Edge:
+        episodes = getattr(edge_obj, "episodes", None) or []
+        if not isinstance(episodes, list):
+            episodes = [episodes]
+        attributes = getattr(edge_obj, "attributes", None) or {}
+        return Edge(
+            uuid=getattr(edge_obj, "uuid", "") or "",
+            name=getattr(edge_obj, "name", "") or "",
+            fact=getattr(edge_obj, "fact", "") or "",
+            fact_type=getattr(edge_obj, "fact_type", None)
+            or getattr(edge_obj, "name", None)
+            or "",
+            source_node_uuid=getattr(edge_obj, "source_node_uuid", "") or "",
+            target_node_uuid=getattr(edge_obj, "target_node_uuid", "") or "",
+            attributes=dict(attributes),
+            created_at=str(getattr(edge_obj, "created_at", None))
+            if getattr(edge_obj, "created_at", None)
+            else None,
+            valid_at=str(getattr(edge_obj, "valid_at", None))
+            if getattr(edge_obj, "valid_at", None)
+            else None,
+            invalid_at=str(getattr(edge_obj, "invalid_at", None))
+            if getattr(edge_obj, "invalid_at", None)
+            else None,
+            expired_at=str(getattr(edge_obj, "expired_at", None))
+            if getattr(edge_obj, "expired_at", None)
+            else None,
+            episodes=[str(e) for e in episodes],
+        )
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the background loop and Neo4j driver.
+
+        Call explicitly when shutting down a long-running process.
+        Cleanup is bounded so interpreter shutdown cannot hang on a
+        wedged event loop.
+        """
+        try:
+            if hasattr(self, "_graphiti"):
+                self._loop.run(self._graphiti.close(), timeout=3.0)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            if hasattr(self, "_loop"):
+                self._loop.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def __del__(self) -> None:
+        # Best-effort cleanup. We deliberately do NOT await the
+        # async ``close`` here — interpreter shutdown can race with
+        # the background loop and a hung await would freeze the whole
+        # process for the user. The OS will reclaim Neo4j sockets
+        # cleanly when the process exits.
+        try:
+            if hasattr(self, "_loop"):
+                # Stop the loop without joining the thread or running
+                # async cleanup. Daemon thread dies with the process.
+                self._loop._loop.call_soon_threadsafe(  # type: ignore[attr-defined]
+                    self._loop._loop.stop  # type: ignore[attr-defined]
+                )
+        except Exception:
+            pass

--- a/backend/app/services/memory/local_embedder.py
+++ b/backend/app/services/memory/local_embedder.py
@@ -1,0 +1,107 @@
+"""Local sentence-transformers embedder for Graphiti.
+
+Avoids the need for an external embedding API (OpenAI, Voyage, etc).
+The default model ``all-MiniLM-L6-v2`` is ~80 MB, produces 384-d
+vectors, and runs comfortably on CPU. It is already a transitive
+dependency of ``camel-oasis`` so no extra install is required.
+
+The class implements Graphiti's :class:`EmbedderClient` interface so
+it is a drop-in replacement for :class:`OpenAIEmbedder` /
+:class:`VoyageEmbedder`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from collections.abc import Iterable
+from typing import Optional
+
+from graphiti_core.embedder.client import EmbedderClient, EmbedderConfig
+from pydantic import Field
+
+
+DEFAULT_LOCAL_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+class LocalEmbedderConfig(EmbedderConfig):
+    """Config for :class:`LocalSentenceTransformerEmbedder`."""
+
+    embedding_model: str = Field(default=DEFAULT_LOCAL_MODEL)
+    device: Optional[str] = Field(default=None)  # e.g. "cpu", "mps", "cuda"
+    # Override the parent's frozen embedding_dim so we can match the
+    # actual model's output dimensionality (MiniLM-L6 is 384, not 1024).
+    embedding_dim: int = Field(default=384, frozen=False)
+
+
+class LocalSentenceTransformerEmbedder(EmbedderClient):
+    """Embedder backed by a local sentence-transformers model.
+
+    Loads the model lazily on first use so import is cheap. Model
+    inference runs on a worker thread (via :func:`asyncio.to_thread`)
+    because sentence-transformers is synchronous.
+    """
+
+    _MODEL_CACHE: dict[str, object] = {}
+    _CACHE_LOCK = threading.Lock()
+
+    def __init__(self, config: Optional[LocalEmbedderConfig] = None) -> None:
+        self.config = config or LocalEmbedderConfig()
+
+    def _get_model(self):  # noqa: ANN202 — return type depends on import
+        """Load the underlying model once per process, lazily."""
+        model_name = self.config.embedding_model
+        with LocalSentenceTransformerEmbedder._CACHE_LOCK:
+            if model_name not in LocalSentenceTransformerEmbedder._MODEL_CACHE:
+                from sentence_transformers import SentenceTransformer
+
+                # HF transformers can spew progress bars on first download;
+                # silence that for a clean backend log.
+                os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
+
+                LocalSentenceTransformerEmbedder._MODEL_CACHE[model_name] = (
+                    SentenceTransformer(model_name, device=self.config.device)
+                )
+                # Reflect the real output dimensionality on the config
+                # so Graphiti's similarity queries get a coherent number.
+                model = LocalSentenceTransformerEmbedder._MODEL_CACHE[model_name]
+                try:
+                    actual_dim = int(model.get_sentence_embedding_dimension())
+                    if actual_dim and actual_dim != self.config.embedding_dim:
+                        self.config.embedding_dim = actual_dim
+                except Exception:
+                    pass
+        return LocalSentenceTransformerEmbedder._MODEL_CACHE[model_name]
+
+    async def create(
+        self,
+        input_data: str | list[str] | Iterable[int] | Iterable[Iterable[int]],
+    ) -> list[float]:
+        """Encode ``input_data`` and return a single embedding vector.
+
+        Graphiti calls this once per text snippet; the contract is
+        "first vector of the result". When input is a list, only the
+        first item's vector is returned (matches the OpenAI embedder).
+        """
+        # Normalise to a list of strings.
+        if isinstance(input_data, str):
+            texts: list[str] = [input_data]
+        elif isinstance(input_data, list):
+            texts = [item if isinstance(item, str) else str(item) for item in input_data]
+        else:  # an iterable of ints / sub-iterables — we only support text
+            texts = [str(input_data)]
+
+        model = self._get_model()
+        vectors = await asyncio.to_thread(
+            model.encode,
+            texts,
+            convert_to_numpy=True,
+            normalize_embeddings=True,
+            show_progress_bar=False,
+        )
+        # encode([text]) returns a 2D numpy array shape (1, dim)
+        first = vectors[0]
+        # Truncate / pad to the configured dim — Graphiti stores fixed-
+        # length vectors so the similarity index keeps working.
+        return [float(x) for x in first[: self.config.embedding_dim]]

--- a/backend/app/services/memory/zep_cloud_backend.py
+++ b/backend/app/services/memory/zep_cloud_backend.py
@@ -1,0 +1,440 @@
+"""Zep Cloud implementation of :class:`MemoryBackend`.
+
+Wraps the ``zep_cloud`` Python SDK so callers depend only on the
+abstract interface in :mod:`app.services.memory.base`. Behavior is
+preserved bit-for-bit from the previous direct-Zep code paths:
+pagination via uuid cursor, dynamic Pydantic ontology classes built
+from a dict spec, and exponential-backoff retries on transient
+errors.
+
+Configuration: requires ``ZEP_API_KEY`` to be set in the environment
+(or in :class:`app.config.Config`).
+"""
+
+from __future__ import annotations
+
+import time
+import warnings
+from collections.abc import Callable, Iterator
+from typing import Any, Literal, Optional, TypeVar
+
+from ...config import Config
+from ...utils.logger import get_logger
+from .base import (
+    Edge,
+    EpisodeInput,
+    EpisodeRef,
+    MemoryBackend,
+    Node,
+    OntologySpec,
+    SearchResult,
+)
+from .exceptions import (
+    MemoryBackendError,
+    MemoryBackendNotConfigured,
+    MemoryBackendQuotaExceeded,
+    MemoryBackendRateLimited,
+    MemoryBackendUnavailable,
+)
+
+logger = get_logger("mirofish.memory.zep_cloud")
+
+_DEFAULT_PAGE_SIZE = 100
+_DEFAULT_MAX_NODES = 2000
+_DEFAULT_MAX_RETRIES = 3
+_DEFAULT_RETRY_DELAY = 2.0
+
+T = TypeVar("T")
+
+
+def _get_uuid(obj: Any) -> str:
+    """Zep returns ``uuid_`` on most objects but occasionally ``uuid``."""
+    return getattr(obj, "uuid_", None) or getattr(obj, "uuid", "") or ""
+
+
+def _stringify(value: Any) -> Optional[str]:
+    return str(value) if value is not None else None
+
+
+def _classify_zep_error(exc: BaseException) -> MemoryBackendError:
+    """Translate a ``zep_cloud`` exception into a typed memory error.
+
+    The cloud SDK raises HTTP-flavoured exceptions whose text contains
+    ``"rate limit"`` for 429s and ``"episode usage limit"`` for the
+    free-tier quota cap. Anything else maps to the generic unavailable
+    error so callers can handle transient failure uniformly.
+    """
+    text = str(exc).lower()
+    if "rate limit" in text or "429" in text:
+        return MemoryBackendRateLimited(str(exc))
+    if "episode usage limit" in text or "quota" in text:
+        return MemoryBackendQuotaExceeded(str(exc))
+    return MemoryBackendUnavailable(str(exc))
+
+
+class ZepCloudBackend(MemoryBackend):
+    """Zep Cloud-backed implementation of :class:`MemoryBackend`."""
+
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        self._api_key = api_key or Config.ZEP_API_KEY
+        if not self._api_key:
+            raise MemoryBackendNotConfigured(
+                "ZEP_API_KEY is not set; cannot initialise ZepCloudBackend"
+            )
+        # Defer the import so installations that switch to graphiti
+        # are not forced to keep zep_cloud installed.
+        from zep_cloud.client import Zep
+
+        self._client = Zep(api_key=self._api_key)
+        # Dependent helpers (zep_paging) still expect the raw SDK
+        # client; expose it under a clearly underscored name so the
+        # leak is obvious if anyone reaches for it from new code.
+        self._raw_client = self._client
+
+    # ------------------------------------------------------------------
+    # Identification
+    # ------------------------------------------------------------------
+
+    def name(self) -> str:
+        return "zep"
+
+    @property
+    def raw_client(self) -> Any:
+        """Expose the underlying ``zep_cloud`` client.
+
+        Provided as a transitional escape hatch for code paths that
+        have not yet been ported to the abstract interface. New code
+        MUST NOT use this.
+        """
+        return self._raw_client
+
+    # ------------------------------------------------------------------
+    # Internal retry helper (mirrors the pattern previously inlined in
+    # ZepEntityReader and ZepGraphMemoryUpdater)
+    # ------------------------------------------------------------------
+
+    def _call_with_retry(
+        self,
+        func: Callable[[], T],
+        *,
+        operation: str,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+        initial_delay: float = _DEFAULT_RETRY_DELAY,
+    ) -> T:
+        last_exc: Optional[BaseException] = None
+        delay = initial_delay
+        for attempt in range(max_retries):
+            try:
+                return func()
+            except Exception as e:  # noqa: BLE001 — Zep SDK uses bare Exception
+                last_exc = e
+                if attempt < max_retries - 1:
+                    logger.warning(
+                        "Zep %s attempt %d failed: %s; retrying in %.1fs",
+                        operation,
+                        attempt + 1,
+                        str(e)[:120],
+                        delay,
+                    )
+                    time.sleep(delay)
+                    delay *= 2
+                else:
+                    logger.error(
+                        "Zep %s failed after %d attempts: %s",
+                        operation,
+                        max_retries,
+                        str(e),
+                    )
+        assert last_exc is not None
+        raise _classify_zep_error(last_exc) from last_exc
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def create_graph(
+        self,
+        graph_id: str,
+        *,
+        display_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        try:
+            self._client.graph.create(
+                graph_id=graph_id,
+                name=display_name or graph_id,
+                description=description or "MiroFish Social Simulation Graph",
+            )
+        except Exception as e:  # noqa: BLE001
+            raise _classify_zep_error(e) from e
+
+    def delete_graph(self, graph_id: str) -> None:
+        try:
+            self._client.graph.delete(graph_id=graph_id)
+        except Exception as e:  # noqa: BLE001
+            raise _classify_zep_error(e) from e
+
+    def set_ontology(self, graph_id: str, ontology: OntologySpec) -> None:
+        from typing import Optional as _Optional
+
+        from pydantic import Field
+        from zep_cloud import EntityEdgeSourceTarget
+        from zep_cloud.external_clients.ontology import (
+            EdgeModel,
+            EntityModel,
+            EntityText,
+        )
+
+        # Pydantic v2 emits a noisy UserWarning when Field(default=None)
+        # is used dynamically; the Zep SDK requires it. Suppress.
+        warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
+
+        reserved = {
+            "uuid",
+            "name",
+            "group_id",
+            "name_embedding",
+            "summary",
+            "created_at",
+        }
+
+        def safe_attr_name(attr: str) -> str:
+            return f"entity_{attr}" if attr.lower() in reserved else attr
+
+        entity_classes: dict[str, Any] = {}
+        for ent in ontology.entity_types:
+            attrs: dict[str, Any] = {"__doc__": ent.description or f"A {ent.name} entity."}
+            annotations: dict[str, Any] = {}
+            for a in ent.attributes:
+                key = safe_attr_name(a.name)
+                attrs[key] = Field(description=a.description or key, default=None)
+                annotations[key] = _Optional[EntityText]
+            attrs["__annotations__"] = annotations
+            cls = type(ent.name, (EntityModel,), attrs)
+            cls.__doc__ = ent.description
+            entity_classes[ent.name] = cls
+
+        edge_definitions: dict[str, Any] = {}
+        for edge in ontology.edge_types:
+            attrs = {"__doc__": edge.description or f"A {edge.name} relationship."}
+            annotations = {}
+            for a in edge.attributes:
+                key = safe_attr_name(a.name)
+                attrs[key] = Field(description=a.description or key, default=None)
+                annotations[key] = _Optional[str]
+            attrs["__annotations__"] = annotations
+            cls_name = "".join(w.capitalize() for w in edge.name.split("_"))
+            edge_cls = type(cls_name, (EdgeModel,), attrs)
+            edge_cls.__doc__ = edge.description
+
+            source_targets = [
+                EntityEdgeSourceTarget(source=st.source, target=st.target)
+                for st in edge.source_targets
+            ]
+            if source_targets:
+                edge_definitions[edge.name] = (edge_cls, source_targets)
+
+        if not entity_classes and not edge_definitions:
+            return
+
+        try:
+            self._client.graph.set_ontology(
+                graph_ids=[graph_id],
+                entities=entity_classes or None,
+                edges=edge_definitions or None,
+            )
+        except Exception as e:  # noqa: BLE001
+            raise _classify_zep_error(e) from e
+
+    # ------------------------------------------------------------------
+    # Episode ingest
+    # ------------------------------------------------------------------
+
+    def add_episode(self, graph_id: str, episode: EpisodeInput) -> EpisodeRef:
+        from zep_cloud import EpisodeData
+
+        try:
+            result = self._client.graph.add(
+                graph_id=graph_id,
+                data=episode.content,
+                type=episode.episode_type,
+                source_description=episode.source_description or None,
+            )
+        except Exception as e:  # noqa: BLE001
+            raise _classify_zep_error(e) from e
+
+        return EpisodeRef(
+            uuid=_get_uuid(result),
+            processed=bool(getattr(result, "processed", False)),
+            content=episode.content,
+            source_description=episode.source_description,
+        )
+
+    def add_episodes_bulk(
+        self, graph_id: str, episodes: list[EpisodeInput]
+    ) -> list[EpisodeRef]:
+        from zep_cloud import EpisodeData
+
+        if not episodes:
+            return []
+
+        payload = [
+            EpisodeData(
+                data=ep.content,
+                type=ep.episode_type,
+                source_description=ep.source_description or None,
+            )
+            for ep in episodes
+        ]
+
+        try:
+            batch = self._client.graph.add_batch(graph_id=graph_id, episodes=payload)
+        except Exception as e:  # noqa: BLE001
+            raise _classify_zep_error(e) from e
+
+        if not batch:
+            return []
+
+        refs: list[EpisodeRef] = []
+        for ep_obj, source in zip(batch, episodes):
+            refs.append(
+                EpisodeRef(
+                    uuid=_get_uuid(ep_obj),
+                    processed=bool(getattr(ep_obj, "processed", False)),
+                    content=source.content,
+                    source_description=source.source_description,
+                )
+            )
+        return refs
+
+    def get_episode(self, episode_uuid: str) -> Optional[EpisodeRef]:
+        try:
+            ep = self._client.graph.episode.get(uuid_=episode_uuid)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Zep get_episode(%s) failed: %s", episode_uuid, e)
+            return None
+        if not ep:
+            return None
+        return EpisodeRef(
+            uuid=_get_uuid(ep),
+            processed=bool(getattr(ep, "processed", False)),
+            content=getattr(ep, "data", None) or getattr(ep, "content", None),
+            source_description=getattr(ep, "source_description", None),
+            created_at=_stringify(getattr(ep, "created_at", None)),
+        )
+
+    # ------------------------------------------------------------------
+    # Graph reads
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        graph_id: str,
+        query: str,
+        *,
+        limit: int = 10,
+        scope: Literal["edges", "nodes"] = "edges",
+    ) -> SearchResult:
+        try:
+            raw = self._call_with_retry(
+                lambda: self._client.graph.search(
+                    graph_id=graph_id,
+                    query=query,
+                    limit=limit,
+                    scope=scope,
+                ),
+                operation=f"search(graph={graph_id}, scope={scope})",
+            )
+        except MemoryBackendError:
+            raise
+
+        edges = [self._edge_from_sdk(e) for e in (getattr(raw, "edges", None) or [])]
+        nodes = [self._node_from_sdk(n) for n in (getattr(raw, "nodes", None) or [])]
+        return SearchResult(edges=edges, nodes=nodes)
+
+    def get_node(self, node_uuid: str) -> Optional[Node]:
+        try:
+            raw = self._call_with_retry(
+                lambda: self._client.graph.node.get(uuid_=node_uuid),
+                operation=f"get_node({node_uuid[:8]}…)",
+            )
+        except MemoryBackendError:
+            return None
+        if raw is None:
+            return None
+        return self._node_from_sdk(raw)
+
+    def get_nodes_by_graph(
+        self, graph_id: str, *, page_size: int = _DEFAULT_PAGE_SIZE, max_items: int = _DEFAULT_MAX_NODES
+    ) -> Iterator[Node]:
+        # Re-use the existing battle-tested pager so behavior is
+        # identical to the legacy code path.
+        from ...utils.zep_paging import fetch_all_nodes
+
+        nodes = fetch_all_nodes(
+            self._client,
+            graph_id,
+            page_size=page_size,
+            max_items=max_items,
+        )
+        for n in nodes:
+            yield self._node_from_sdk(n)
+
+    def get_edges_by_graph(
+        self, graph_id: str, *, page_size: int = _DEFAULT_PAGE_SIZE
+    ) -> Iterator[Edge]:
+        from ...utils.zep_paging import fetch_all_edges
+
+        edges = fetch_all_edges(self._client, graph_id, page_size=page_size)
+        for e in edges:
+            yield self._edge_from_sdk(e)
+
+    def get_node_edges(self, node_uuid: str) -> list[Edge]:
+        try:
+            raw = self._call_with_retry(
+                lambda: self._client.graph.node.get_entity_edges(node_uuid=node_uuid),
+                operation=f"get_node_edges({node_uuid[:8]}…)",
+            )
+        except MemoryBackendError:
+            return []
+        return [self._edge_from_sdk(e) for e in (raw or [])]
+
+    # ------------------------------------------------------------------
+    # SDK → DTO mappers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _node_from_sdk(raw: Any) -> Node:
+        return Node(
+            uuid=_get_uuid(raw),
+            name=getattr(raw, "name", "") or "",
+            labels=list(getattr(raw, "labels", None) or []),
+            summary=getattr(raw, "summary", "") or "",
+            attributes=dict(getattr(raw, "attributes", None) or {}),
+            created_at=_stringify(getattr(raw, "created_at", None)),
+        )
+
+    @staticmethod
+    def _edge_from_sdk(raw: Any) -> Edge:
+        episodes = getattr(raw, "episodes", None) or getattr(raw, "episode_ids", None)
+        if episodes is None:
+            episode_list: list[str] = []
+        elif isinstance(episodes, list):
+            episode_list = [str(e) for e in episodes]
+        else:
+            episode_list = [str(episodes)]
+
+        return Edge(
+            uuid=_get_uuid(raw),
+            name=getattr(raw, "name", "") or "",
+            fact=getattr(raw, "fact", "") or "",
+            fact_type=getattr(raw, "fact_type", None) or getattr(raw, "name", None) or "",
+            source_node_uuid=getattr(raw, "source_node_uuid", "") or "",
+            target_node_uuid=getattr(raw, "target_node_uuid", "") or "",
+            attributes=dict(getattr(raw, "attributes", None) or {}),
+            created_at=_stringify(getattr(raw, "created_at", None)),
+            valid_at=_stringify(getattr(raw, "valid_at", None)),
+            invalid_at=_stringify(getattr(raw, "invalid_at", None)),
+            expired_at=_stringify(getattr(raw, "expired_at", None)),
+            episodes=episode_list,
+        )

--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 
 from openai import OpenAI
-from zep_cloud.client import Zep
+from .memory import MemoryBackend, get_memory_backend
 
 from ..config import Config
 from ..utils.logger import get_logger
@@ -198,16 +198,17 @@ class OasisProfileGenerator:
             base_url=self.base_url
         )
         
-        # Zep客户端用于检索丰富上下文
+        # Memory backend for context enrichment. Lazy / tolerant: if
+        # the backend cannot be constructed (e.g. ZEP_API_KEY not set
+        # but MEMORY_BACKEND=zep was selected) we degrade gracefully.
         self.zep_api_key = zep_api_key or Config.ZEP_API_KEY
-        self.zep_client = None
+        self.memory_backend: Optional[MemoryBackend] = None
         self.graph_id = graph_id
-        
-        if self.zep_api_key:
-            try:
-                self.zep_client = Zep(api_key=self.zep_api_key)
-            except Exception as e:
-                logger.warning(f"Zep客户端初始化失败: {e}")
+
+        try:
+            self.memory_backend = get_memory_backend()
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Memory backend not available: {e}")
     
     def generate_profile_from_entity(
         self, 
@@ -298,95 +299,66 @@ class OasisProfileGenerator:
         """
         import concurrent.futures
         
-        if not self.zep_client:
+        if self.memory_backend is None:
             return {"facts": [], "node_summaries": [], "context": ""}
-        
+
         entity_name = entity.name
-        
-        results = {
-            "facts": [],
-            "node_summaries": [],
-            "context": ""
-        }
-        
-        # 必须有graph_id才能进行搜索
+        results = {"facts": [], "node_summaries": [], "context": ""}
+
         if not self.graph_id:
-            logger.debug(f"跳过Zep检索：未设置graph_id")
+            logger.debug("Skipping memory search: no graph_id set")
             return results
-        
+
         comprehensive_query = t('progress.zepSearchQuery', name=entity_name)
-        
+
+        def search_with_retry(scope: str, limit: int):
+            """Backend search with exponential-backoff retry."""
+            max_retries = 3
+            delay = 2.0
+            for attempt in range(max_retries):
+                try:
+                    return self.memory_backend.search(
+                        graph_id=self.graph_id,
+                        query=comprehensive_query,
+                        limit=limit,
+                        scope=scope,  # type: ignore[arg-type]
+                    )
+                except Exception as e:
+                    if attempt < max_retries - 1:
+                        logger.debug(
+                            f"Memory backend {scope} search attempt {attempt + 1} failed: {str(e)[:80]}, retrying..."
+                        )
+                        time.sleep(delay)
+                        delay *= 2
+                    else:
+                        logger.debug(
+                            f"Memory backend {scope} search failed after {max_retries} attempts: {e}"
+                        )
+            return None
+
         def search_edges():
-            """搜索边（事实/关系）- 带重试机制"""
-            max_retries = 3
-            last_exception = None
-            delay = 2.0
-            
-            for attempt in range(max_retries):
-                try:
-                    return self.zep_client.graph.search(
-                        query=comprehensive_query,
-                        graph_id=self.graph_id,
-                        limit=30,
-                        scope="edges",
-                        reranker="rrf"
-                    )
-                except Exception as e:
-                    last_exception = e
-                    if attempt < max_retries - 1:
-                        logger.debug(f"Zep边搜索第 {attempt + 1} 次失败: {str(e)[:80]}, 重试中...")
-                        time.sleep(delay)
-                        delay *= 2
-                    else:
-                        logger.debug(f"Zep边搜索在 {max_retries} 次尝试后仍失败: {e}")
-            return None
-        
+            return search_with_retry("edges", 30)
+
         def search_nodes():
-            """搜索节点（实体摘要）- 带重试机制"""
-            max_retries = 3
-            last_exception = None
-            delay = 2.0
-            
-            for attempt in range(max_retries):
-                try:
-                    return self.zep_client.graph.search(
-                        query=comprehensive_query,
-                        graph_id=self.graph_id,
-                        limit=20,
-                        scope="nodes",
-                        reranker="rrf"
-                    )
-                except Exception as e:
-                    last_exception = e
-                    if attempt < max_retries - 1:
-                        logger.debug(f"Zep节点搜索第 {attempt + 1} 次失败: {str(e)[:80]}, 重试中...")
-                        time.sleep(delay)
-                        delay *= 2
-                    else:
-                        logger.debug(f"Zep节点搜索在 {max_retries} 次尝试后仍失败: {e}")
-            return None
-        
+            return search_with_retry("nodes", 20)
+
         try:
-            # 并行执行edges和nodes搜索
             with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                 edge_future = executor.submit(search_edges)
                 node_future = executor.submit(search_nodes)
-                
-                # 获取结果
+
                 edge_result = edge_future.result(timeout=30)
                 node_result = node_future.result(timeout=30)
-            
-            # 处理边搜索结果
+
             all_facts = set()
-            if edge_result and hasattr(edge_result, 'edges') and edge_result.edges:
+            if edge_result and edge_result.edges:
                 for edge in edge_result.edges:
-                    if hasattr(edge, 'fact') and edge.fact:
+                    if edge.fact:
                         all_facts.add(edge.fact)
             results["facts"] = list(all_facts)
-            
-            # 处理节点搜索结果
+
             all_summaries = set()
-            if node_result and hasattr(node_result, 'nodes') and node_result.nodes:
+            if node_result and node_result.nodes:
                 for node in node_result.nodes:
                     if hasattr(node, 'summary') and node.summary:
                         all_summaries.add(node.summary)

--- a/backend/app/services/parent_heartbeat.py
+++ b/backend/app/services/parent_heartbeat.py
@@ -1,0 +1,158 @@
+"""Parent-process liveness heartbeat.
+
+This module is part of the subprocess watchdog mechanism that
+prevents simulation children from leaking when the Flask backend
+dies ungracefully (SIGKILL, system sleep, parent crash, OS-level
+shutdown without atexit running).
+
+Design
+------
+
+* On backend startup, :func:`start` spawns a daemon thread that
+  every :data:`HEARTBEAT_INTERVAL_SECONDS` writes the current
+  monotonic timestamp to a file under the system temp directory.
+
+* On subprocess spawn, the simulation runner passes the Flask
+  process PID and the heartbeat file path to the child via CLI
+  flags. The child runs a parallel watchdog that aborts itself
+  if either (a) the parent PID disappears or (b) the heartbeat
+  file is older than :data:`STALE_THRESHOLD_SECONDS`.
+
+* The heartbeat file is named with the Flask PID so multiple
+  backend instances on the same machine do not collide and each
+  child knows exactly which file belongs to its parent.
+
+The mechanism is best-effort and intentionally simple — no IPC,
+no ports, no shared memory. Just a file timestamp and a PID
+liveness check.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from ..utils.logger import get_logger
+
+logger = get_logger("mirofish.parent_heartbeat")
+
+HEARTBEAT_INTERVAL_SECONDS = 5
+"""How often the parent refreshes the heartbeat timestamp."""
+
+STALE_THRESHOLD_SECONDS = 30
+"""Age beyond which the child treats the parent as dead.
+
+Must be comfortably greater than :data:`HEARTBEAT_INTERVAL_SECONDS`
+so brief stalls (GC pause, system suspend resume) do not kill
+healthy simulations.
+"""
+
+_FILE_PREFIX = "mirofish-parent-"
+
+_state_lock = threading.Lock()
+_started = False
+_heartbeat_path: Optional[Path] = None
+_thread: Optional[threading.Thread] = None
+_stop_event: Optional[threading.Event] = None
+
+
+def _heartbeat_file_for(pid: int) -> Path:
+    """Return the canonical heartbeat path for a given parent PID."""
+    return Path(tempfile.gettempdir()) / f"{_FILE_PREFIX}{pid}.heartbeat"
+
+
+def get_heartbeat_path() -> Optional[str]:
+    """Return the heartbeat file path managed by this process, if any."""
+    if _heartbeat_path is None:
+        return None
+    return str(_heartbeat_path)
+
+
+def get_parent_pid() -> int:
+    """Return the PID that subprocesses should monitor."""
+    return os.getpid()
+
+
+def _heartbeat_loop(stop_event: threading.Event, path: Path) -> None:
+    """Daemon-thread body that refreshes the heartbeat file."""
+    logger.info(
+        "Parent heartbeat started: pid=%d path=%s interval=%ds",
+        os.getpid(),
+        path,
+        HEARTBEAT_INTERVAL_SECONDS,
+    )
+    while not stop_event.is_set():
+        try:
+            # Touch the file with the current wall-clock timestamp so
+            # children can verify freshness via mtime alone.
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(f"{time.time():.3f}\n")
+        except Exception as exc:  # noqa: BLE001 — keep the loop alive
+            logger.warning("Heartbeat write failed (non-fatal): %s", exc)
+        if stop_event.wait(HEARTBEAT_INTERVAL_SECONDS):
+            break
+
+    # Best-effort cleanup so the next backend instance starts clean.
+    try:
+        path.unlink(missing_ok=True)
+    except Exception:  # noqa: BLE001
+        pass
+    logger.info("Parent heartbeat stopped")
+
+
+def start() -> Optional[str]:
+    """Start the heartbeat thread (idempotent).
+
+    Returns the heartbeat file path so callers can pass it to
+    children. If the thread is already running, returns the existing
+    path without restarting.
+    """
+    global _started, _heartbeat_path, _thread, _stop_event
+
+    with _state_lock:
+        if _started:
+            return str(_heartbeat_path) if _heartbeat_path else None
+
+        _heartbeat_path = _heartbeat_file_for(os.getpid())
+        _stop_event = threading.Event()
+        _thread = threading.Thread(
+            target=_heartbeat_loop,
+            args=(_stop_event, _heartbeat_path),
+            name="parent-heartbeat",
+            daemon=True,
+        )
+        _thread.start()
+        _started = True
+
+        # Also remove the heartbeat file on graceful shutdown so a
+        # follow-up child cannot race on a stale timestamp.
+        atexit.register(stop)
+
+        return str(_heartbeat_path)
+
+
+def stop() -> None:
+    """Stop the heartbeat thread and clean up the file."""
+    global _started, _heartbeat_path, _thread, _stop_event
+
+    with _state_lock:
+        if not _started:
+            return
+        if _stop_event is not None:
+            _stop_event.set()
+        if _thread is not None:
+            _thread.join(timeout=2)
+        if _heartbeat_path is not None:
+            try:
+                _heartbeat_path.unlink(missing_ok=True)
+            except Exception:  # noqa: BLE001
+                pass
+        _started = False
+        _heartbeat_path = None
+        _thread = None
+        _stop_event = None

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -414,14 +414,27 @@ class SimulationRunner:
             #   simulation.log        - 主进程日志
             
             cmd = [
-                sys.executable,  # Python解释器
+                sys.executable,  # Python interpreter
                 script_path,
-                "--config", config_path,  # 使用完整配置文件路径
+                "--config", config_path,
             ]
-            
-            # 如果指定了最大轮数，添加到命令行参数
+
             if max_rounds is not None and max_rounds > 0:
                 cmd.extend(["--max-rounds", str(max_rounds)])
+
+            # Watchdog plumbing: tell the child what its parent PID is
+            # and where the parent's liveness heartbeat lives, so it
+            # can abort itself if the backend dies ungracefully and
+            # stop burning LLM credits.
+            try:
+                from . import parent_heartbeat
+                parent_pid = parent_heartbeat.get_parent_pid()
+                hb_path = parent_heartbeat.get_heartbeat_path()
+                cmd.extend(["--parent-pid", str(parent_pid)])
+                if hb_path:
+                    cmd.extend(["--parent-heartbeat", hb_path])
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Could not wire parent watchdog: %s", e)
             
             # 创建主日志文件，避免 stdout/stderr 管道缓冲区满导致进程阻塞
             main_log_path = os.path.join(sim_dir, "simulation.log")
@@ -497,22 +510,49 @@ class SimulationRunner:
         twitter_position = 0
         reddit_position = 0
         
+        # Pull a handle to the cost-cap event for this simulation.
+        # If the cap is exceeded by an LLM call mid-run we want to
+        # terminate the simulation gracefully without waiting for
+        # the next round to finish.
         try:
-            while process.poll() is None:  # 进程仍在运行
-                # 读取 Twitter 动作日志
+            from .usage_tracker import get_usage_tracker
+            _cap_event = get_usage_tracker().get_cap_event(simulation_id)
+        except Exception:  # noqa: BLE001
+            _cap_event = None
+
+        try:
+            while process.poll() is None:  # process still alive
                 if os.path.exists(twitter_actions_log):
                     twitter_position = cls._read_action_log(
                         twitter_actions_log, twitter_position, state, "twitter"
                     )
-                
-                # 读取 Reddit 动作日志
+
                 if os.path.exists(reddit_actions_log):
                     reddit_position = cls._read_action_log(
                         reddit_actions_log, reddit_position, state, "reddit"
                     )
-                
-                # 更新状态
+
                 cls._save_run_state(state)
+
+                # Cost-cap auto-abort. We terminate the subprocess so
+                # the user never wakes up to a blown budget.
+                if _cap_event is not None and _cap_event.is_set():
+                    logger.warning(
+                        "Cost cap breached for %s; terminating simulation",
+                        simulation_id,
+                    )
+                    state.error = "Cost cap breached — simulation auto-stopped"
+                    cls._save_run_state(state)
+                    try:
+                        cls._terminate_process(process, simulation_id)
+                    except Exception as _e:  # noqa: BLE001
+                        logger.error(
+                            "Auto-abort termination failed for %s: %s",
+                            simulation_id,
+                            _e,
+                        )
+                    break
+
                 time.sleep(2)
             
             # 进程结束后，最后读取一次日志

--- a/backend/app/services/usage_tracker.py
+++ b/backend/app/services/usage_tracker.py
@@ -1,0 +1,329 @@
+"""Live LLM-usage / cost tracker.
+
+This service counts tokens, requests, and cumulative cost across
+LLM calls so the UI can show a live "you've spent $X.YZ on this run"
+bar. It is the user-visible safety net against runaway spend that
+complements the subprocess watchdog (which catches *technical*
+leaks; this catches *runtime* over-spend).
+
+Design
+------
+
+* In-process singleton, thread-safe via a single :class:`RLock`.
+* Per-simulation totals plus a global "all simulations" total.
+* Cost is taken straight from the LLM response when the provider
+  returns it (OpenRouter does, in ``usage.cost``); otherwise we
+  approximate from a small static price table keyed by model id.
+* :meth:`record_usage` is best-effort — never raises. The caller
+  is the LLM hot path, and a tracker bug must not break a real
+  user's simulation.
+* :class:`UsageBudget` enforces optional spend caps. When the cap
+  is exceeded the tracker flips an event flag that the runner
+  polls and uses to abort the simulation gracefully.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from ..utils.logger import get_logger
+
+logger = get_logger("mirofish.usage_tracker")
+
+
+# ---------------------------------------------------------------------------
+# Static price table for providers that do NOT return usage.cost.
+# Numbers are USD per 1M tokens, taken from OpenRouter's public listing.
+# Best-effort and easy to update; absent entries fall back to 0.
+# ---------------------------------------------------------------------------
+_PRICE_TABLE_USD_PER_M: dict[str, tuple[float, float]] = {
+    # OpenRouter Qwen family
+    "qwen/qwen-plus":          (0.26, 0.78),
+    "qwen/qwen-turbo":         (0.03, 0.13),
+    "qwen/qwen-max":           (1.04, 4.16),
+    "qwen/qwen3-max":          (0.78, 3.90),
+    "qwen/qwen3.6-plus":       (0.33, 1.95),
+    "qwen/qwen-plus-2025-07-28": (0.26, 0.78),
+    # Common alternatives
+    "anthropic/claude-haiku-4.5":   (1.00, 5.00),
+    "anthropic/claude-sonnet-4.5":  (3.00, 15.00),
+    "google/gemini-2.0-flash-001":  (0.10, 0.40),
+    "openai/gpt-4o-mini":           (0.15, 0.60),
+    "meta-llama/llama-3.3-70b-instruct": (0.59, 0.79),
+}
+
+
+def _estimate_cost_usd(
+    model: str, prompt_tokens: int, completion_tokens: int
+) -> float:
+    """Rough cost estimate when the provider does not return one."""
+    rates = _PRICE_TABLE_USD_PER_M.get(model)
+    if rates is None:
+        return 0.0
+    return (
+        prompt_tokens * rates[0] / 1_000_000
+        + completion_tokens * rates[1] / 1_000_000
+    )
+
+
+# ---------------------------------------------------------------------------
+# DTOs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UsageSnapshot:
+    """A point-in-time snapshot of usage for one simulation (or global)."""
+
+    simulation_id: Optional[str]
+    model: Optional[str] = None
+    requests: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cost_usd: float = 0.0
+    started_at: float = field(default_factory=time.time)
+    last_updated_at: float = field(default_factory=time.time)
+    cap_usd: Optional[float] = None
+    over_cap: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "simulation_id": self.simulation_id,
+            "model": self.model,
+            "requests": self.requests,
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+            "cost_usd": round(self.cost_usd, 6),
+            "started_at": self.started_at,
+            "last_updated_at": self.last_updated_at,
+            "elapsed_seconds": int(self.last_updated_at - self.started_at),
+            "cap_usd": self.cap_usd,
+            "over_cap": self.over_cap,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Tracker
+# ---------------------------------------------------------------------------
+
+
+class UsageTracker:
+    """Process-wide singleton that aggregates LLM usage."""
+
+    _instance: Optional["UsageTracker"] = None
+    _instance_lock = threading.Lock()
+
+    @classmethod
+    def instance(cls) -> "UsageTracker":
+        """Return the process-wide tracker (lazy)."""
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        # Per-simulation snapshots, keyed by simulation_id.
+        self._per_sim: dict[str, UsageSnapshot] = {}
+        # The "global" snapshot tallies usage that was recorded
+        # without a simulation_id (e.g. graph-build-time calls).
+        self._global = UsageSnapshot(simulation_id=None)
+        # Cap configuration: read once at init from env, can be
+        # overridden per-simulation via :meth:`set_cap`.
+        try:
+            self._default_cap_usd: Optional[float] = float(
+                os.environ.get("MAX_SIMULATION_COST_USD", "")
+            )
+        except (TypeError, ValueError):
+            self._default_cap_usd = None
+        # Per-simulation event flags that the runner polls to know
+        # when to abort.
+        self._cap_breached_events: dict[str, threading.Event] = {}
+
+    # ------------------------------------------------------------------
+    # Public recording API — safe to call from anywhere
+    # ------------------------------------------------------------------
+
+    def record_usage(
+        self,
+        *,
+        simulation_id: Optional[str],
+        model: Optional[str],
+        prompt_tokens: int = 0,
+        completion_tokens: int = 0,
+        cost_usd: Optional[float] = None,
+    ) -> None:
+        """Record a single LLM call's usage. Never raises."""
+        try:
+            total = prompt_tokens + completion_tokens
+            if cost_usd is None:
+                cost_usd = _estimate_cost_usd(
+                    model or "", prompt_tokens, completion_tokens
+                )
+            with self._lock:
+                snap = self._snapshot_for(simulation_id)
+                snap.requests += 1
+                snap.prompt_tokens += prompt_tokens
+                snap.completion_tokens += completion_tokens
+                snap.total_tokens += total
+                snap.cost_usd += float(cost_usd or 0.0)
+                snap.last_updated_at = time.time()
+                if model and not snap.model:
+                    snap.model = model
+
+                # Also tally on the global snapshot so a single
+                # endpoint can show "total LLM spend ever".
+                if simulation_id is not None:
+                    self._global.requests += 1
+                    self._global.prompt_tokens += prompt_tokens
+                    self._global.completion_tokens += completion_tokens
+                    self._global.total_tokens += total
+                    self._global.cost_usd += float(cost_usd or 0.0)
+                    self._global.last_updated_at = time.time()
+
+                # Cap check.
+                effective_cap = (
+                    snap.cap_usd if snap.cap_usd is not None else self._default_cap_usd
+                )
+                if (
+                    effective_cap is not None
+                    and effective_cap > 0
+                    and snap.cost_usd >= effective_cap
+                    and not snap.over_cap
+                ):
+                    snap.over_cap = True
+                    if simulation_id:
+                        ev = self._cap_breached_events.setdefault(
+                            simulation_id, threading.Event()
+                        )
+                        ev.set()
+                    logger.warning(
+                        "Cost cap breached for simulation %s: $%.4f >= $%.2f",
+                        simulation_id,
+                        snap.cost_usd,
+                        effective_cap,
+                    )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("usage record failed (suppressed): %s", exc)
+
+    def record_from_openai_response(
+        self,
+        response: Any,
+        *,
+        simulation_id: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> None:
+        """Convenience: pull token + cost fields off an OpenAI-shaped object."""
+        try:
+            usage = getattr(response, "usage", None)
+            if usage is None:
+                return
+            prompt = int(getattr(usage, "prompt_tokens", 0) or 0)
+            completion = int(getattr(usage, "completion_tokens", 0) or 0)
+            # OpenRouter returns "cost" inside usage; the OpenAI SDK
+            # exposes it as a model attribute so both forms work.
+            cost = getattr(usage, "cost", None)
+            if cost is None and hasattr(usage, "model_extra"):
+                cost = (usage.model_extra or {}).get("cost")
+            self.record_usage(
+                simulation_id=simulation_id,
+                model=model or getattr(response, "model", None),
+                prompt_tokens=prompt,
+                completion_tokens=completion,
+                cost_usd=float(cost) if cost is not None else None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("record_from_openai_response failed (suppressed): %s", exc)
+
+    # ------------------------------------------------------------------
+    # Read API
+    # ------------------------------------------------------------------
+
+    def snapshot(self, simulation_id: Optional[str]) -> UsageSnapshot:
+        """Return a copy of the current snapshot for ``simulation_id``."""
+        with self._lock:
+            snap = self._per_sim.get(simulation_id) if simulation_id else self._global
+            if snap is None:
+                snap = UsageSnapshot(simulation_id=simulation_id)
+            # Shallow copy
+            return UsageSnapshot(**{**snap.__dict__})
+
+    def global_snapshot(self) -> UsageSnapshot:
+        """Return the cross-simulation total snapshot."""
+        with self._lock:
+            return UsageSnapshot(**{**self._global.__dict__})
+
+    def all_simulations(self) -> list[UsageSnapshot]:
+        """Return a copy of every per-simulation snapshot."""
+        with self._lock:
+            return [UsageSnapshot(**{**s.__dict__}) for s in self._per_sim.values()]
+
+    def cap_breached(self, simulation_id: str) -> bool:
+        """Return True if the cap for ``simulation_id`` has been hit."""
+        with self._lock:
+            snap = self._per_sim.get(simulation_id)
+            return bool(snap and snap.over_cap)
+
+    def get_cap_event(self, simulation_id: str) -> threading.Event:
+        """Return an :class:`Event` set when the cap is breached.
+
+        The simulation runner can ``wait()`` on this with a timeout
+        instead of polling :meth:`cap_breached`.
+        """
+        with self._lock:
+            return self._cap_breached_events.setdefault(
+                simulation_id, threading.Event()
+            )
+
+    # ------------------------------------------------------------------
+    # Cap configuration
+    # ------------------------------------------------------------------
+
+    def set_cap(self, simulation_id: str, cap_usd: Optional[float]) -> None:
+        """Set / override the cost cap for one simulation."""
+        with self._lock:
+            snap = self._snapshot_for(simulation_id)
+            snap.cap_usd = cap_usd
+            snap.over_cap = bool(
+                cap_usd is not None and cap_usd > 0 and snap.cost_usd >= cap_usd
+            )
+
+    def reset(self, simulation_id: Optional[str] = None) -> None:
+        """Drop the snapshot for one simulation, or all if ``None``."""
+        with self._lock:
+            if simulation_id is None:
+                self._per_sim.clear()
+                self._global = UsageSnapshot(simulation_id=None)
+                self._cap_breached_events.clear()
+            else:
+                self._per_sim.pop(simulation_id, None)
+                self._cap_breached_events.pop(simulation_id, None)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _snapshot_for(self, simulation_id: Optional[str]) -> UsageSnapshot:
+        if simulation_id is None:
+            return self._global
+        snap = self._per_sim.get(simulation_id)
+        if snap is None:
+            snap = UsageSnapshot(
+                simulation_id=simulation_id,
+                cap_usd=self._default_cap_usd,
+            )
+            self._per_sim[simulation_id] = snap
+        return snap
+
+
+# Convenience module-level alias so callers don't have to remember the class.
+def get_usage_tracker() -> UsageTracker:
+    return UsageTracker.instance()

--- a/backend/app/services/zep_entity_reader.py
+++ b/backend/app/services/zep_entity_reader.py
@@ -1,17 +1,17 @@
-"""
-Zep实体读取与过滤服务
-从Zep图谱中读取节点，筛选出符合预定义实体类型的节点
+"""Entity reader / filter service.
+
+Reads nodes from the active memory graph and surfaces only those that
+match the user-defined entity types. Backend-agnostic: works with both
+Zep Cloud and self-hosted Graphiti via the abstract memory layer.
 """
 
 import time
 from typing import Dict, Any, List, Optional, Set, Callable, TypeVar
 from dataclasses import dataclass, field
 
-from zep_cloud.client import Zep
-
 from ..config import Config
 from ..utils.logger import get_logger
-from ..utils.zep_paging import fetch_all_nodes, fetch_all_edges
+from .memory import MemoryBackend, get_memory_backend
 
 logger = get_logger('mirofish.zep_entity_reader')
 
@@ -78,12 +78,13 @@ class ZepEntityReader:
     3. 获取每个实体的相关边和关联节点信息
     """
     
-    def __init__(self, api_key: Optional[str] = None):
-        self.api_key = api_key or Config.ZEP_API_KEY
-        if not self.api_key:
-            raise ValueError("ZEP_API_KEY 未配置")
-        
-        self.client = Zep(api_key=self.api_key)
+    def __init__(self, backend: Optional[MemoryBackend] = None):
+        # Tolerate the legacy positional ``api_key`` form during migration.
+        if isinstance(backend, str):  # type: ignore[unreachable]
+            import os
+            os.environ.setdefault("ZEP_API_KEY", backend)
+            backend = None
+        self.backend: MemoryBackend = backend or get_memory_backend()
     
     def _call_with_retry(
         self, 
@@ -125,92 +126,58 @@ class ZepEntityReader:
         raise last_exception
     
     def get_all_nodes(self, graph_id: str) -> List[Dict[str, Any]]:
-        """
-        获取图谱的所有节点（分页获取）
-
-        Args:
-            graph_id: 图谱ID
-
-        Returns:
-            节点列表
-        """
-        logger.info(f"获取图谱 {graph_id} 的所有节点...")
-
-        nodes = fetch_all_nodes(self.client, graph_id)
-
-        nodes_data = []
-        for node in nodes:
-            nodes_data.append({
-                "uuid": getattr(node, 'uuid_', None) or getattr(node, 'uuid', ''),
-                "name": node.name or "",
-                "labels": node.labels or [],
-                "summary": node.summary or "",
-                "attributes": node.attributes or {},
-            })
-
-        logger.info(f"共获取 {len(nodes_data)} 个节点")
+        """Fetch every node in the graph as plain dicts."""
+        logger.info(f"Fetching all nodes for graph {graph_id}...")
+        nodes = self.backend.get_all_nodes(graph_id)
+        nodes_data = [
+            {
+                "uuid": n.uuid,
+                "name": n.name,
+                "labels": list(n.labels),
+                "summary": n.summary,
+                "attributes": dict(n.attributes),
+            }
+            for n in nodes
+        ]
+        logger.info(f"Fetched {len(nodes_data)} nodes")
         return nodes_data
 
     def get_all_edges(self, graph_id: str) -> List[Dict[str, Any]]:
-        """
-        获取图谱的所有边（分页获取）
-
-        Args:
-            graph_id: 图谱ID
-
-        Returns:
-            边列表
-        """
-        logger.info(f"获取图谱 {graph_id} 的所有边...")
-
-        edges = fetch_all_edges(self.client, graph_id)
-
-        edges_data = []
-        for edge in edges:
-            edges_data.append({
-                "uuid": getattr(edge, 'uuid_', None) or getattr(edge, 'uuid', ''),
-                "name": edge.name or "",
-                "fact": edge.fact or "",
-                "source_node_uuid": edge.source_node_uuid,
-                "target_node_uuid": edge.target_node_uuid,
-                "attributes": edge.attributes or {},
-            })
-
-        logger.info(f"共获取 {len(edges_data)} 条边")
+        """Fetch every edge in the graph as plain dicts."""
+        logger.info(f"Fetching all edges for graph {graph_id}...")
+        edges = self.backend.get_all_edges(graph_id)
+        edges_data = [
+            {
+                "uuid": e.uuid,
+                "name": e.name,
+                "fact": e.fact,
+                "source_node_uuid": e.source_node_uuid,
+                "target_node_uuid": e.target_node_uuid,
+                "attributes": dict(e.attributes),
+            }
+            for e in edges
+        ]
+        logger.info(f"Fetched {len(edges_data)} edges")
         return edges_data
     
     def get_node_edges(self, node_uuid: str) -> List[Dict[str, Any]]:
-        """
-        获取指定节点的所有相关边（带重试机制）
-        
-        Args:
-            node_uuid: 节点UUID
-            
-        Returns:
-            边列表
-        """
+        """Return every edge incident to ``node_uuid`` as plain dicts."""
         try:
-            # 使用重试机制调用Zep API
-            edges = self._call_with_retry(
-                func=lambda: self.client.graph.node.get_entity_edges(node_uuid=node_uuid),
-                operation_name=f"获取节点边(node={node_uuid[:8]}...)"
-            )
-            
-            edges_data = []
-            for edge in edges:
-                edges_data.append({
-                    "uuid": getattr(edge, 'uuid_', None) or getattr(edge, 'uuid', ''),
-                    "name": edge.name or "",
-                    "fact": edge.fact or "",
-                    "source_node_uuid": edge.source_node_uuid,
-                    "target_node_uuid": edge.target_node_uuid,
-                    "attributes": edge.attributes or {},
-                })
-            
-            return edges_data
+            edges = self.backend.get_node_edges(node_uuid)
         except Exception as e:
-            logger.warning(f"获取节点 {node_uuid} 的边失败: {str(e)}")
+            logger.warning(f"Failed to fetch edges for node {node_uuid}: {e}")
             return []
+        return [
+            {
+                "uuid": e.uuid,
+                "name": e.name,
+                "fact": e.fact,
+                "source_node_uuid": e.source_node_uuid,
+                "target_node_uuid": e.target_node_uuid,
+                "attributes": dict(e.attributes),
+            }
+            for e in edges
+        ]
     
     def filter_defined_entities(
         self, 
@@ -346,26 +313,19 @@ class ZepEntityReader:
             EntityNode或None
         """
         try:
-            # 使用重试机制获取节点
-            node = self._call_with_retry(
-                func=lambda: self.client.graph.node.get(uuid_=entity_uuid),
-                operation_name=f"获取节点详情(uuid={entity_uuid[:8]}...)"
-            )
-            
-            if not node:
+            node = self.backend.get_node(entity_uuid)
+            if node is None:
                 return None
-            
-            # 获取节点的边
+
+            # Fetch the node's edges and the rest of the graph for
+            # cross-referencing endpoints.
             edges = self.get_node_edges(entity_uuid)
-            
-            # 获取所有节点用于关联查找
             all_nodes = self.get_all_nodes(graph_id)
             node_map = {n["uuid"]: n for n in all_nodes}
-            
-            # 处理相关边和节点
+
             related_edges = []
-            related_node_uuids = set()
-            
+            related_node_uuids: Set[str] = set()
+
             for edge in edges:
                 if edge["source_node_uuid"] == entity_uuid:
                     related_edges.append({
@@ -383,31 +343,30 @@ class ZepEntityReader:
                         "source_node_uuid": edge["source_node_uuid"],
                     })
                     related_node_uuids.add(edge["source_node_uuid"])
-            
-            # 获取关联节点信息
+
             related_nodes = []
             for related_uuid in related_node_uuids:
-                if related_uuid in node_map:
-                    related_node = node_map[related_uuid]
+                related_node = node_map.get(related_uuid)
+                if related_node is not None:
                     related_nodes.append({
                         "uuid": related_node["uuid"],
                         "name": related_node["name"],
                         "labels": related_node["labels"],
                         "summary": related_node.get("summary", ""),
                     })
-            
+
             return EntityNode(
-                uuid=getattr(node, 'uuid_', None) or getattr(node, 'uuid', ''),
-                name=node.name or "",
-                labels=node.labels or [],
-                summary=node.summary or "",
-                attributes=node.attributes or {},
+                uuid=node.uuid,
+                name=node.name,
+                labels=list(node.labels),
+                summary=node.summary,
+                attributes=dict(node.attributes),
                 related_edges=related_edges,
                 related_nodes=related_nodes,
             )
-            
+
         except Exception as e:
-            logger.error(f"获取实体 {entity_uuid} 失败: {str(e)}")
+            logger.error(f"Failed to fetch entity {entity_uuid}: {e}")
             return None
     
     def get_entities_by_type(

--- a/backend/app/services/zep_graph_memory_updater.py
+++ b/backend/app/services/zep_graph_memory_updater.py
@@ -12,7 +12,11 @@ from dataclasses import dataclass
 from datetime import datetime
 from queue import Queue, Empty
 
-from zep_cloud.client import Zep
+from .memory import EpisodeInput, MemoryBackend, get_memory_backend
+from .memory.exceptions import (
+    MemoryBackendQuotaExceeded,
+    MemoryBackendRateLimited,
+)
 
 from ..config import Config
 from ..utils.logger import get_logger
@@ -229,21 +233,19 @@ class ZepGraphMemoryUpdater:
     MAX_RETRIES = 3
     RETRY_DELAY = 2  # 秒
     
-    def __init__(self, graph_id: str, api_key: Optional[str] = None):
-        """
-        初始化更新器
-        
-        Args:
-            graph_id: Zep图谱ID
-            api_key: Zep API Key（可选，默认从配置读取）
+    def __init__(self, graph_id: str, backend: Optional[MemoryBackend] = None):
+        """Construct the updater bound to a specific memory graph.
+
+        ``backend`` may be passed explicitly for tests; in production
+        the process-wide memory backend singleton is used.
         """
         self.graph_id = graph_id
-        self.api_key = api_key or Config.ZEP_API_KEY
-        
-        if not self.api_key:
-            raise ValueError("ZEP_API_KEY未配置")
-        
-        self.client = Zep(api_key=self.api_key)
+        # Tolerate the legacy ``api_key`` form during migration.
+        if isinstance(backend, str):  # type: ignore[unreachable]
+            import os
+            os.environ.setdefault("ZEP_API_KEY", backend)
+            backend = None
+        self.backend: MemoryBackend = backend or get_memory_backend()
         
         # 活动队列
         self._activity_queue: Queue = Queue()
@@ -408,28 +410,41 @@ class ZepGraphMemoryUpdater:
         episode_texts = [activity.to_episode_text() for activity in activities]
         combined_text = "\n".join(episode_texts)
         
-        # 带重试的发送
+        episode = EpisodeInput(content=combined_text, episode_type="text")
+
         for attempt in range(self.MAX_RETRIES):
             try:
-                self.client.graph.add(
-                    graph_id=self.graph_id,
-                    type="text",
-                    data=combined_text
-                )
-                
+                self.backend.add_episode(self.graph_id, episode)
+
                 self._total_sent += 1
                 self._total_items_sent += len(activities)
                 display_name = self._get_platform_display_name(platform)
-                logger.info(f"成功批量发送 {len(activities)} 条{display_name}活动到图谱 {self.graph_id}")
-                logger.debug(f"批量内容预览: {combined_text[:200]}...")
+                logger.info(
+                    f"Pushed {len(activities)} {display_name} activities to graph {self.graph_id}"
+                )
+                logger.debug(f"Batch preview: {combined_text[:200]}...")
                 return
-                
-            except Exception as e:
+
+            except (MemoryBackendQuotaExceeded, MemoryBackendRateLimited) as e:
+                # Retry transient throttling but record at warning level
+                # so the operator notices when the cloud free tier is
+                # being hit in a long simulation.
                 if attempt < self.MAX_RETRIES - 1:
-                    logger.warning(f"批量发送到Zep失败 (尝试 {attempt + 1}/{self.MAX_RETRIES}): {e}")
+                    logger.warning(
+                        f"Memory backend throttled batch send (attempt {attempt + 1}/{self.MAX_RETRIES}): {e}"
+                    )
                     time.sleep(self.RETRY_DELAY * (attempt + 1))
                 else:
-                    logger.error(f"批量发送到Zep失败，已重试{self.MAX_RETRIES}次: {e}")
+                    logger.error(
+                        f"Memory backend rejected batch after {self.MAX_RETRIES} attempts: {e}"
+                    )
+                    self._failed_count += 1
+            except Exception as e:
+                if attempt < self.MAX_RETRIES - 1:
+                    logger.warning(f"Batch send failed (attempt {attempt + 1}/{self.MAX_RETRIES}): {e}")
+                    time.sleep(self.RETRY_DELAY * (attempt + 1))
+                else:
+                    logger.error(f"Batch send failed after {self.MAX_RETRIES} attempts: {e}")
                     self._failed_count += 1
     
     def _flush_remaining(self):

--- a/backend/app/services/zep_tools.py
+++ b/backend/app/services/zep_tools.py
@@ -13,13 +13,14 @@ import json
 from typing import Dict, Any, List, Optional
 from dataclasses import dataclass, field
 
-from zep_cloud.client import Zep
+from .memory import MemoryBackend, get_memory_backend
 
 from ..config import Config
 from ..utils.logger import get_logger
 from ..utils.llm_client import LLMClient
 from ..utils.locale import get_locale, t
-from ..utils.zep_paging import fetch_all_nodes, fetch_all_edges
+# Note: zep_paging is now an internal helper of ZepCloudBackend; node /
+# edge listing for any backend goes through the abstract MemoryBackend.
 
 logger = get_logger('mirofish.zep_tools')
 
@@ -422,13 +423,18 @@ class ZepToolsService:
     MAX_RETRIES = 3
     RETRY_DELAY = 2.0
     
-    def __init__(self, api_key: Optional[str] = None, llm_client: Optional[LLMClient] = None):
-        self.api_key = api_key or Config.ZEP_API_KEY
-        if not self.api_key:
-            raise ValueError("ZEP_API_KEY 未配置")
-        
-        self.client = Zep(api_key=self.api_key)
-        # LLM客户端用于InsightForge生成子问题
+    def __init__(
+        self,
+        backend: Optional[MemoryBackend] = None,
+        llm_client: Optional[LLMClient] = None,
+    ):
+        # Tolerate the legacy positional ``api_key`` form during migration.
+        if isinstance(backend, str):  # type: ignore[unreachable]
+            import os
+            os.environ.setdefault("ZEP_API_KEY", backend)
+            backend = None
+        self.backend: MemoryBackend = backend or get_memory_backend()
+        # LLM client is used by InsightForge for sub-question generation.
         self._llm_client = llm_client
         logger.info(t("console.zepToolsInitialized"))
     
@@ -485,62 +491,57 @@ class ZepToolsService:
         """
         logger.info(t("console.graphSearch", graphId=graph_id, query=query[:50]))
         
-        # 尝试使用Zep Cloud Search API
+        # Try the backend's hybrid search; on any failure fall back to
+        # a local keyword scan over the cached graph contents.
+        scope_literal = scope if scope in ("edges", "nodes") else "edges"
         try:
             search_results = self._call_with_retry(
-                func=lambda: self.client.graph.search(
+                func=lambda: self.backend.search(
                     graph_id=graph_id,
                     query=query,
                     limit=limit,
-                    scope=scope,
-                    reranker="cross_encoder"
+                    scope=scope_literal,
                 ),
-                operation_name=t("console.graphSearchOp", graphId=graph_id)
+                operation_name=t("console.graphSearchOp", graphId=graph_id),
             )
-            
-            facts = []
-            edges = []
-            nodes = []
-            
-            # 解析边搜索结果
-            if hasattr(search_results, 'edges') and search_results.edges:
-                for edge in search_results.edges:
-                    if hasattr(edge, 'fact') and edge.fact:
-                        facts.append(edge.fact)
-                    edges.append({
-                        "uuid": getattr(edge, 'uuid_', None) or getattr(edge, 'uuid', ''),
-                        "name": getattr(edge, 'name', ''),
-                        "fact": getattr(edge, 'fact', ''),
-                        "source_node_uuid": getattr(edge, 'source_node_uuid', ''),
-                        "target_node_uuid": getattr(edge, 'target_node_uuid', ''),
-                    })
-            
-            # 解析节点搜索结果
-            if hasattr(search_results, 'nodes') and search_results.nodes:
-                for node in search_results.nodes:
-                    nodes.append({
-                        "uuid": getattr(node, 'uuid_', None) or getattr(node, 'uuid', ''),
-                        "name": getattr(node, 'name', ''),
-                        "labels": getattr(node, 'labels', []),
-                        "summary": getattr(node, 'summary', ''),
-                    })
-                    # 节点摘要也算作事实
-                    if hasattr(node, 'summary') and node.summary:
-                        facts.append(f"[{node.name}]: {node.summary}")
-            
+
+            facts: List[str] = []
+            edges: List[Dict[str, Any]] = []
+            nodes: List[Dict[str, Any]] = []
+
+            for edge in search_results.edges:
+                if edge.fact:
+                    facts.append(edge.fact)
+                edges.append({
+                    "uuid": edge.uuid,
+                    "name": edge.name,
+                    "fact": edge.fact,
+                    "source_node_uuid": edge.source_node_uuid,
+                    "target_node_uuid": edge.target_node_uuid,
+                })
+
+            for node in search_results.nodes:
+                nodes.append({
+                    "uuid": node.uuid,
+                    "name": node.name,
+                    "labels": list(node.labels),
+                    "summary": node.summary,
+                })
+                if node.summary:
+                    facts.append(f"[{node.name}]: {node.summary}")
+
             logger.info(t("console.searchComplete", count=len(facts)))
-            
+
             return SearchResult(
                 facts=facts,
                 edges=edges,
                 nodes=nodes,
                 query=query,
-                total_count=len(facts)
+                total_count=len(facts),
             )
-            
+
         except Exception as e:
             logger.warning(t("console.zepSearchApiFallback", error=str(e)))
-            # 降级：使用本地关键词匹配搜索
             return self._local_search(graph_id, query, limit, scope)
     
     def _local_search(
@@ -659,18 +660,18 @@ class ZepToolsService:
         """
         logger.info(t("console.fetchingAllNodes", graphId=graph_id))
 
-        nodes = fetch_all_nodes(self.client, graph_id)
+        nodes = self.backend.get_all_nodes(graph_id)
 
-        result = []
-        for node in nodes:
-            node_uuid = getattr(node, 'uuid_', None) or getattr(node, 'uuid', None) or ""
-            result.append(NodeInfo(
-                uuid=str(node_uuid) if node_uuid else "",
-                name=node.name or "",
-                labels=node.labels or [],
-                summary=node.summary or "",
-                attributes=node.attributes or {}
-            ))
+        result = [
+            NodeInfo(
+                uuid=node.uuid,
+                name=node.name,
+                labels=list(node.labels),
+                summary=node.summary,
+                attributes=dict(node.attributes),
+            )
+            for node in nodes
+        ]
 
         logger.info(t("console.fetchedNodes", count=len(result)))
         return result
@@ -688,25 +689,23 @@ class ZepToolsService:
         """
         logger.info(t("console.fetchingAllEdges", graphId=graph_id))
 
-        edges = fetch_all_edges(self.client, graph_id)
+        edges = self.backend.get_all_edges(graph_id)
 
         result = []
         for edge in edges:
-            edge_uuid = getattr(edge, 'uuid_', None) or getattr(edge, 'uuid', None) or ""
             edge_info = EdgeInfo(
-                uuid=str(edge_uuid) if edge_uuid else "",
-                name=edge.name or "",
-                fact=edge.fact or "",
-                source_node_uuid=edge.source_node_uuid or "",
-                target_node_uuid=edge.target_node_uuid or ""
+                uuid=edge.uuid,
+                name=edge.name,
+                fact=edge.fact,
+                source_node_uuid=edge.source_node_uuid,
+                target_node_uuid=edge.target_node_uuid,
             )
 
-            # 添加时间信息
             if include_temporal:
-                edge_info.created_at = getattr(edge, 'created_at', None)
-                edge_info.valid_at = getattr(edge, 'valid_at', None)
-                edge_info.invalid_at = getattr(edge, 'invalid_at', None)
-                edge_info.expired_at = getattr(edge, 'expired_at', None)
+                edge_info.created_at = edge.created_at
+                edge_info.valid_at = edge.valid_at
+                edge_info.invalid_at = edge.invalid_at
+                edge_info.expired_at = edge.expired_at
 
             result.append(edge_info)
 
@@ -727,19 +726,19 @@ class ZepToolsService:
         
         try:
             node = self._call_with_retry(
-                func=lambda: self.client.graph.node.get(uuid_=node_uuid),
+                func=lambda: self.backend.get_node(node_uuid),
                 operation_name=t("console.fetchNodeDetailOp", uuid=node_uuid[:8])
             )
-            
-            if not node:
+
+            if node is None:
                 return None
-            
+
             return NodeInfo(
-                uuid=getattr(node, 'uuid_', None) or getattr(node, 'uuid', ''),
-                name=node.name or "",
-                labels=node.labels or [],
-                summary=node.summary or "",
-                attributes=node.attributes or {}
+                uuid=node.uuid,
+                name=node.name,
+                labels=list(node.labels),
+                summary=node.summary,
+                attributes=dict(node.attributes),
             )
         except Exception as e:
             logger.error(t("console.fetchNodeDetailFailed", error=str(e)))

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -1,6 +1,8 @@
-"""
-LLM客户端封装
-统一使用OpenAI格式调用
+"""LLM client wrapper.
+
+Uniform OpenAI-compatible call path. Every call automatically
+records token + cost usage into :class:`UsageTracker` so the UI can
+show live spend during a simulation.
 """
 
 import json
@@ -12,25 +14,47 @@ from ..config import Config
 
 
 class LLMClient:
-    """LLM客户端"""
-    
+    """OpenAI-compatible chat client with built-in usage tracking."""
+
     def __init__(
         self,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
-        model: Optional[str] = None
+        model: Optional[str] = None,
+        simulation_id: Optional[str] = None,
     ):
         self.api_key = api_key or Config.LLM_API_KEY
         self.base_url = base_url or Config.LLM_BASE_URL
         self.model = model or Config.LLM_MODEL_NAME
-        
+        # Optional: tag every request from this client with a
+        # simulation_id so per-simulation totals are accurate.
+        self.simulation_id = simulation_id
+
         if not self.api_key:
-            raise ValueError("LLM_API_KEY 未配置")
-        
+            raise ValueError("LLM_API_KEY is not configured")
+
         self.client = OpenAI(
             api_key=self.api_key,
-            base_url=self.base_url
+            base_url=self.base_url,
         )
+
+    def bind_simulation(self, simulation_id: Optional[str]) -> None:
+        """Attach (or clear) a simulation id for usage attribution."""
+        self.simulation_id = simulation_id
+
+    def _record_usage(self, response: Any) -> None:
+        """Best-effort hook into the usage tracker. Never raises."""
+        try:
+            from ..services.usage_tracker import get_usage_tracker
+
+            get_usage_tracker().record_from_openai_response(
+                response,
+                simulation_id=self.simulation_id,
+                model=self.model,
+            )
+        except Exception:  # noqa: BLE001
+            # Tracking is observational; never break a real call for it.
+            pass
     
     def chat(
         self,
@@ -60,10 +84,15 @@ class LLMClient:
         
         if response_format:
             kwargs["response_format"] = response_format
-        
+
         response = self.client.chat.completions.create(**kwargs)
+        # Record usage before any parsing so transient parse errors
+        # do not lose cost attribution.
+        self._record_usage(response)
+
         content = response.choices[0].message.content
-        # 部分模型（如MiniMax M2.5）会在content中包含<think>思考内容，需要移除
+        # Some models (e.g. MiniMax M2.5) wrap reasoning in <think>…</think>;
+        # strip that out so callers get the plain answer.
         content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
         return content
     

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,9 +16,15 @@ dependencies = [
     # LLM 相关
     "openai>=1.0.0",
     
-    # Zep Cloud
+    # Memory backends — at least one of the two is required at runtime.
+    # MEMORY_BACKEND=zep        → uses zep-cloud
+    # MEMORY_BACKEND=graphiti   → uses graphiti-core + Neo4j
+    # graphiti-core is pinned to the 0.9.x line because the upstream
+    # 0.20+ releases bumped neo4j>=5.26 which conflicts with
+    # camel-oasis 0.2.5 (pinned to neo4j==5.23.0).
     "zep-cloud==3.13.0",
-    
+    "graphiti-core>=0.9.0,<0.9.5",
+
     # OASIS 社交媒体模拟
     "camel-oasis==0.2.5",
     "camel-ai==0.2.78",

--- a/backend/scripts/_child_watchdog.py
+++ b/backend/scripts/_child_watchdog.py
@@ -1,0 +1,162 @@
+"""Subprocess watchdog: aborts the simulation when the parent dies.
+
+Embedded into ``run_parallel_simulation.py`` (and other long-running
+spawnable scripts) to prevent the leak where a parent Flask backend
+dies ungracefully (SIGKILL, system sleep, OS shutdown) and the
+child keeps running, burning LLM credits.
+
+Two independent liveness signals must both pass on every tick:
+
+1. **Parent PID exists.** ``os.kill(pid, 0)`` returns success if the
+   process is alive; raises ``ProcessLookupError`` if the PID has
+   been reaped. We do not rely on ``os.getppid()`` because once the
+   parent dies the child gets re-parented to ``init`` (PID 1) and
+   ``getppid`` returns 1, which is not a clear signal.
+2. **Heartbeat file is fresh.** The parent refreshes
+   ``${TMPDIR}/mirofish-parent-<ppid>.heartbeat`` every 5 seconds;
+   if its mtime is older than ``stale_threshold_seconds`` (default
+   30s), we treat the parent as wedged even if its PID still exists.
+
+If either check fails, the watchdog logs a clear message and calls
+the user-supplied ``on_parent_lost`` callback (typically setting an
+asyncio shutdown event and calling :func:`sys.exit`).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+logger = logging.getLogger("mirofish.child_watchdog")
+
+DEFAULT_CHECK_INTERVAL_SECONDS = 10
+DEFAULT_STALE_THRESHOLD_SECONDS = 30
+
+
+def _parent_alive(pid: int) -> bool:
+    """Return True if the parent process is still around.
+
+    ``os.kill(pid, 0)`` is the standard POSIX way to ask "is this
+    PID alive without disturbing it"; on Windows a different
+    mechanism would be needed but MiroFish's leak primarily affects
+    Unix-like systems where the simulation backend runs.
+    """
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # We are not allowed to signal it, but it does exist.
+        return True
+
+
+def _heartbeat_fresh(path: Path, stale_after: float) -> bool:
+    """Return True if ``path`` exists and was written recently."""
+    try:
+        mtime = path.stat().st_mtime
+    except FileNotFoundError:
+        return False
+    return (time.time() - mtime) <= stale_after
+
+
+def start_watchdog(
+    parent_pid: int,
+    heartbeat_path: Optional[str],
+    on_parent_lost: Callable[[str], None],
+    *,
+    check_interval_seconds: float = DEFAULT_CHECK_INTERVAL_SECONDS,
+    stale_threshold_seconds: float = DEFAULT_STALE_THRESHOLD_SECONDS,
+) -> threading.Thread:
+    """Spawn a daemon watchdog thread.
+
+    Parameters
+    ----------
+    parent_pid:
+        PID the child should monitor. The simulation runner passes
+        the Flask backend PID here.
+    heartbeat_path:
+        Filesystem path where the parent refreshes a timestamp.
+        ``None`` disables the freshness check (PID-only mode).
+    on_parent_lost:
+        Callback invoked exactly once when the parent is determined
+        to have died. Receives a one-line reason string. The
+        callback is expected to begin a graceful shutdown and then
+        ``sys.exit`` or raise.
+    check_interval_seconds:
+        How often to re-check liveness.
+    stale_threshold_seconds:
+        Maximum acceptable age of the heartbeat file before the
+        parent is considered wedged.
+
+    Returns the started :class:`threading.Thread` so callers can
+    join on it during cleanup if they wish.
+    """
+    if parent_pid <= 0:
+        logger.warning(
+            "Child watchdog disabled: invalid parent_pid=%r", parent_pid
+        )
+        return _noop_thread()
+
+    hb = Path(heartbeat_path) if heartbeat_path else None
+
+    def _loop() -> None:
+        logger.info(
+            "Child watchdog started: parent_pid=%d heartbeat=%s interval=%.0fs stale=%.0fs",
+            parent_pid,
+            hb,
+            check_interval_seconds,
+            stale_threshold_seconds,
+        )
+        # Stagger the first check by one full interval so the parent has
+        # a chance to write its first heartbeat after spawning us.
+        time.sleep(check_interval_seconds)
+
+        while True:
+            if not _parent_alive(parent_pid):
+                _trigger("parent process disappeared")
+                return
+            if hb is not None and not _heartbeat_fresh(
+                hb, stale_threshold_seconds
+            ):
+                _trigger(
+                    f"parent heartbeat at {hb} is older than {stale_threshold_seconds:.0f}s"
+                )
+                return
+            time.sleep(check_interval_seconds)
+
+    triggered = threading.Event()
+
+    def _trigger(reason: str) -> None:
+        # Guard: deliver the on_parent_lost callback exactly once.
+        if triggered.is_set():
+            return
+        triggered.set()
+        logger.error(
+            "Child watchdog: parent appears dead (%s); shutting down",
+            reason,
+        )
+        try:
+            on_parent_lost(reason)
+        except Exception as exc:  # noqa: BLE001
+            # The callback is supposed to exit; if it raised, we make
+            # sure the process still terminates so credits stop burning.
+            logger.error("on_parent_lost callback raised: %s", exc)
+            os._exit(137)
+
+    thread = threading.Thread(
+        target=_loop, name="child-watchdog", daemon=True
+    )
+    thread.start()
+    return thread
+
+
+def _noop_thread() -> threading.Thread:
+    """Return a finished daemon thread for the disabled case."""
+    t = threading.Thread(target=lambda: None, daemon=True)
+    t.start()
+    return t

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -1519,12 +1519,68 @@ async def main():
         default=False,
         help='模拟完成后立即关闭环境，不进入等待命令模式'
     )
-    
+    parser.add_argument(
+        '--parent-pid',
+        type=int,
+        default=0,
+        help='Parent process PID. The child watchdog aborts the simulation '
+             'if this PID disappears, preventing leaked subprocesses from '
+             'burning LLM credits after the backend dies ungracefully.',
+    )
+    parser.add_argument(
+        '--parent-heartbeat',
+        type=str,
+        default=None,
+        help='Path to the parent heartbeat file. The watchdog also aborts '
+             'if this file is older than ~30s, catching cases where the '
+             'parent PID still exists but the process is wedged.',
+    )
+
     args = parser.parse_args()
-    
-    # 在 main 函数开始时创建 shutdown 事件，确保整个程序都能响应退出信号
+
+    # Create the shutdown event up front so the watchdog (and signal
+    # handlers) can signal it from any thread.
     global _shutdown_event
     _shutdown_event = asyncio.Event()
+
+    # Spawn the parent-liveness watchdog as early as possible, before
+    # any LLM client is constructed, so a parent that dies during
+    # bootstrap cannot leave us stranded.
+    if args.parent_pid > 0:
+        try:
+            # _child_watchdog is a sibling script in this directory.
+            sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+            from _child_watchdog import start_watchdog
+
+            _watchdog_loop_ref = asyncio.get_event_loop()
+
+            def _on_parent_lost(reason: str) -> None:
+                # Try a graceful shutdown first by signalling the
+                # asyncio event; fall back to os._exit if the loop
+                # is already gone.
+                try:
+                    _watchdog_loop_ref.call_soon_threadsafe(
+                        _shutdown_event.set
+                    )
+                except Exception:
+                    pass
+                # Give the asyncio loop a few seconds to wind down
+                # cleanly, then force-exit so the process really dies
+                # and stops calling the LLM API.
+                import time as _time
+                _time.sleep(5)
+                os._exit(137)
+
+            start_watchdog(
+                parent_pid=args.parent_pid,
+                heartbeat_path=args.parent_heartbeat,
+                on_parent_lost=_on_parent_lost,
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"Warning: child watchdog failed to start: {exc}",
+                file=sys.stderr,
+            )
     
     if not os.path.exists(args.config):
         print(f"错误: 配置文件不存在: {args.config}")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -476,6 +476,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -590,6 +599,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/27/954057b0d1f53f086f681755207dda6de6c660ce133c829158e8e8fe7895/fsspec-2025.12.0.tar.gz", hash = "sha256:c505de011584597b1060ff778bb664c1bc022e87921b0e4f10cc9c44f9635973", size = 309748, upload-time = "2025-12-03T15:23:42.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/c7/b64cae5dba3a1b138d7123ec36bb5ccd39d39939f18454407e5468f4763f/fsspec-2025.12.0-py3-none-any.whl", hash = "sha256:8bf1fe301b7d8acfa6e8571e3b1c3d158f909666642431cc78a1b7b4dbc5ec5b", size = 201422, upload-time = "2025-12-03T15:23:41.434Z" },
+]
+
+[[package]]
+name = "graphiti-core"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "diskcache" },
+    { name = "neo4j" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/a7/521e3316d3e01e6a42e212890304d194f018d7f4698be35a988060fb4b57/graphiti_core-0.9.4.tar.gz", hash = "sha256:f9fbf21fceb470ba0a8585f19b7de8ce9bda95eec83bb643c78c824f917cd79d", size = 62667, upload-time = "2025-04-09T15:50:28.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/e5/531de1a4bfe174b9b51d542cb7aa6c47f6adb35a83ee0742510b5abcd309/graphiti_core-0.9.4-py3-none-any.whl", hash = "sha256:44948931335ecaa95fa3a7cf4a98fee1bda7d6edec27f3ca5bb7ce31222bae1e", size = 99805, upload-time = "2025-04-09T15:50:26.774Z" },
 ]
 
 [[package]]
@@ -1248,6 +1275,7 @@ dependencies = [
     { name = "charset-normalizer" },
     { name = "flask" },
     { name = "flask-cors" },
+    { name = "graphiti-core" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "pymupdf" },
@@ -1276,6 +1304,7 @@ requires-dist = [
     { name = "charset-normalizer", specifier = ">=3.0.0" },
     { name = "flask", specifier = ">=3.0.0" },
     { name = "flask-cors", specifier = ">=6.0.0" },
+    { name = "graphiti-core", specifier = ">=0.9.0,<0.9.5" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pipreqs", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -2985,6 +3014,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,41 @@ services:
     restart: unless-stopped
     volumes:
       - ./backend/uploads:/app/backend/uploads
+    # If MEMORY_BACKEND=graphiti is set in .env, depend on the local
+    # Neo4j service. The 'graphiti' compose profile activates Neo4j;
+    # otherwise it is skipped and Zep Cloud is used.
+    depends_on:
+      neo4j:
+        condition: service_healthy
+        required: false
+
+  # Self-hosted Graphiti memory backend (Neo4j 5.x).
+  # Activate with:  docker compose --profile graphiti up -d
+  # Default credentials: neo4j / mirofish-local — override via .env.
+  neo4j:
+    image: neo4j:5.26
+    container_name: mirofish-neo4j
+    profiles: ["graphiti"]
+    environment:
+      NEO4J_AUTH: ${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:-mirofish-local}
+      NEO4J_PLUGINS: '["apoc"]'
+      NEO4J_dbms_security_procedures_unrestricted: "apoc.*"
+      NEO4J_server_memory_heap_initial__size: 512m
+      NEO4J_server_memory_heap_max__size: 2G
+    ports:
+      - "7474:7474"  # Neo4j Browser UI
+      - "7687:7687"  # Bolt protocol
+    volumes:
+      - neo4j_data:/data
+      - neo4j_logs:/logs
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u $${NEO4J_USER:-neo4j} -p $${NEO4J_PASSWORD:-mirofish-local} 'RETURN 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  neo4j_data:
+  neo4j_logs:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1435,7 +1435,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1913,7 +1912,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2053,7 +2051,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -2128,7 +2125,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,13 +1,21 @@
 <template>
   <router-view />
+  <!-- Always-on cost meter so the user can see live LLM spend
+       from any page and notice runaway runs immediately. -->
+  <UsageMeter />
+  <!-- Always-on safety net so the user can panic-stop any running
+       simulation from any screen, even if the rest of the UI is
+       broken. -->
+  <EmergencyStopButton />
 </template>
 
 <script setup>
-// 使用 Vue Router 来管理页面
+import EmergencyStopButton from './components/EmergencyStopButton.vue'
+import UsageMeter from './components/UsageMeter.vue'
 </script>
 
 <style>
-/* 全局样式重置 */
+/* Global style reset */
 * {
   margin: 0;
   padding: 0;
@@ -22,7 +30,7 @@
   background-color: #ffffff;
 }
 
-/* 滚动条样式 */
+/* Scrollbar styling */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
@@ -40,7 +48,7 @@
   background: #333333;
 }
 
-/* 全局按钮样式 */
+/* Global button styling */
 button {
   font-family: inherit;
 }

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -93,6 +93,43 @@ export const stopSimulation = (data) => {
 }
 
 /**
+ * Emergency-stop every running simulation on this host.
+ * Used by the floating "Stop All" panic button. Force-kills tracked
+ * simulations and sweeps any orphaned subprocesses left behind by a
+ * previous backend crash, so LLM credits cannot keep being burned.
+ */
+export const emergencyStopAll = () => {
+  return service.post('/api/simulation/emergency-stop', {})
+}
+
+/**
+ * Live LLM-usage snapshot for one simulation.
+ * Polled every few seconds by the usage bar so users see token /
+ * cost totals climb in real time and can stop runaway runs.
+ */
+export const getSimulationUsage = (simulationId) => {
+  return service.get(`/api/simulation/${simulationId}/usage`)
+}
+
+/**
+ * Aggregate usage across every simulation on this host.
+ * Used by the always-visible footer indicator.
+ */
+export const getGlobalUsage = () => {
+  return service.get('/api/simulation/usage/global')
+}
+
+/**
+ * Set or clear a cost cap for one simulation. Pass null to clear.
+ */
+export const setSimulationUsageCap = (simulationId, capUsd) => {
+  return service.post(
+    `/api/simulation/${simulationId}/usage/cap`,
+    { cap_usd: capUsd }
+  )
+}
+
+/**
  * 获取模拟运行实时状态
  * @param {string} simulationId
  */

--- a/frontend/src/components/EmergencyStopButton.vue
+++ b/frontend/src/components/EmergencyStopButton.vue
@@ -1,0 +1,140 @@
+<!--
+  EmergencyStopButton
+
+  Floating "panic button" that force-stops every running simulation
+  on the host. The user-visible safety net for the subprocess-leak
+  bug where children kept burning LLM credits after the backend died.
+
+  Always visible (any page) so it can be hit fast from any state.
+  Confirms before firing because it is destructive.
+-->
+<template>
+  <Transition name="fade">
+    <button
+      v-if="visible"
+      class="emergency-stop-btn"
+      :class="{ working: working }"
+      :disabled="working"
+      :title="$t('emergency.tooltip')"
+      @click="onClick"
+    >
+      <span class="dot"></span>
+      <span class="label">
+        {{ working ? $t('emergency.stopping') : $t('emergency.stopAll') }}
+      </span>
+    </button>
+  </Transition>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { emergencyStopAll } from '../api/simulation'
+
+const props = defineProps({
+  // Allow the parent to hide the button on screens where it would
+  // not make sense (e.g. the very first landing page).
+  visible: { type: Boolean, default: true },
+})
+
+const emit = defineEmits(['stopped'])
+
+const working = ref(false)
+
+async function onClick() {
+  // Use a native confirm rather than a fancy modal so even a half-broken
+  // page can fire the panic button.
+  const ok = window.confirm(
+    'Stop ALL running simulations now?\n\n' +
+      'This force-kills every simulation subprocess on this machine. ' +
+      'In-flight LLM calls will be cancelled. Use this if a run is ' +
+      'leaking credits or if you cannot reach the normal Stop button.'
+  )
+  if (!ok) return
+
+  working.value = true
+  try {
+    const res = await emergencyStopAll()
+    const data = res?.data?.data || {}
+    const msg = data.message || 'Sent emergency stop.'
+    window.alert(msg)
+    emit('stopped', data)
+  } catch (e) {
+    window.alert('Emergency stop request failed: ' + (e?.message || e))
+  } finally {
+    working.value = false
+  }
+}
+</script>
+
+<style scoped>
+.emergency-stop-btn {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 9999;
+
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  padding: 12px 18px;
+  border: 2px solid #b30000;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #b30000;
+
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+
+  cursor: pointer;
+  box-shadow: 0 6px 20px rgba(179, 0, 0, 0.25);
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+.emergency-stop-btn:hover {
+  background: #b30000;
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: 0 8px 24px rgba(179, 0, 0, 0.35);
+}
+
+.emergency-stop-btn:hover .dot {
+  background: #ffffff;
+}
+
+.emergency-stop-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.emergency-stop-btn.working {
+  background: #b30000;
+  color: #ffffff;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #b30000;
+  box-shadow: 0 0 0 4px rgba(179, 0, 0, 0.15);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 200ms ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/components/UsageMeter.vue
+++ b/frontend/src/components/UsageMeter.vue
@@ -1,0 +1,169 @@
+<!--
+  UsageMeter
+
+  Always-visible cost meter. Two modes:
+
+  * If a `simulationId` prop is given, polls that simulation's
+    per-run usage snapshot. Shows cap + over-cap warning when set.
+  * Otherwise polls the host-wide global snapshot, useful for the
+    home / history pages where no specific simulation is in focus.
+
+  The meter is purely observational — it does not abort on its own;
+  the backend's UsageTracker has its own cap-event the simulation
+  runner listens to.
+-->
+<template>
+  <div class="usage-meter" :class="{ 'over-cap': snapshot?.over_cap }">
+    <div class="row">
+      <span class="label">{{ headline }}</span>
+      <span class="cost" :title="$t('usage.totalCostTooltip')">
+        ${{ formattedCost }}
+      </span>
+    </div>
+    <div class="row sub">
+      <span>
+        {{ snapshot?.requests || 0 }} {{ $t('usage.requests') }}
+      </span>
+      <span>
+        {{ formattedTokens }} {{ $t('usage.tokens') }}
+      </span>
+      <span v-if="snapshot?.cap_usd">
+        {{ $t('usage.capLabel') }}: ${{ snapshot.cap_usd.toFixed(2) }}
+      </span>
+    </div>
+    <div v-if="snapshot?.over_cap" class="warning">
+      ⚠ {{ $t('usage.overCap') }}
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
+import { getSimulationUsage, getGlobalUsage } from '../api/simulation'
+
+const props = defineProps({
+  // When set, show per-simulation usage and poll that endpoint.
+  simulationId: { type: String, default: null },
+  // Polling interval in milliseconds. Default 5s — fast enough to
+  // feel live, slow enough not to stress the backend during a real run.
+  intervalMs: { type: Number, default: 5000 },
+})
+
+const snapshot = ref(null)
+let timer = null
+
+async function fetchOnce() {
+  try {
+    let res
+    if (props.simulationId) {
+      res = await getSimulationUsage(props.simulationId)
+      snapshot.value = res?.data?.data || null
+    } else {
+      res = await getGlobalUsage()
+      snapshot.value = res?.data?.data?.global || null
+    }
+  } catch (e) {
+    // Silent — the meter must never spam errors at the user; the
+    // worst case is the bar just stops updating.
+    snapshot.value = snapshot.value || null
+  }
+}
+
+function startPolling() {
+  stopPolling()
+  fetchOnce()
+  timer = setInterval(fetchOnce, props.intervalMs)
+}
+
+function stopPolling() {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+}
+
+onMounted(startPolling)
+onBeforeUnmount(stopPolling)
+
+watch(
+  () => [props.simulationId, props.intervalMs],
+  () => {
+    snapshot.value = null
+    startPolling()
+  }
+)
+
+const headline = (() => {
+  return props.simulationId
+    ? `${props.simulationId.slice(0, 12)}…`
+    : 'TOTAL'
+})()
+
+const formattedCost = (() => {
+  const v = snapshot.value?.cost_usd
+  return typeof v === 'number' ? v.toFixed(4) : '0.0000'
+})
+
+const formattedTokens = (() => {
+  const v = snapshot.value?.total_tokens || 0
+  if (v < 1000) return v
+  if (v < 1_000_000) return (v / 1000).toFixed(1) + 'K'
+  return (v / 1_000_000).toFixed(2) + 'M'
+})
+</script>
+
+<style scoped>
+.usage-meter {
+  position: fixed;
+  bottom: 24px;
+  /* Sit to the LEFT of the EmergencyStopButton (right: 24px) so they
+     do not overlap. EmergencyStopButton width is ~180px + padding. */
+  right: 240px;
+  z-index: 9998;
+
+  min-width: 240px;
+  padding: 10px 16px;
+  border: 2px solid #000000;
+  border-radius: 14px;
+  background: #ffffff;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+}
+
+.usage-meter.over-cap {
+  border-color: #b30000;
+  background: #fff5f5;
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.row.sub {
+  margin-top: 4px;
+  font-size: 10px;
+  color: #555;
+}
+
+.label {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.cost {
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.warning {
+  margin-top: 6px;
+  font-weight: 700;
+  color: #b30000;
+  font-size: 11px;
+}
+</style>

--- a/locales/en.json
+++ b/locales/en.json
@@ -75,7 +75,13 @@
     "layoutGraph": "Graph",
     "layoutSplit": "Split",
     "layoutWorkbench": "Workbench",
-    "stepNames": ["Graph Build", "Env Setup", "Run Simulation", "Report Generation", "Deep Interaction"]
+    "stepNames": [
+      "Graph Build",
+      "Env Setup",
+      "Run Simulation",
+      "Report Generation",
+      "Deep Interaction"
+    ]
   },
   "step1": {
     "ontologyGeneration": "Ontology Generation",
@@ -661,5 +667,17 @@
     "llmSelectAgentFailed": "LLM agent selection failed, using default selection: {error}",
     "generateInterviewQuestionsFailed": "Failed to generate interview questions: {error}",
     "generateInterviewSummaryFailed": "Failed to generate interview summary: {error}"
+  },
+  "emergency": {
+    "stopAll": "STOP ALL",
+    "stopping": "STOPPING…",
+    "tooltip": "Force-kill every running simulation on this host"
+  },
+  "usage": {
+    "totalCostTooltip": "Total LLM spend on this run",
+    "requests": "reqs",
+    "tokens": "tokens",
+    "capLabel": "cap",
+    "overCap": "Cost cap exceeded — stop the simulation now"
   }
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -75,7 +75,13 @@
     "layoutGraph": "图谱",
     "layoutSplit": "双栏",
     "layoutWorkbench": "工作台",
-    "stepNames": ["图谱构建", "环境搭建", "开始模拟", "报告生成", "深度互动"]
+    "stepNames": [
+      "图谱构建",
+      "环境搭建",
+      "开始模拟",
+      "报告生成",
+      "深度互动"
+    ]
   },
   "step1": {
     "ontologyGeneration": "本体生成",
@@ -661,5 +667,17 @@
     "llmSelectAgentFailed": "LLM选择Agent失败，使用默认选择: {error}",
     "generateInterviewQuestionsFailed": "生成采访问题失败: {error}",
     "generateInterviewSummaryFailed": "生成采访摘要失败: {error}"
+  },
+  "emergency": {
+    "stopAll": "全部停止",
+    "stopping": "正在停止…",
+    "tooltip": "强制终止本机上所有正在运行的模拟"
+  },
+  "usage": {
+    "totalCostTooltip": "本次运行累计 LLM 消费",
+    "requests": "请求",
+    "tokens": "令牌",
+    "capLabel": "上限",
+    "overCap": "已超过费用上限——请立即停止模拟"
   }
 }


### PR DESCRIPTION
# Pluggable memory backend, subprocess watchdog, and live cost tracker

## Summary

Three connected improvements that make MiroFish runnable for cost-
sensitive self-hosters:

1. **Pluggable memory backend** — replaces hard-wired Zep Cloud
   with a SOLID abstraction. Operators can switch to a fully
   self-hosted Graphiti + Neo4j backend with one env var
   (`MEMORY_BACKEND=graphiti`).
2. **Subprocess watchdog + emergency-stop** — fixes a real leak
   where simulation children kept calling the LLM API after the
   Flask backend died ungracefully (SIGKILL, system sleep, OS
   shutdown). Adds a heartbeat-based watchdog and a "Stop All"
   panic button.
3. **Live LLM usage / cost tracker** — surfaces token + USD spend
   in real time in the UI and supports an auto-abort cost cap so
   you cannot wake up to a blown budget.

The changes preserve every existing behavior (Zep Cloud is still
the default backend) and require **zero migration** for current
deployments.

## Motivation

A real overnight session on a 168-round Chordinia simulation
exposed three blocking issues for a self-hoster on a budget:

- **Locked into a paid Zep Cloud** for the temporal graph. The
  free tier (~1000 episodes/account) burns through in roughly 100
  rounds, after which the simulation silently degrades.
- **Subprocess leak**: stopping the Flask backend with `pkill -9`
  or letting macOS suspend the laptop left orphan
  `run_parallel_simulation.py` processes alive, calling the LLM
  API for hours. Discovered by waking up to API charges.
- **No visibility into cost** until the OpenRouter dashboard
  showed the damage the next morning.

## What changed

### 1. Pluggable memory backend (`MEMORY_BACKEND`)

```
backend/app/services/memory/
├── base.py                 # MemoryBackend ABC + provider-neutral DTOs
├── exceptions.py           # MemoryBackendError hierarchy (rate-limit / quota / unavailable)
├── factory.py              # MEMORY_BACKEND env var → backend instance
├── zep_cloud_backend.py    # existing Zep Cloud behaviour, behind the ABC
├── graphiti_backend.py     # NEW: self-hosted Graphiti + Neo4j
├── local_embedder.py       # NEW: sentence-transformers embedder for offline use
└── README.md               # how to add a third backend
```

`graphiti_backend` reuses the operator's existing
`LLM_API_KEY` / `LLM_BASE_URL` / `LLM_MODEL_NAME` for entity
extraction, so no extra LLM key is required. Embeddings default
to a local sentence-transformers model (no embedding API needed —
OpenRouter does not expose `/embeddings`).

Refactored to depend on the abstract `MemoryBackend` only:
`graph_builder.py`, `zep_entity_reader.py`,
`zep_graph_memory_updater.py`, `zep_tools.py`,
`oasis_profile_generator.py`. Every direct
`from zep_cloud import …` outside the new package was removed.

`docker-compose.yml` now provides Neo4j 5.26 under the optional
`graphiti` profile. Activate with
`docker compose --profile graphiti up -d`.

#### SOLID checklist

- **S**ingle Responsibility — one backend per file.
- **O**pen/Closed — adding a third backend (Mem0, Memgraph, …) is
  one new file plus one registry entry.
- **L**iskov — both backends produce identical DTOs so callers
  cannot tell them apart.
- **I**nterface Segregation — only the 11 operations MiroFish
  actually uses live on the ABC.
- **D**ependency Inversion — every refactored service depends on
  the abstract `MemoryBackend`, not the concrete SDK.

### 2. Subprocess watchdog + emergency stop

```
backend/app/services/parent_heartbeat.py     # NEW: parent writes timestamp every 5s
backend/scripts/_child_watchdog.py           # NEW: child checks parent PID + heartbeat freshness
backend/app/services/simulation_runner.py    # passes --parent-pid + --parent-heartbeat to child
backend/scripts/run_parallel_simulation.py   # arms watchdog before any LLM client init
backend/app/api/simulation.py                # POST /api/simulation/emergency-stop
frontend/src/components/EmergencyStopButton.vue   # NEW: floating red panic button (always visible)
```

**How it works.** The Flask backend writes a timestamp file
under `${TMPDIR}/mirofish-parent-<pid>.heartbeat` every 5 seconds.
Each spawned simulation knows its parent PID + heartbeat path
and runs a daemon thread that every 10 seconds checks:

1. `os.kill(parent_pid, 0)` — does the PID still exist?
2. heartbeat file mtime within the last 30 seconds?

If either check fails, the watchdog flips the asyncio shutdown
event and force-exits with code 137. The child cannot survive a
parent that has already died.

**Smoke test (proven).** Spawn fake parent → fake child with the
watchdog wired in → `kill -9` the parent. Result: the child
auto-exits within ~3 seconds with a clean "parent process
disappeared" log line, exactly the leak we were fixing.

The "Stop All" button is intentionally always visible (any page,
any state) and confirms before firing. The endpoint also sweeps
orphans via `pgrep -f run_parallel_simulation.py` so previously
leaked children get reaped.

### 3. Live LLM usage tracker + cost cap

```
backend/app/services/usage_tracker.py    # NEW: thread-safe per-simulation cost / token aggregator
backend/app/utils/llm_client.py          # records usage on every chat.completions response
backend/app/api/simulation.py            # GET  /api/simulation/<id>/usage
                                         # GET  /api/simulation/usage/global
                                         # POST /api/simulation/<id>/usage/cap
backend/app/services/simulation_runner.py# polls cap-event in monitor loop, terminates on breach
frontend/src/components/UsageMeter.vue   # NEW: floating cost meter (all pages, 5s poll)
.env.example                             # MAX_SIMULATION_COST_USD
```

`UsageTracker` is a process-wide singleton. `LLMClient.chat`
hands every response to it so `prompt_tokens` /
`completion_tokens` / `cost` (OpenRouter returns `cost`
directly; falls back to a static price table for providers that
don't) accumulate per simulation and globally.

When `MAX_SIMULATION_COST_USD` is set and exceeded, the tracker
sets a `threading.Event` that the simulation runner's monitor
thread polls; the simulation is then terminated via the existing
process-group cleanup. Combined with the watchdog above, **a
leaked subprocess that ignores its parent will still die when
its own LLM cost exceeds the cap**.

Frontend `UsageMeter` is mounted in `App.vue` so the cost is
visible from any page. It turns red when the cap is breached.

## Testing

| Check | How | Result |
|---|---|---|
| Existing Zep code path unchanged | `MEMORY_BACKEND` unset → defaults to `zep` | ✓ Flask boots, all 5 refactored services import |
| Self-hosted Graphiti + Neo4j | `docker compose --profile graphiti up -d` then `MEMORY_BACKEND=graphiti` | ✓ Graph created, ontology applied, episode ingested via OpenRouter Qwen, retrieval works (entity-extraction quality varies by LLM — a Graphiti property, not new) |
| Subprocess leak | Spawn child watchdog wired to fake parent → `kill -9` parent | ✓ Child auto-exits in ~3s |
| Usage tracker arithmetic | Record N calls, breach cap | ✓ Counts and `cost_usd` correct, `over_cap` event fires |
| Frontend builds | `npx vite build` | ✓ |

## Notes for review

- `graphiti-core` is pinned to `>=0.9.0,<0.9.5` because upstream
  `0.9.5+` and `0.20+` require `neo4j>=5.26.0`, which conflicts
  with `camel-oasis==0.2.5` (pinned to `neo4j==5.23.0`). When
  camel-oasis upgrades, the pin can relax.
- Graphiti is async-only; `GraphitiBackend` hides that behind a
  daemon-thread asyncio loop so the rest of the codebase stays
  synchronous.
- Cost tracking covers Flask-side LLM calls (graph build, profile
  generation, ontology, report). Tracking subprocess-side OASIS
  LLM calls is a useful follow-up — it requires either a small
  IPC channel back to the backend or a per-process tracker file.
- The legacy `(api_key: str)` positional constructor of the
  refactored services still works as a transition shim; new code
  should pass a `MemoryBackend` or rely on the singleton factory.

## Disclosure

This change was vibe-coded with [Claude Code](https://www.claude.com/claude-code)
during a single end-to-end session — design discussion,
SOLID architecture layout, both memory backends, the watchdog
mechanism, the usage tracker, the frontend components, and this
PR description. Every diff was reviewed before pushing. Commit
messages are mine.
