### PR TITLE
Fix chat history filter dropping repeated user messages

### DIFF
--- a/frontend/src/components/Step5Interaction.vue
+++ b/frontend/src/components/Step5Interaction.vue
@@ -684,7 +684,7 @@ const sendToReportAgent = async (message) => {
   
   // Build chat history for API
   const historyForApi = chatHistory.value
-    .filter(msg => msg.role !== 'user' || msg.content !== message)
+    .slice(0, -1)
     .slice(-10) // Keep last 10 messages
     .map(msg => ({
       role: msg.role,
@@ -720,7 +720,7 @@ const sendToAgent = async (message) => {
   let prompt = message
   if (chatHistory.value.length > 1) {
     const historyContext = chatHistory.value
-      .filter(msg => msg.content !== message)
+      .slice(0, -1)
       .slice(-6)
       .map(msg => `${msg.role === 'user' ? '提问者' : '你'}：${msg.content}`)
       .join('\n')


### PR DESCRIPTION
Hit this while testing chat in step 5. If you send the same short reply twice (e.g. "tell me more") the filter at Step5Interaction.vue:687 also drops the earlier matching message, so the backend gets a chat_history with consecutive assistant messages and no immediately-preceding user turn.

Repro:
  1. Ask anything
  2. Reply "tell me more"
  3. Reply "tell me more" again. The chat_history sent to /api/report/chat is missing the turn-2 user message

Same shape of bug at line 723 in sendToAgent.
