### PR TITLE
Download report feature implemented

### DIFF
--- a/frontend/src/api/report.js
+++ b/frontend/src/api/report.js
@@ -43,6 +43,14 @@ export const getReport = (reportId) => {
 }
 
 /**
+ * Download report as Markdown file
+ * @param {string} reportId
+ */
+export const downloadReport = (reportId) => {
+  return service.get(`/api/report/${reportId}/download`, { responseType: 'blob' })
+}
+
+/**
  * 与 Report Agent 对话
  * @param {Object} data - { simulation_id, message, chat_history? }
  */

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -127,6 +127,16 @@
             </div>
           </div>
 
+          <!-- Download Button -->
+          <button v-if="isComplete" class="download-btn" @click="handleDownload">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+              <polyline points="7 10 12 15 17 10"></polyline>
+              <line x1="12" y1="15" x2="12" y2="3"></line>
+            </svg>
+            <span>{{ $t('step4.downloadReport') || 'Download Report' }}</span>
+          </button>
+
           <!-- Next Step Button - 在完成后显示 -->
           <button v-if="isComplete" class="next-step-btn" @click="goToInteraction">
             <span>{{ $t('step4.goToInteraction') }}</span>
@@ -393,7 +403,7 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick, h, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { getAgentLog, getConsoleLog } from '../api/report'
+import { getAgentLog, getConsoleLog, downloadReport } from '../api/report'
 
 const router = useRouter()
 const { t } = useI18n()
@@ -411,6 +421,16 @@ const goToInteraction = () => {
   if (props.reportId) {
     router.push({ name: 'Interaction', params: { reportId: props.reportId } })
   }
+}
+
+const handleDownload = async () => {
+  const res = await downloadReport(props.reportId)
+  const url = URL.createObjectURL(new Blob([res.data]))
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${props.reportId}.md`
+  a.click()
+  URL.revokeObjectURL(url)
 }
 
 // State
@@ -3400,6 +3420,28 @@ watch(() => props.reportId, (newId) => {
   color: #065F46;
   font-weight: 600;
   font-size: 14px;
+}
+
+.download-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: calc(100% - 40px);
+  margin: 4px 20px 0 20px;
+  padding: 12px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #D1FAE5;
+  background: #065F46;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.download-btn:hover {
+  background: #047857;
 }
 
 .next-step-btn {


### PR DESCRIPTION
## Summary

  - Adds a **"Download Report"** button to Stage 4 (`Step4Report.vue`) that appears once report generation is complete
  - Wires it to the existing backend endpoint `GET /api/report/<report_id>/download` which was already implemented but
  never exposed in the UI
  - Adds `downloadReport()` to `frontend/src/api/report.js` using `responseType: 'blob'` so axios handles the file
  response correctly

  ## Why

  Users completing the full 5-stage pipeline had no way to save or share the generated report. The backend already had a
  working download endpoint returning the assembled `full_report.md` — the UI just never called it.

  ## Changes

  | File | Change |
  |------|--------|
  | `frontend/src/api/report.js` | Added `downloadReport(reportId)` function |
  | `frontend/src/components/Step4Report.vue` | Added download button, `handleDownload()` handler, and button CSS |

  ## Test Plan

  - [ ] Run the full 5-stage pipeline to completion
  - [ ] Confirm "Download Report" button appears in Stage 4 when report is complete
  - [ ] Click the button — browser should download `{report_id}.md`
  - [ ] Open the file and confirm it contains the full formatted report
  - [ ] Confirm "Go to Interaction" button still works normally

  Closes #636 