### PR TITLE
docs(readme): fix typo in Shanda logo alt text

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -8,7 +8,7 @@
 </br>
 <em>A Simple and Universal Swarm Intelligence Engine, Predicting Anything</em>
 
-<a href="https://www.shanda.com/" target="_blank"><img src="./static/image/shanda_logo.png" alt="666ghj%2MiroFish | Shanda" height="40"/></a>
+<a href="https://www.shanda.com/" target="_blank"><img src="./static/image/shanda_logo.png" alt="666ghj%2FMiroFish | Shanda" height="40"/></a>
 
 [![GitHub Stars](https://img.shields.io/github/stars/666ghj/MiroFish?style=flat-square&color=DAA520)](https://github.com/666ghj/MiroFish/stargazers)
 [![GitHub Watchers](https://img.shields.io/github/watchers/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/watchers)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </br>
 <em>A Simple and Universal Swarm Intelligence Engine, Predicting Anything</em>
 
-<a href="https://www.shanda.com/" target="_blank"><img src="./static/image/shanda_logo.png" alt="666ghj%2MiroFish | Shanda" height="40"/></a>
+<a href="https://www.shanda.com/" target="_blank"><img src="./static/image/shanda_logo.png" alt="666ghj%2FMiroFish | Shanda" height="40"/></a>
 
 [![GitHub Stars](https://img.shields.io/github/stars/666ghj/MiroFish?style=flat-square&color=DAA520)](https://github.com/666ghj/MiroFish/stargazers)
 [![GitHub Watchers](https://img.shields.io/github/watchers/666ghj/MiroFish?style=flat-square)](https://github.com/666ghj/MiroFish/watchers)


### PR DESCRIPTION
Shanda 赞助 logo 的 alt 文本里 URL 编码漏了一个字母 `F`：

```diff
- <img src="./static/image/shanda_logo.png" alt="666ghj%2MiroFish | Shanda" height="40"/>
+ <img src="./static/image/shanda_logo.png" alt="666ghj%2FMiroFish | Shanda" height="40"/>
```

同文件里其他所有 badge（Trendshift 等）的 alt 都正确使用 `666ghj%2FMiroFish`，仅这一处 Shanda logo 漏了。两个 README（中英文）都有同样的 typo，一并修复。

仅 2 行改动，不涉及任何文案、结构或排版调整。