### PR TITLE
fix(frontend): show local date in history cards (matches displayed time)

### DIFF
--- a/frontend/src/components/HistoryDatabase.vue
+++ b/frontend/src/components/HistoryDatabase.vue
@@ -312,7 +312,13 @@ const formatDate = (dateStr) => {
   if (!dateStr) return ''
   try {
     const date = new Date(dateStr)
-    return date.toISOString().slice(0, 10)
+    // Use local date components (like formatTime below) so the displayed day
+    // matches the displayed time. toISOString() converts to UTC and can show
+    // the wrong day for non-UTC clients near midnight.
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
   } catch {
     return dateStr?.slice(0, 10) || ''
   }


### PR DESCRIPTION
## Problem

In `frontend/src/components/HistoryDatabase.vue`, the history card's **date** and **time** are derived from different time zones, so they can disagree by up to a day.

```js
const formatDate = (dateStr) => {           // UTC
  const date = new Date(dateStr)
  return date.toISOString().slice(0, 10)
}
const formatTime = (dateStr) => {           // local
  const date = new Date(dateStr)
  return `${date.getHours()...}:${date.getMinutes()...}`
}
```

`created_at` is a **naive-local** timestamp (`datetime.now().isoformat()`), returned verbatim by the history API. `new Date("2026-07-08T01:00:00")` is parsed as local; `formatTime` shows the local clock, but `formatDate`'s `toISOString()` converts to UTC first. For any non-UTC client the day can shift — e.g. for the project's UTC+8 audience, a record created between 00:00 and 08:00 local shows **yesterday's** date next to today's time.

## Fix

Derive the date from local components, matching `formatTime`:

```js
const year = date.getFullYear()
const month = String(date.getMonth() + 1).padStart(2, '0')
const day = String(date.getDate()).padStart(2, '0')
return `${year}-${month}-${day}`
```

## Verification

Extracted both helpers and ran them under Node on a UTC+3 machine with the naive timestamp `2026-07-08T01:00:00`:

- `formatTime` → `01:00` (local, July 8)
- **Before:** `formatDate` → `2026-07-07` (UTC) — wrong day
- **After:** `formatDate` → `2026-07-08` — matches the time shown

Under `TZ=UTC` the discrepancy disappears in both versions, confirming the time zone was the sole cause. (No frontend test suite exists; happy to add a vitest case if you set one up.)
