### PR TITLE
fix: remove redundant .to_dict() in list_tasks API

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -559,7 +559,7 @@ def list_tasks():
     
     return jsonify({
         "success": True,
-        "data": [t.to_dict() for t in tasks],
+        "data": tasks,  # list_tasks() already returns to_dict() results
         "count": len(tasks)
     })
 


### PR DESCRIPTION
## Fix: Remove redundant .to_dict() in list_tasks API

### Problem
The `/api/graph/tasks` endpoint throws `AttributeError: 'dict' object has no attribute 'to_dict'`.

### Root Cause
`TaskManager.list_tasks()` already returns serialized dicts via `.to_dict()` at line 172 in `task.py`:
```python
return [t.to_dict() for t in sorted(tasks, ...)]
```

But the API endpoint in `graph.py:562` calls `.to_dict()` again on each item:
```python
"data": [t.to_dict() for t in tasks],  # t is already a dict!
```

### Fix
Simply return `tasks` directly since it is already a list of dicts.

### Testing
- Before: `curl /api/graph/tasks` -> 500 Error
- After: `curl /api/graph/tasks` -> `{"success": true, "data": [], "count": 0}`
