### PR TITLE
docs: add multi-language README support

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -1,0 +1,203 @@
+<div align="center">
+
+<img src="./static/image/MiroFish_logo_compressed.jpeg" alt="MiroFish Logo" width="75%"/>
+
+<a href="https://trendshift.io/repositories/16144" target="_blank"><img src="https://trendshift.io/api/badge/repositories/16144" alt="666ghj%2FMiroFish | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+简洁通用的群体智能引擎，预测万物
+</br>
+<em>A Simple and Universal Swarm Intelligence Engine, Predicting Anything</em>
+
+<a href="https://www.shanda.com/" target="_blank"><img src="./static/image/shanda_logo.png" alt="666ghj%2MiroFish | Shanda" height="40"/></a>
+
+[![GitHub Stars](https://img.shields.io/github/stars/666ghj/MiroFish?style=flat-square&color=DAA520)](https://github.com/666ghj/MiroFish/stargazers)
+[![GitHub Watchers](https://img.shields.io/github/watchers/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/watchers)
+[![GitHub Forks](https://img.shields.io/github/forks/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/network)
+[![Docker](https://img.shields.io/badge/Docker-Build-2496ED?style=flat-square&logo=docker&logoColor=white)](https://hub.docker.com/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/666ghj/MiroFish)
+
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](http://discord.gg/ePf5aPaHnA)
+[![X](https://img.shields.io/badge/X-Follow-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/mirofish_ai)
+[![Instagram](https://img.shields.io/badge/Instagram-Follow-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/mirofish_ai/)
+
+**Sprachen / Languages:** [English](./README.md) · [中文](./README-ZH.md) · [Español](./README-ES.md) · [Français](./README-FR.md) · [Português](./README-PT.md) · [Русский](./README-RU.md) · [Deutsch](./README-DE.md)
+
+</div>
+
+## ⚡ Überblick
+
+**MiroFish** ist eine KI-Prognose-Engine der nächsten Generation, die auf Multi-Agenten-Technologie basiert. Durch die Extraktion von Ausgangsinformationen aus der realen Welt (wie Eilmeldungen, Politikentwürfe oder Finanzsignale) wird automatisch eine hochpräzise parallele digitale Welt aufgebaut. In diesem Raum interagieren Tausende intelligenter Agenten mit unabhängigen Persönlichkeiten, Langzeitgedächtnis und Verhaltenslogik frei und durchlaufen soziale Evolution. Sie können Variablen dynamisch aus der «Gottperspektive» injizieren, um zukünftige Entwicklungen präzise abzuleiten — **proben Sie die Zukunft in einer digitalen Sandbox und treffen Sie Entscheidungen nach unzähligen Simulationen**.
+
+> Sie müssen nur: Ausgangsmaterialien hochladen (Datenanalyseberichte oder interessante Geschichten) und Ihre Prognoseanforderungen in natürlicher Sprache beschreiben</br>
+> MiroFish liefert: einen detaillierten Prognosebericht und eine interaktive hochpräzise digitale Welt
+
+### Unsere Vision
+
+MiroFish widmet sich der Schaffung eines Schwarmintelligenz-Spiegels, der die Realität abbildet. Durch die Erfassung kollektiver Emergenz, die durch individuelle Interaktionen ausgelöst wird, überwinden wir die Grenzen traditioneller Prognosen:
+
+- **Auf Makroebene**: Wir sind ein Probelabor für Entscheidungsträger, das Politik und PR risikofrei testen lässt
+- **Auf Mikroebene**: Wir sind eine kreative Sandbox für Einzelnutzer — ob Romanendungen ableiten oder fantasievolle Szenarien erkunden, alles kann unterhaltsam und zugänglich sein
+
+Von ernsthaften Prognosen bis zu spielerischen Simulationen — wir lassen jedes «Was wäre, wenn» sein Ergebnis sehen und machen es möglich, alles vorherzusagen.
+
+## 🌐 Live-Demo
+
+Besuchen Sie unsere Online-Demo-Umgebung und erleben Sie eine Prognosesimulation zu aktuellen Meinungsereignissen, die wir für Sie vorbereitet haben: [mirofish-live-demo](https://666ghj.github.io/mirofish-demo/)
+
+## 📸 Screenshots
+
+<div align="center">
+<table>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图1.png" alt="Screenshot 1" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图2.png" alt="Screenshot 2" width="100%"/></td>
+</tr>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图3.png" alt="Screenshot 3" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图4.png" alt="Screenshot 4" width="100%"/></td>
+</tr>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图5.png" alt="Screenshot 5" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图6.png" alt="Screenshot 6" width="100%"/></td>
+</tr>
+</table>
+</div>
+
+## 🎬 Demo-Videos
+
+### 1. Simulation der öffentlichen Meinung der Universität Wuhan + MiroFish-Projektvorstellung
+
+<div align="center">
+<a href="https://www.bilibili.com/video/BV1VYBsBHEMY/" target="_blank"><img src="./static/image/武大模拟演示封面.png" alt="MiroFish Demo-Video" width="75%"/></a>
+
+Klicken Sie auf das Bild, um das vollständige Demo-Video zur Prognose mit dem von BettaFish generierten «Bericht zur öffentlichen Meinung der Universität Wuhan» anzusehen
+</div>
+
+### 2. Simulation des verlorenen Endes von «Traum der roten Kammer»
+
+<div align="center">
+<a href="https://www.bilibili.com/video/BV1cPk3BBExq" target="_blank"><img src="./static/image/红楼梦模拟推演封面.jpg" alt="MiroFish Demo-Video" width="75%"/></a>
+
+Klicken Sie auf das Bild, um MiroFishs tiefgreifende Prognose des verlorenen Endes basierend auf Hunderttausenden von Wörtern aus den ersten 80 Kapiteln von «Traum der roten Kammer» anzusehen
+</div>
+
+> Weitere Beispiele für **Finanzprognosen**, **politische Nachrichtenprognosen** usw. folgen in Kürze...
+
+## 🔄 Arbeitsablauf
+
+1. **Graph-Aufbau**: Samenextraktion und Injektion individueller/kollektiver Erinnerung sowie GraphRAG-Konstruktion
+2. **Umgebungseinrichtung**: Extraktion von Entitätsbeziehungen, Persona-Generierung und Agentenkonfigurations-Injektion
+3. **Simulation**: Parallele Simulation auf zwei Plattformen, automatische Analyse der Prognoseanforderungen und dynamische zeitliche Speicheraktualisierungen
+4. **Berichtserstellung**: ReportAgent mit umfangreichem Toolset für tiefe Interaktion mit der post-simulations Umgebung
+5. **Tiefe Interaktion**: Chatten Sie mit jedem Agenten in der simulierten Welt und interagieren Sie mit ReportAgent
+
+## 🚀 Schnellstart
+
+### Option 1: Quellcode-Bereitstellung (empfohlen)
+
+#### Voraussetzungen
+
+| Tool | Version | Beschreibung | Installation prüfen |
+|------|---------|-------------|-------------------|
+| **Node.js** | 18+ | Frontend-Laufzeit, inkl. npm | `node -v` |
+| **Python** | ≥3.11, ≤3.12 | Backend-Laufzeit | `python --version` |
+| **uv** | Neueste | Python-Paketmanager | `uv --version` |
+
+#### 1. Umgebungsvariablen konfigurieren
+
+```bash
+# Beispielkonfigurationsdatei kopieren
+cp .env.example .env
+
+# .env-Datei bearbeiten und erforderliche API-Schlüssel eintragen
+```
+
+**Erforderliche Umgebungsvariablen:**
+
+```env
+# LLM-API-Konfiguration (unterstützt jede LLM-API im OpenAI-SDK-Format)
+# Empfohlen: Alibaba Qwen-plus-Modell über Bailian Platform: https://bailian.console.aliyun.com/
+# Hoher Verbrauch, testen Sie zuerst Simulationen mit weniger als 40 Runden
+LLM_API_KEY=your_api_key
+LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+LLM_MODEL_NAME=qwen-plus
+
+# Zep Cloud-Konfiguration
+# Kostenloses Monatskontingent reicht für einfache Nutzung: https://app.getzep.com/
+ZEP_API_KEY=your_zep_api_key
+```
+
+#### 2. Abhängigkeiten installieren
+
+```bash
+# Alle Abhängigkeiten mit einem Befehl installieren (Root + Frontend + Backend)
+npm run setup:all
+```
+
+Oder schrittweise installieren:
+
+```bash
+# Node-Abhängigkeiten installieren (Root + Frontend)
+npm run setup
+
+# Python-Abhängigkeiten installieren (Backend, erstellt automatisch virtuelle Umgebung)
+npm run setup:backend
+```
+
+#### 3. Dienste starten
+
+```bash
+# Frontend und Backend gleichzeitig starten (vom Projektroot aus)
+npm run dev
+```
+
+**Dienst-URLs:**
+- Frontend: `http://localhost:3000`
+- Backend-API: `http://localhost:5001`
+
+**Einzeln starten:**
+
+```bash
+npm run backend   # Nur Backend
+npm run frontend  # Nur Frontend
+```
+
+### Option 2: Docker-Bereitstellung
+
+```bash
+# 1. Umgebungsvariablen konfigurieren (wie bei Quellcode-Bereitstellung)
+cp .env.example .env
+
+# 2. Image abrufen und starten
+docker compose up -d
+```
+
+Liest standardmäßig `.env` aus dem Root-Verzeichnis, mappt Ports `3000 (Frontend) / 5001 (Backend)`
+
+> Mirror-Adresse für schnelleres Herunterladen ist als Kommentar in `docker-compose.yml` angegeben, bei Bedarf ersetzen.
+
+## 📬 Werden Sie Teil der Community
+
+<div align="center">
+<img src="./static/image/QQ群.png" alt="QQ-Gruppe" width="60%"/>
+</div>
+
+&nbsp;
+
+Das MiroFish-Team sucht Vollzeit-/Praktikanten. Wenn Sie sich für Multi-Agenten-Simulation und LLM-Anwendungen interessieren, senden Sie Ihren Lebenslauf an: **mirofish@shanda.com**
+
+## 📄 Danksagungen
+
+**MiroFish hat strategische Unterstützung und Inkubation von Shanda Group erhalten!**
+
+MiroFishs Simulations-Engine wird von **[OASIS (Open Agent Social Interaction Simulations)](https://github.com/camel-ai/oasis)** angetrieben. Wir danken dem CAMEL-AI-Team herzlich für ihre Open-Source-Beiträge!
+
+## 📈 Projektstatistiken
+
+<a href="https://www.star-history.com/#666ghj/MiroFish&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&legend=top-left" />
+ </picture>
+</a>

--- a/README-ES.md
+++ b/README-ES.md
@@ -1,0 +1,203 @@
+<div align="center">
+
+<img src="./static/image/MiroFish_logo_compressed.jpeg" alt="MiroFish Logo" width="75%"/>
+
+<a href="https://trendshift.io/repositories/16144" target="_blank"><img src="https://trendshift.io/api/badge/repositories/16144" alt="666ghj%2FMiroFish | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+简洁通用的群体智能引擎，预测万物
+</br>
+<em>A Simple and Universal Swarm Intelligence Engine, Predicting Anything</em>
+
+<a href="https://www.shanda.com/" target="_blank"><img src="./static/image/shanda_logo.png" alt="666ghj%2MiroFish | Shanda" height="40"/></a>
+
+[![GitHub Stars](https://img.shields.io/github/stars/666ghj/MiroFish?style=flat-square&color=DAA520)](https://github.com/666ghj/MiroFish/stargazers)
+[![GitHub Watchers](https://img.shields.io/github/watchers/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/watchers)
+[![GitHub Forks](https://img.shields.io/github/forks/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/network)
+[![Docker](https://img.shields.io/badge/Docker-Build-2496ED?style=flat-square&logo=docker&logoColor=white)](https://hub.docker.com/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/666ghj/MiroFish)
+
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](http://discord.gg/ePf5aPaHnA)
+[![X](https://img.shields.io/badge/X-Follow-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/mirofish_ai)
+[![Instagram](https://img.shields.io/badge/Instagram-Follow-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/mirofish_ai/)
+
+**Idiomas / Languages:** [English](./README.md) · [中文](./README-ZH.md) · [Español](./README-ES.md) · [Français](./README-FR.md) · [Português](./README-PT.md) · [Русский](./README-RU.md) · [Deutsch](./README-DE.md)
+
+</div>
+
+## ⚡ Descripción general
+
+**MiroFish** es un motor de predicción con IA de nueva generación impulsado por tecnología multiagente. Al extraer información semilla del mundo real (como noticias de última hora, borradores de políticas o señales financieras), construye automáticamente un mundo digital paralelo de alta fidelidad. En este espacio, miles de agentes inteligentes con personalidades independientes, memoria a largo plazo y lógica de comportamiento interactúan libremente y evolucionan socialmente. Puedes inyectar variables dinámicamente desde una «vista de Dios» para deducir con precisión trayectorias futuras — **ensaya el futuro en un sandbox digital y gana decisiones tras innumerables simulaciones**.
+
+> Solo necesitas: subir materiales semilla (informes de análisis de datos o historias interesantes) y describir tus requisitos de predicción en lenguaje natural</br>
+> MiroFish devolverá: un informe de predicción detallado y un mundo digital interactivo de alta fidelidad
+
+### Nuestra visión
+
+MiroFish se dedica a crear un espejo de inteligencia colectiva que refleje la realidad. Al capturar la emergencia colectiva provocada por las interacciones individuales, superamos las limitaciones de la predicción tradicional:
+
+- **A nivel macro**: somos un laboratorio de ensayo para tomadores de decisiones, permitiendo probar políticas y relaciones públicas sin riesgo
+- **A nivel micro**: somos un sandbox creativo para usuarios individuales — ya sea deducir finales de novelas o explorar escenarios imaginativos, todo puede ser divertido y accesible
+
+Desde predicciones serias hasta simulaciones lúdicas, permitimos que cada «¿y si?» vea su resultado, haciendo posible predecir cualquier cosa.
+
+## 🌐 Demo en línea
+
+Visita nuestro entorno de demostración en línea y experimenta una simulación de predicción sobre eventos de opinión pública que hemos preparado para ti: [mirofish-live-demo](https://666ghj.github.io/mirofish-demo/)
+
+## 📸 Capturas de pantalla
+
+<div align="center">
+<table>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图1.png" alt="Captura 1" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图2.png" alt="Captura 2" width="100%"/></td>
+</tr>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图3.png" alt="Captura 3" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图4.png" alt="Captura 4" width="100%"/></td>
+</tr>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图5.png" alt="Captura 5" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图6.png" alt="Captura 6" width="100%"/></td>
+</tr>
+</table>
+</div>
+
+## 🎬 Videos de demostración
+
+### 1. Simulación de opinión pública de la Universidad de Wuhan + Introducción al proyecto MiroFish
+
+<div align="center">
+<a href="https://www.bilibili.com/video/BV1VYBsBHEMY/" target="_blank"><img src="./static/image/武大模拟演示封面.png" alt="Video demo MiroFish" width="75%"/></a>
+
+Haz clic en la imagen para ver el video completo de predicción usando el «Informe de opinión pública de Wuhan» generado por BettaFish
+</div>
+
+### 2. Simulación del final perdido de «Sueño en el pabellón rojo»
+
+<div align="center">
+<a href="https://www.bilibili.com/video/BV1cPk3BBExq" target="_blank"><img src="./static/image/红楼梦模拟推演封面.jpg" alt="Video demo MiroFish" width="75%"/></a>
+
+Haz clic en la imagen para ver la predicción profunda de MiroFish sobre el final perdido basada en cientos de miles de palabras de los primeros 80 capítulos de «Sueño en el pabellón rojo»
+</div>
+
+> Más ejemplos de **predicción financiera**, **predicción de noticias políticas**, etc. próximamente...
+
+## 🔄 Flujo de trabajo
+
+1. **Construcción del grafo**: Extracción de semillas e inyección de memoria individual/colectiva y construcción GraphRAG
+2. **Configuración del entorno**: Extracción de relaciones entre entidades, generación de personas e inyección de configuración de agentes
+3. **Simulación**: Simulación paralela en doble plataforma, análisis automático de requisitos de predicción y actualizaciones dinámicas de memoria temporal
+4. **Generación de informes**: ReportAgent con un rico conjunto de herramientas para interacción profunda con el entorno post-simulación
+5. **Interacción profunda**: Chatea con cualquier agente del mundo simulado e interactúa con ReportAgent
+
+## 🚀 Inicio rápido
+
+### Opción 1: Despliegue desde código fuente (recomendado)
+
+#### Requisitos previos
+
+| Herramienta | Versión | Descripción | Verificar instalación |
+|------|---------|-------------|-------------------|
+| **Node.js** | 18+ | Entorno de ejecución frontend, incluye npm | `node -v` |
+| **Python** | ≥3.11, ≤3.12 | Entorno de ejecución backend | `python --version` |
+| **uv** | Última | Gestor de paquetes Python | `uv --version` |
+
+#### 1. Configurar variables de entorno
+
+```bash
+# Copiar el archivo de configuración de ejemplo
+cp .env.example .env
+
+# Editar el archivo .env y completar las claves API necesarias
+```
+
+**Variables de entorno requeridas:**
+
+```env
+# Configuración de API LLM (compatible con cualquier API LLM con formato OpenAI SDK)
+# Recomendado: modelo Qwen-plus de Alibaba vía Bailian Platform: https://bailian.console.aliyun.com/
+# Alto consumo, prueba primero simulaciones con menos de 40 rondas
+LLM_API_KEY=your_api_key
+LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+LLM_MODEL_NAME=qwen-plus
+
+# Configuración de Zep Cloud
+# La cuota mensual gratuita es suficiente para uso simple: https://app.getzep.com/
+ZEP_API_KEY=your_zep_api_key
+```
+
+#### 2. Instalar dependencias
+
+```bash
+# Instalación de todas las dependencias con un solo comando (raíz + frontend + backend)
+npm run setup:all
+```
+
+O instalar paso a paso:
+
+```bash
+# Instalar dependencias Node (raíz + frontend)
+npm run setup
+
+# Instalar dependencias Python (backend, crea entorno virtual automáticamente)
+npm run setup:backend
+```
+
+#### 3. Iniciar servicios
+
+```bash
+# Iniciar frontend y backend (ejecutar desde la raíz del proyecto)
+npm run dev
+```
+
+**URLs de servicio:**
+- Frontend: `http://localhost:3000`
+- API Backend: `http://localhost:5001`
+
+**Iniciar por separado:**
+
+```bash
+npm run backend   # Solo backend
+npm run frontend  # Solo frontend
+```
+
+### Opción 2: Despliegue con Docker
+
+```bash
+# 1. Configurar variables de entorno (igual que despliegue desde código)
+cp .env.example .env
+
+# 2. Descargar imagen e iniciar
+docker compose up -d
+```
+
+Lee `.env` desde el directorio raíz por defecto, mapea puertos `3000 (frontend) / 5001 (backend)`
+
+> La dirección del mirror para descarga más rápida se proporciona como comentarios en `docker-compose.yml`, reemplazar si es necesario.
+
+## 📬 Únete a la conversación
+
+<div align="center">
+<img src="./static/image/QQ群.png" alt="Grupo QQ" width="60%"/>
+</div>
+
+&nbsp;
+
+El equipo de MiroFish está reclutando posiciones de tiempo completo/prácticas. Si te interesan la simulación multiagente y las aplicaciones LLM, envía tu currículum a: **mirofish@shanda.com**
+
+## 📄 Agradecimientos
+
+**¡MiroFish ha recibido apoyo estratégico e incubación de Shanda Group!**
+
+El motor de simulación de MiroFish está impulsado por **[OASIS (Open Agent Social Interaction Simulations)](https://github.com/camel-ai/oasis)**. ¡Agradecemos sinceramente al equipo CAMEL-AI por sus contribuciones de código abierto!
+
+## 📈 Estadísticas del proyecto
+
+<a href="https://www.star-history.com/#666ghj/MiroFish&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&legend=top-left" />
+ </picture>
+</a>

--- a/README-FR.md
+++ b/README-FR.md
@@ -1,0 +1,203 @@
+<div align="center">
+
+<img src="./static/image/MiroFish_logo_compressed.jpeg" alt="MiroFish Logo" width="75%"/>
+
+<a href="https://trendshift.io/repositories/16144" target="_blank"><img src="https://trendshift.io/api/badge/repositories/16144" alt="666ghj%2FMiroFish | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+简洁通用的群体智能引擎，预测万物
+</br>
+<em>A Simple and Universal Swarm Intelligence Engine, Predicting Anything</em>
+
+<a href="https://www.shanda.com/" target="_blank"><img src="./static/image/shanda_logo.png" alt="666ghj%2MiroFish | Shanda" height="40"/></a>
+
+[![GitHub Stars](https://img.shields.io/github/stars/666ghj/MiroFish?style=flat-square&color=DAA520)](https://github.com/666ghj/MiroFish/stargazers)
+[![GitHub Watchers](https://img.shields.io/github/watchers/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/watchers)
+[![GitHub Forks](https://img.shields.io/github/forks/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/network)
+[![Docker](https://img.shields.io/badge/Docker-Build-2496ED?style=flat-square&logo=docker&logoColor=white)](https://hub.docker.com/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/666ghj/MiroFish)
+
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](http://discord.gg/ePf5aPaHnA)
+[![X](https://img.shields.io/badge/X-Follow-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/mirofish_ai)
+[![Instagram](https://img.shields.io/badge/Instagram-Follow-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/mirofish_ai/)
+
+**Langues / Languages:** [English](./README.md) · [中文](./README-ZH.md) · [Español](./README-ES.md) · [Français](./README-FR.md) · [Português](./README-PT.md) · [Русский](./README-RU.md) · [Deutsch](./README-DE.md)
+
+</div>
+
+## ⚡ Aperçu
+
+**MiroFish** est un moteur de prédiction IA de nouvelle génération propulsé par la technologie multi-agents. En extrayant des informations semences du monde réel (comme des actualités de dernière minute, des projets de politiques ou des signaux financiers), il construit automatiquement un monde numérique parallèle haute fidélité. Dans cet espace, des milliers d'agents intelligents dotés de personnalités indépendantes, d'une mémoire à long terme et d'une logique comportementale interagissent librement et évoluent socialement. Vous pouvez injecter des variables dynamiquement depuis une « vue divine » pour déduire avec précision les trajectoires futures — **répétez le futur dans un bac à sable numérique et gagnez vos décisions après d'innombrables simulations**.
+
+> Il vous suffit de : téléverser des matériaux semences (rapports d'analyse de données ou histoires intéressantes) et décrire vos besoins de prédiction en langage naturel</br>
+> MiroFish retournera : un rapport de prédiction détaillé et un monde numérique interactif haute fidélité
+
+### Notre vision
+
+MiroFish s'engage à créer un miroir d'intelligence collective qui reflète la réalité. En capturant l'émergence collective déclenchée par les interactions individuelles, nous dépassons les limites de la prédiction traditionnelle :
+
+- **Au niveau macro** : nous sommes un laboratoire de répétition pour les décideurs, permettant de tester politiques et relations publiques sans risque
+- **Au niveau micro** : nous sommes un bac à sable créatif pour les utilisateurs individuels — que ce soit pour déduire des fins de romans ou explorer des scénarios imaginatifs, tout peut être amusant et accessible
+
+Des prédictions sérieuses aux simulations ludiques, nous permettons à chaque « et si » de voir son issue, rendant possible la prédiction de tout.
+
+## 🌐 Démo en ligne
+
+Visitez notre environnement de démonstration en ligne et découvrez une simulation de prédiction sur des événements d'opinion publique que nous avons préparés pour vous : [mirofish-live-demo](https://666ghj.github.io/mirofish-demo/)
+
+## 📸 Captures d'écran
+
+<div align="center">
+<table>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图1.png" alt="Capture 1" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图2.png" alt="Capture 2" width="100%"/></td>
+</tr>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图3.png" alt="Capture 3" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图4.png" alt="Capture 4" width="100%"/></td>
+</tr>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图5.png" alt="Capture 5" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图6.png" alt="Capture 6" width="100%"/></td>
+</tr>
+</table>
+</div>
+
+## 🎬 Vidéos de démonstration
+
+### 1. Simulation d'opinion publique de l'Université de Wuhan + Présentation du projet MiroFish
+
+<div align="center">
+<a href="https://www.bilibili.com/video/BV1VYBsBHEMY/" target="_blank"><img src="./static/image/武大模拟演示封面.png" alt="Vidéo démo MiroFish" width="75%"/></a>
+
+Cliquez sur l'image pour voir la vidéo complète de prédiction utilisant le « Rapport d'opinion publique de Wuhan » généré par BettaFish
+</div>
+
+### 2. Simulation de la fin perdue du « Rêve dans le pavillon rouge »
+
+<div align="center">
+<a href="https://www.bilibili.com/video/BV1cPk3BBExq" target="_blank"><img src="./static/image/红楼梦模拟推演封面.jpg" alt="Vidéo démo MiroFish" width="75%"/></a>
+
+Cliquez sur l'image pour voir la prédiction approfondie de MiroFish sur la fin perdue basée sur des centaines de milliers de mots des 80 premiers chapitres du « Rêve dans le pavillon rouge »
+</div>
+
+> D'autres exemples de **prédiction financière**, **prédiction de l'actualité politique**, etc. arrivent bientôt...
+
+## 🔄 Flux de travail
+
+1. **Construction du graphe** : Extraction de semences et injection de mémoire individuelle/collective et construction GraphRAG
+2. **Configuration de l'environnement** : Extraction des relations entre entités, génération de personas et injection de configuration des agents
+3. **Simulation** : Simulation parallèle sur double plateforme, analyse automatique des besoins de prédiction et mises à jour dynamiques de la mémoire temporelle
+4. **Génération de rapports** : ReportAgent avec un riche ensemble d'outils pour une interaction approfondie avec l'environnement post-simulation
+5. **Interaction approfondie** : Discutez avec n'importe quel agent du monde simulé et interagissez avec ReportAgent
+
+## 🚀 Démarrage rapide
+
+### Option 1 : Déploiement depuis les sources (recommandé)
+
+#### Prérequis
+
+| Outil | Version | Description | Vérifier l'installation |
+|------|---------|-------------|-------------------|
+| **Node.js** | 18+ | Environnement d'exécution frontend, inclut npm | `node -v` |
+| **Python** | ≥3.11, ≤3.12 | Environnement d'exécution backend | `python --version` |
+| **uv** | Dernière | Gestionnaire de paquets Python | `uv --version` |
+
+#### 1. Configurer les variables d'environnement
+
+```bash
+# Copier le fichier de configuration exemple
+cp .env.example .env
+
+# Éditer le fichier .env et renseigner les clés API requises
+```
+
+**Variables d'environnement requises :**
+
+```env
+# Configuration API LLM (compatible avec toute API LLM au format OpenAI SDK)
+# Recommandé : modèle Qwen-plus d'Alibaba via Bailian Platform : https://bailian.console.aliyun.com/
+# Consommation élevée, essayez d'abord des simulations de moins de 40 tours
+LLM_API_KEY=your_api_key
+LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+LLM_MODEL_NAME=qwen-plus
+
+# Configuration Zep Cloud
+# Le quota mensuel gratuit suffit pour un usage simple : https://app.getzep.com/
+ZEP_API_KEY=your_zep_api_key
+```
+
+#### 2. Installer les dépendances
+
+```bash
+# Installation de toutes les dépendances en une commande (racine + frontend + backend)
+npm run setup:all
+```
+
+Ou installer étape par étape :
+
+```bash
+# Installer les dépendances Node (racine + frontend)
+npm run setup
+
+# Installer les dépendances Python (backend, crée automatiquement l'environnement virtuel)
+npm run setup:backend
+```
+
+#### 3. Démarrer les services
+
+```bash
+# Démarrer frontend et backend (exécuter depuis la racine du projet)
+npm run dev
+```
+
+**URLs des services :**
+- Frontend : `http://localhost:3000`
+- API Backend : `http://localhost:5001`
+
+**Démarrer séparément :**
+
+```bash
+npm run backend   # Backend uniquement
+npm run frontend  # Frontend uniquement
+```
+
+### Option 2 : Déploiement Docker
+
+```bash
+# 1. Configurer les variables d'environnement (identique au déploiement source)
+cp .env.example .env
+
+# 2. Télécharger l'image et démarrer
+docker compose up -d
+```
+
+Lit `.env` depuis le répertoire racine par défaut, mappe les ports `3000 (frontend) / 5001 (backend)`
+
+> L'adresse miroir pour un téléchargement plus rapide est fournie en commentaires dans `docker-compose.yml`, à remplacer si nécessaire.
+
+## 📬 Rejoignez la conversation
+
+<div align="center">
+<img src="./static/image/QQ群.png" alt="Groupe QQ" width="60%"/>
+</div>
+
+&nbsp;
+
+L'équipe MiroFish recrute des postes à temps plein/stages. Si vous êtes intéressé par la simulation multi-agents et les applications LLM, envoyez votre CV à : **mirofish@shanda.com**
+
+## 📄 Remerciements
+
+**MiroFish a reçu le soutien stratégique et l'incubation de Shanda Group !**
+
+Le moteur de simulation de MiroFish est propulsé par **[OASIS (Open Agent Social Interaction Simulations)](https://github.com/camel-ai/oasis)**. Nous remercions sincèrement l'équipe CAMEL-AI pour leurs contributions open source !
+
+## 📈 Statistiques du projet
+
+<a href="https://www.star-history.com/#666ghj/MiroFish&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&legend=top-left" />
+ </picture>
+</a>

--- a/README-PT.md
+++ b/README-PT.md
@@ -1,0 +1,203 @@
+<div align="center">
+
+<img src="./static/image/MiroFish_logo_compressed.jpeg" alt="MiroFish Logo" width="75%"/>
+
+<a href="https://trendshift.io/repositories/16144" target="_blank"><img src="https://trendshift.io/api/badge/repositories/16144" alt="666ghj%2FMiroFish | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+简洁通用的群体智能引擎，预测万物
+</br>
+<em>A Simple and Universal Swarm Intelligence Engine, Predicting Anything</em>
+
+<a href="https://www.shanda.com/" target="_blank"><img src="./static/image/shanda_logo.png" alt="666ghj%2MiroFish | Shanda" height="40"/></a>
+
+[![GitHub Stars](https://img.shields.io/github/stars/666ghj/MiroFish?style=flat-square&color=DAA520)](https://github.com/666ghj/MiroFish/stargazers)
+[![GitHub Watchers](https://img.shields.io/github/watchers/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/watchers)
+[![GitHub Forks](https://img.shields.io/github/forks/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/network)
+[![Docker](https://img.shields.io/badge/Docker-Build-2496ED?style=flat-square&logo=docker&logoColor=white)](https://hub.docker.com/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/666ghj/MiroFish)
+
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](http://discord.gg/ePf5aPaHnA)
+[![X](https://img.shields.io/badge/X-Follow-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/mirofish_ai)
+[![Instagram](https://img.shields.io/badge/Instagram-Follow-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/mirofish_ai/)
+
+**Idiomas / Languages:** [English](./README.md) · [中文](./README-ZH.md) · [Español](./README-ES.md) · [Français](./README-FR.md) · [Português](./README-PT.md) · [Русский](./README-RU.md) · [Deutsch](./README-DE.md)
+
+</div>
+
+## ⚡ Visão geral
+
+**MiroFish** é um motor de previsão com IA de nova geração impulsionado por tecnologia multiagente. Ao extrair informações semente do mundo real (como notícias de última hora, rascunhos de políticas ou sinais financeiros), constrói automaticamente um mundo digital paralelo de alta fidelidade. Neste espaço, milhares de agentes inteligentes com personalidades independentes, memória de longo prazo e lógica comportamental interagem livremente e evoluem socialmente. Você pode injetar variáveis dinamicamente de uma «visão divina» para deduzir com precisão trajetórias futuras — **ensaiar o futuro em um sandbox digital e vencer decisões após inúmeras simulações**.
+
+> Você só precisa: enviar materiais semente (relatórios de análise de dados ou histórias interessantes) e descrever seus requisitos de previsão em linguagem natural</br>
+> MiroFish retornará: um relatório de previsão detalhado e um mundo digital interativo de alta fidelidade
+
+### Nossa visão
+
+MiroFish dedica-se a criar um espelho de inteligência coletiva que reflete a realidade. Ao capturar a emergência coletiva provocada por interações individuais, superamos as limitações da previsão tradicional:
+
+- **No nível macro**: somos um laboratório de ensaio para tomadores de decisão, permitindo testar políticas e relações públicas sem risco
+- **No nível micro**: somos um sandbox criativo para usuários individuais — seja deduzir finais de romances ou explorar cenários imaginativos, tudo pode ser divertido e acessível
+
+De previsões sérias a simulações lúdicas, permitimos que cada «e se» veja seu resultado, tornando possível prever qualquer coisa.
+
+## 🌐 Demo online
+
+Visite nosso ambiente de demonstração online e experimente uma simulação de previsão sobre eventos de opinião pública que preparamos para você: [mirofish-live-demo](https://666ghj.github.io/mirofish-demo/)
+
+## 📸 Capturas de tela
+
+<div align="center">
+<table>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图1.png" alt="Captura 1" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图2.png" alt="Captura 2" width="100%"/></td>
+</tr>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图3.png" alt="Captura 3" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图4.png" alt="Captura 4" width="100%"/></td>
+</tr>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图5.png" alt="Captura 5" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图6.png" alt="Captura 6" width="100%"/></td>
+</tr>
+</table>
+</div>
+
+## 🎬 Vídeos de demonstração
+
+### 1. Simulação de opinião pública da Universidade de Wuhan + Introdução ao projeto MiroFish
+
+<div align="center">
+<a href="https://www.bilibili.com/video/BV1VYBsBHEMY/" target="_blank"><img src="./static/image/武大模拟演示封面.png" alt="Vídeo demo MiroFish" width="75%"/></a>
+
+Clique na imagem para assistir ao vídeo completo de previsão usando o «Relatório de opinião pública de Wuhan» gerado pelo BettaFish
+</div>
+
+### 2. Simulação do final perdido de «Sonho do pavilhão vermelho»
+
+<div align="center">
+<a href="https://www.bilibili.com/video/BV1cPk3BBExq" target="_blank"><img src="./static/image/红楼梦模拟推演封面.jpg" alt="Vídeo demo MiroFish" width="75%"/></a>
+
+Clique na imagem para ver a previsão profunda do MiroFish sobre o final perdido com base em centenas de milhares de palavras dos primeiros 80 capítulos de «Sonho do pavilhão vermelho»
+</div>
+
+> Mais exemplos de **previsão financeira**, **previsão de notícias políticas**, etc. em breve...
+
+## 🔄 Fluxo de trabalho
+
+1. **Construção do grafo**: Extração de sementes e injeção de memória individual/coletiva e construção GraphRAG
+2. **Configuração do ambiente**: Extração de relações entre entidades, geração de personas e injeção de configuração de agentes
+3. **Simulação**: Simulação paralela em dupla plataforma, análise automática de requisitos de previsão e atualizações dinâmicas de memória temporal
+4. **Geração de relatórios**: ReportAgent com um rico conjunto de ferramentas para interação profunda com o ambiente pós-simulação
+5. **Interação profunda**: Converse com qualquer agente do mundo simulado e interaja com o ReportAgent
+
+## 🚀 Início rápido
+
+### Opção 1: Implantação a partir do código-fonte (recomendado)
+
+#### Pré-requisitos
+
+| Ferramenta | Versão | Descrição | Verificar instalação |
+|------|---------|-------------|-------------------|
+| **Node.js** | 18+ | Ambiente de execução frontend, inclui npm | `node -v` |
+| **Python** | ≥3.11, ≤3.12 | Ambiente de execução backend | `python --version` |
+| **uv** | Mais recente | Gerenciador de pacotes Python | `uv --version` |
+
+#### 1. Configurar variáveis de ambiente
+
+```bash
+# Copiar o arquivo de configuração de exemplo
+cp .env.example .env
+
+# Editar o arquivo .env e preencher as chaves API necessárias
+```
+
+**Variáveis de ambiente obrigatórias:**
+
+```env
+# Configuração de API LLM (compatível com qualquer API LLM no formato OpenAI SDK)
+# Recomendado: modelo Qwen-plus da Alibaba via Bailian Platform: https://bailian.console.aliyun.com/
+# Alto consumo, tente primeiro simulações com menos de 40 rodadas
+LLM_API_KEY=your_api_key
+LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+LLM_MODEL_NAME=qwen-plus
+
+# Configuração Zep Cloud
+# A cota mensal gratuita é suficiente para uso simples: https://app.getzep.com/
+ZEP_API_KEY=your_zep_api_key
+```
+
+#### 2. Instalar dependências
+
+```bash
+# Instalação de todas as dependências com um comando (raiz + frontend + backend)
+npm run setup:all
+```
+
+Ou instalar passo a passo:
+
+```bash
+# Instalar dependências Node (raiz + frontend)
+npm run setup
+
+# Instalar dependências Python (backend, cria ambiente virtual automaticamente)
+npm run setup:backend
+```
+
+#### 3. Iniciar serviços
+
+```bash
+# Iniciar frontend e backend (executar a partir da raiz do projeto)
+npm run dev
+```
+
+**URLs dos serviços:**
+- Frontend: `http://localhost:3000`
+- API Backend: `http://localhost:5001`
+
+**Iniciar separadamente:**
+
+```bash
+npm run backend   # Apenas backend
+npm run frontend  # Apenas frontend
+```
+
+### Opção 2: Implantação com Docker
+
+```bash
+# 1. Configurar variáveis de ambiente (igual à implantação por código)
+cp .env.example .env
+
+# 2. Baixar imagem e iniciar
+docker compose up -d
+```
+
+Lê `.env` do diretório raiz por padrão, mapeia portas `3000 (frontend) / 5001 (backend)`
+
+> O endereço mirror para download mais rápido é fornecido como comentários em `docker-compose.yml`, substituir se necessário.
+
+## 📬 Participe da conversa
+
+<div align="center">
+<img src="./static/image/QQ群.png" alt="Grupo QQ" width="60%"/>
+</div>
+
+&nbsp;
+
+A equipe MiroFish está recrutando posições em tempo integral/estágio. Se você se interessa por simulação multiagente e aplicações LLM, envie seu currículo para: **mirofish@shanda.com**
+
+## 📄 Agradecimentos
+
+**MiroFish recebeu apoio estratégico e incubação do Shanda Group!**
+
+O motor de simulação do MiroFish é impulsionado por **[OASIS (Open Agent Social Interaction Simulations)](https://github.com/camel-ai/oasis)**. Agradecemos sinceramente à equipe CAMEL-AI por suas contribuições open source!
+
+## 📈 Estatísticas do projeto
+
+<a href="https://www.star-history.com/#666ghj/MiroFish&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&legend=top-left" />
+ </picture>
+</a>

--- a/README-RU.md
+++ b/README-RU.md
@@ -1,0 +1,203 @@
+<div align="center">
+
+<img src="./static/image/MiroFish_logo_compressed.jpeg" alt="MiroFish Logo" width="75%"/>
+
+<a href="https://trendshift.io/repositories/16144" target="_blank"><img src="https://trendshift.io/api/badge/repositories/16144" alt="666ghj%2FMiroFish | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+简洁通用的群体智能引擎，预测万物
+</br>
+<em>A Simple and Universal Swarm Intelligence Engine, Predicting Anything</em>
+
+<a href="https://www.shanda.com/" target="_blank"><img src="./static/image/shanda_logo.png" alt="666ghj%2MiroFish | Shanda" height="40"/></a>
+
+[![GitHub Stars](https://img.shields.io/github/stars/666ghj/MiroFish?style=flat-square&color=DAA520)](https://github.com/666ghj/MiroFish/stargazers)
+[![GitHub Watchers](https://img.shields.io/github/watchers/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/watchers)
+[![GitHub Forks](https://img.shields.io/github/forks/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/network)
+[![Docker](https://img.shields.io/badge/Docker-Build-2496ED?style=flat-square&logo=docker&logoColor=white)](https://hub.docker.com/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/666ghj/MiroFish)
+
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](http://discord.gg/ePf5aPaHnA)
+[![X](https://img.shields.io/badge/X-Follow-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/mirofish_ai)
+[![Instagram](https://img.shields.io/badge/Instagram-Follow-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/mirofish_ai/)
+
+**Языки / Languages:** [English](./README.md) · [中文](./README-ZH.md) · [Español](./README-ES.md) · [Français](./README-FR.md) · [Português](./README-PT.md) · [Русский](./README-RU.md) · [Deutsch](./README-DE.md)
+
+</div>
+
+## ⚡ Обзор
+
+**MiroFish** — это AI-движок прогнозирования нового поколения на основе мультиагентных технологий. Извлекая исходную информацию из реального мира (например, срочные новости, проекты политик или финансовые сигналы), он автоматически создаёт высокоточный параллельный цифровой мир. В этом пространстве тысячи интеллектуальных агентов с независимыми личностями, долгосрочной памятью и поведенческой логикой свободно взаимодействуют и социально эволюционируют. Вы можете динамически вводить переменные с «божественной перспективы» для точного прогнозирования будущих траекторий — **репетируйте будущее в цифровой песочнице и принимайте решения после бесчисленных симуляций**.
+
+> Вам нужно только: загрузить исходные материалы (аналитические отчёты или интересные истории) и описать требования к прогнозу на естественном языке</br>
+> MiroFish вернёт: подробный отчёт прогноза и интерактивный высокоточный цифровой мир
+
+### Наше видение
+
+MiroFish стремится создать зеркало коллективного интеллекта, отражающее реальность. Захватывая коллективное возникновение, вызванное индивидуальными взаимодействиями, мы преодолеваем ограничения традиционного прогнозирования:
+
+- **На макроуровне**: мы — лаборатория репетиций для лиц, принимающих решения, позволяющая тестировать политику и PR без риска
+- **На микроуровне**: мы — творческая песочница для отдельных пользователей — будь то вывод финалов романов или исследование воображаемых сценариев, всё может быть интересным и доступным
+
+От серьёзных прогнозов до игровых симуляций — мы позволяем каждому «а что, если» увидеть результат, делая возможным прогнозирование чего угодно.
+
+## 🌐 Онлайн-демо
+
+Посетите нашу онлайн-демонстрацию и опробуйте симуляцию прогноза по актуальным событиям общественного мнения, которую мы подготовили для вас: [mirofish-live-demo](https://666ghj.github.io/mirofish-demo/)
+
+## 📸 Скриншоты
+
+<div align="center">
+<table>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图1.png" alt="Скриншот 1" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图2.png" alt="Скриншот 2" width="100%"/></td>
+</tr>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图3.png" alt="Скриншот 3" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图4.png" alt="Скриншот 4" width="100%"/></td>
+</tr>
+<tr>
+<td><img src="./static/image/Screenshot/运行截图5.png" alt="Скриншот 5" width="100%"/></td>
+<td><img src="./static/image/Screenshot/运行截图6.png" alt="Скриншот 6" width="100%"/></td>
+</tr>
+</table>
+</div>
+
+## 🎬 Демонстрационные видео
+
+### 1. Симуляция общественного мнения Уханьского университета + представление проекта MiroFish
+
+<div align="center">
+<a href="https://www.bilibili.com/video/BV1VYBsBHEMY/" target="_blank"><img src="./static/image/武大模拟演示封面.png" alt="Демо-видео MiroFish" width="75%"/></a>
+
+Нажмите на изображение, чтобы посмотреть полное демо-видео прогноза с использованием «Отчёта об общественном мнении Уханьского университета», сгенерированного BettaFish
+</div>
+
+### 2. Симуляция утерянного финала «Сон в красном тереме»
+
+<div align="center">
+<a href="https://www.bilibili.com/video/BV1cPk3BBExq" target="_blank"><img src="./static/image/红楼梦模拟推演封面.jpg" alt="Демо-видео MiroFish" width="75%"/></a>
+
+Нажмите на изображение, чтобы увидеть глубокий прогноз MiroFish утерянного финала на основе сотен тысяч слов из первых 80 глав «Сна в красном тереме»
+</div>
+
+> Скоро появятся примеры **финансового прогнозирования**, **прогнозирования политических новостей** и другие...
+
+## 🔄 Рабочий процесс
+
+1. **Построение графа**: Извлечение исходных данных и инъекция индивидуальной/коллективной памяти и построение GraphRAG
+2. **Настройка среды**: Извлечение связей между сущностями, генерация персон и инъекция конфигурации агентов
+3. **Симуляция**: Параллельная симуляция на двух платформах, автоматический разбор требований к прогнозу и динамическое обновление временной памяти
+4. **Генерация отчётов**: ReportAgent с богатым набором инструментов для глубокого взаимодействия со средой после симуляции
+5. **Глубокое взаимодействие**: Общайтесь с любым агентом в симулированном мире и взаимодействуйте с ReportAgent
+
+## 🚀 Быстрый старт
+
+### Вариант 1: Развёртывание из исходного кода (рекомендуется)
+
+#### Требования
+
+| Инструмент | Версия | Описание | Проверка установки |
+|------|---------|-------------|-------------------|
+| **Node.js** | 18+ | Среда выполнения frontend, включает npm | `node -v` |
+| **Python** | ≥3.11, ≤3.12 | Среда выполнения backend | `python --version` |
+| **uv** | Последняя | Менеджер пакетов Python | `uv --version` |
+
+#### 1. Настройка переменных окружения
+
+```bash
+# Скопировать пример конфигурационного файла
+cp .env.example .env
+
+# Отредактировать файл .env и заполнить необходимые API-ключи
+```
+
+**Обязательные переменные окружения:**
+
+```env
+# Конфигурация LLM API (поддерживает любой LLM API в формате OpenAI SDK)
+# Рекомендуется: модель Qwen-plus от Alibaba через Bailian Platform: https://bailian.console.aliyun.com/
+# Высокое потребление, сначала попробуйте симуляции менее 40 раундов
+LLM_API_KEY=your_api_key
+LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+LLM_MODEL_NAME=qwen-plus
+
+# Конфигурация Zep Cloud
+# Бесплатная месячная квота достаточна для простого использования: https://app.getzep.com/
+ZEP_API_KEY=your_zep_api_key
+```
+
+#### 2. Установка зависимостей
+
+```bash
+# Установка всех зависимостей одной командой (корень + frontend + backend)
+npm run setup:all
+```
+
+Или пошаговая установка:
+
+```bash
+# Установить Node-зависимости (корень + frontend)
+npm run setup
+
+# Установить Python-зависимости (backend, автоматически создаёт виртуальное окружение)
+npm run setup:backend
+```
+
+#### 3. Запуск сервисов
+
+```bash
+# Запустить frontend и backend (из корня проекта)
+npm run dev
+```
+
+**Адреса сервисов:**
+- Frontend: `http://localhost:3000`
+- Backend API: `http://localhost:5001`
+
+**Запуск по отдельности:**
+
+```bash
+npm run backend   # Только backend
+npm run frontend  # Только frontend
+```
+
+### Вариант 2: Развёртывание через Docker
+
+```bash
+# 1. Настроить переменные окружения (как при развёртывании из исходников)
+cp .env.example .env
+
+# 2. Загрузить образ и запустить
+docker compose up -d
+```
+
+По умолчанию читает `.env` из корневого каталога, порты `3000 (frontend) / 5001 (backend)`
+
+> Адрес зеркала для более быстрой загрузки указан в комментариях в `docker-compose.yml`, при необходимости замените.
+
+## 📬 Присоединяйтесь к обсуждению
+
+<div align="center">
+<img src="./static/image/QQ群.png" alt="Группа QQ" width="60%"/>
+</div>
+
+&nbsp;
+
+Команда MiroFish набирает сотрудников на полную занятость/стажировку. Если вас интересуют мультиагентная симуляция и LLM-приложения, отправляйте резюме на: **mirofish@shanda.com**
+
+## 📄 Благодарности
+
+**MiroFish получил стратегическую поддержку и инкубацию от Shanda Group!**
+
+Движок симуляции MiroFish работает на **[OASIS (Open Agent Social Interaction Simulations)](https://github.com/camel-ai/oasis)**. Мы искренне благодарим команду CAMEL-AI за их вклад в open source!
+
+## 📈 Статистика проекта
+
+<a href="https://www.star-history.com/#666ghj/MiroFish&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=666ghj/MiroFish&type=date&legend=top-left" />
+ </picture>
+</a>

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -20,7 +20,7 @@
 [![X](https://img.shields.io/badge/X-Follow-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/mirofish_ai)
 [![Instagram](https://img.shields.io/badge/Instagram-Follow-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/mirofish_ai/)
 
-[English](./README.md) | [中文文档](./README-ZH.md)
+**语言 / Languages:** [English](./README.md) · [中文](./README-ZH.md) · [Español](./README-ES.md) · [Français](./README-FR.md) · [Português](./README-PT.md) · [Русский](./README-RU.md) · [Deutsch](./README-DE.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 [![X](https://img.shields.io/badge/X-Follow-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/mirofish_ai)
 [![Instagram](https://img.shields.io/badge/Instagram-Follow-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/mirofish_ai/)
 
-[English](./README.md) | [中文文档](./README-ZH.md)
+**Languages:** [English](./README.md) · [中文](./README-ZH.md) · [Español](./README-ES.md) · [Français](./README-FR.md) · [Português](./README-PT.md) · [Русский](./README-RU.md) · [Deutsch](./README-DE.md)
 
 </div>
 


### PR DESCRIPTION
## Summary

- Add README translations for Spanish, French, Portuguese, Russian, and German to match the seven languages supported by the app's i18n system (`locales/languages.json`)
- Update the language switcher in `README.md` and `README-ZH.md` with links to all localized README files

## Changes

| File | Description |
|------|-------------|
| `README-ES.md` | Spanish documentation |
| `README-FR.md` | French documentation |
| `README-PT.md` | Portuguese documentation |
| `README-RU.md` | Russian documentation |
| `README-DE.md` | German documentation |
| `README.md` / `README-ZH.md` | Updated language navigation bar |

Each localized README preserves the same structure, screenshots, demo links, and setup instructions as the English and Chinese versions.

## Test plan

- [ ] Verify language switcher links work in all README files
- [ ] Confirm images and external links render correctly in each translation
- [ ] Review translation accuracy for target languages