### PR TITLE
fix(simulation): make create_simulation idempotent to prevent duplicate sims

### DIFF
--- a/backend/app/services/simulation_manager.py
+++ b/backend/app/services/simulation_manager.py
@@ -197,19 +197,43 @@ class SimulationManager:
         graph_id: str,
         enable_twitter: bool = True,
         enable_reddit: bool = True,
+        force_new: bool = False,
     ) -> SimulationState:
         """
         创建新的模拟
-        
+
         Args:
             project_id: 项目ID
             graph_id: Zep图谱ID
             enable_twitter: 是否启用Twitter模拟
             enable_reddit: 是否启用Reddit模拟
-            
+            force_new: 强制新建，跳过幂等复用（默认False）
+
         Returns:
             SimulationState
         """
+        # 幂等防重复：若已存在同一 project+graph 且尚未运行的模拟，则直接复用，
+        # 避免前端重试（requestWithRetry）或重复提交导致创建出多个相同的模拟。
+        if not force_new:
+            reusable_statuses = (
+                SimulationStatus.CREATED,
+                SimulationStatus.PREPARING,
+                SimulationStatus.READY,
+            )
+            for existing in self.list_simulations(project_id=project_id):
+                if (
+                    existing.graph_id == graph_id
+                    and existing.enable_twitter == enable_twitter
+                    and existing.enable_reddit == enable_reddit
+                    and existing.current_round == 0
+                    and existing.status in reusable_statuses
+                ):
+                    logger.info(
+                        f"复用未运行的模拟（幂等防重复）: {existing.simulation_id}, "
+                        f"project={project_id}, graph={graph_id}, status={existing.status.value}"
+                    )
+                    return existing
+
         import uuid
         simulation_id = f"sim_{uuid.uuid4().hex[:12]}"
         


### PR DESCRIPTION
## Problem

Creating a simulation is not idempotent. Each `POST /api/simulation/create` mints a fresh `sim_<uuid>` via `SimulationManager.create_simulation`. The frontend calls it through `requestWithRetry(() => service.post('/api/simulation/create', data), 3, 1000)` (`frontend/src/api/simulation.js`), so when the first request is slow or times out, the automatic retry fires a **second** create for the same project + graph.

Result: two identical simulations for the same project/graph, created ~2 seconds apart (matching the 1000 ms retry interval), which is confusing in the Simulation History UI.

## Fix

Add an idempotency guard at the top of `create_simulation`: before minting a new id, reuse an existing simulation for the same `project_id` + `graph_id` (and matching `enable_twitter` / `enable_reddit`) when it has **not been run yet** — `current_round == 0` and status in `CREATED` / `PREPARING` / `READY`.

A `force_new=True` parameter is added as an escape hatch for callers that deliberately want a brand-new simulation.

This makes the POST safe to retry (the real root cause is a non-idempotent POST behind an auto-retry).

## Verification

Repeated `POST /api/simulation/create` for the same project now returns the **same** `simulation_id` instead of spawning duplicates.

## Scope

Single-file change: `backend/app/services/simulation_manager.py`. No API signature change (the new param is optional and defaults to current behavior for fresh projects).