### PR TITLE
fix(deps): remove stale peer flags from frontend package-lock.json

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1435,7 +1435,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1913,7 +1912,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2053,7 +2051,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -2128,7 +2125,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",


### PR DESCRIPTION
## Summary

- Re-generated `frontend/package-lock.json` via `npm install` to remove spurious `"peer": true` entries on `d3-selection`, `vite`, and `vue`
- These stale flags were left over from an older lockfile and are inaccurate in the current dependency tree
- No dependency versions changed — purely a lockfile cleanup

## Test plan
- [ ] `cd frontend && npm install` completes without errors
- [ ] `npm run dev` starts normally
- [ ] No regressions in the dependency graph

Generated with [Claude Code](https://claude.com/claude-code)