### PR TITLE
fix: add max_items limit to fetch_all_edges to prevent unbounded memory growth

### DIFF
--- a/backend/app/utils/zep_paging.py
+++ b/backend/app/utils/zep_paging.py
@@ -19,6 +19,7 @@ logger = get_logger('mirofish.zep_paging')
 
 _DEFAULT_PAGE_SIZE = 100
 _MAX_NODES = 2000
+_MAX_EDGES = 5000
 _DEFAULT_MAX_RETRIES = 3
 _DEFAULT_RETRY_DELAY = 2.0  # seconds, doubles each retry
 
@@ -106,10 +107,11 @@ def fetch_all_edges(
     client: Zep,
     graph_id: str,
     page_size: int = _DEFAULT_PAGE_SIZE,
+    max_items: int = _MAX_EDGES,
     max_retries: int = _DEFAULT_MAX_RETRIES,
     retry_delay: float = _DEFAULT_RETRY_DELAY,
 ) -> list[Any]:
-    """分页获取图谱所有边，返回完整列表。每页请求自带重试。"""
+    """分页获取图谱所有边，最多返回 max_items 条（默认 5000）。每页请求自带重试。"""
     all_edges: list[Any] = []
     cursor: str | None = None
     page_num = 0
@@ -132,6 +134,10 @@ def fetch_all_edges(
             break
 
         all_edges.extend(batch)
+        if len(all_edges) >= max_items:
+            all_edges = all_edges[:max_items]
+            logger.warning(f"Edge count reached limit ({max_items}), stopping pagination for graph {graph_id}")
+            break
         if len(batch) < page_size:
             break
 


### PR DESCRIPTION
## Description

Adds a `max_items` parameter (default 5000) to `fetch_all_edges()` to cap edge retrieval and prevent unbounded memory growth, following the same pattern as `fetch_all_nodes()`.

## Changes

- Added `_MAX_EDGES = 5000` constant
- Added `max_items` parameter to `fetch_all_edges()`, defaulting to `_MAX_EDGES`
- Added break-when-limit-reached logic, matching `fetch_all_nodes()` behavior
- Updated docstring to reflect the limit

Closes #513