### PR TITLE
docs: add VITE_API_BASE_URL documentation for remote/VPS deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ LLM_MODEL_NAME=qwen-plus
 # 每月免费额度即可支撑简单使用：https://app.getzep.com/
 ZEP_API_KEY=your_zep_api_key_here
 
+# ===== 前端 API 地址配置（远程部署时需要）=====
+# 本地开发默认使用 http://localhost:5001
+# 远程部署时请设置后端实际地址，例如：
+# VITE_API_BASE_URL=https://your-domain.com:5001
+# VITE_API_BASE_URL=http://your-server-ip:5001
+
 # ===== 加速 LLM 配置（可选）=====
 # 注意如果不使用加速配置，env文件中就不要出现下面的配置项
 LLM_BOOST_API_KEY=your_api_key_here

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -176,6 +176,17 @@ docker compose up -d
 
 > 在 `docker-compose.yml` 中已通过注释提供加速镜像地址，可按需替换
 
+### 远程 / VPS 部署
+
+在远程服务器或 VPS 上部署时，前端默认使用 `http://localhost:5001` 调用 API，远程环境下会失效。请在构建前设置 `VITE_API_BASE_URL` 环境变量：
+
+```bash
+# 在 frontend/.env 中（或构建前设置环境变量）
+VITE_API_BASE_URL=https://your-domain.com:5001
+```
+
+这将告诉前端 Axios 客户端后端 API 的实际地址。如果不设置，前端将在用户浏览器中尝试连接 `localhost:5001`，这仅在前端和后端运行在同一台本地机器上时有效。
+
 ## 📬 更多交流
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -176,6 +176,17 @@ Reads `.env` from root directory by default, maps ports `3000 (frontend) / 5001 
 
 > Mirror address for faster pulling is provided as comments in `docker-compose.yml`, replace if needed.
 
+### Remote / VPS Deployment
+
+When deploying on a remote server or VPS, the frontend defaults to `http://localhost:5001` for API calls, which won't work remotely. Set the `VITE_API_BASE_URL` environment variable before building:
+
+```bash
+# In frontend/.env (or as an environment variable before build)
+VITE_API_BASE_URL=https://your-domain.com:5001
+```
+
+This tells the frontend Axios client where to reach the backend. Without it, the frontend will try to connect to `localhost:5001` inside the user's browser, which only works when both frontend and backend run on the same local machine.
+
 ## 📬 Join the Conversation
 
 <div align="center">


### PR DESCRIPTION
## Description

Adds documentation explaining how to set `VITE_API_BASE_URL` for remote/VPS deployments. Without this, users deploying on a VPS get cryptic connection errors because the frontend defaults to `http://localhost:5001`.

## Changes

- `.env.example`: Added commented section explaining `VITE_API_BASE_URL`
- `README.md`: Added Remote/VPS Deployment section in Quick Start
- `README-ZH.md`: Same in Chinese

Closes #514