### PR TITLE
fix: cap Zep edge pagination without breaking callers

### DIFF
--- a/backend/app/utils/zep_paging.py
+++ b/backend/app/utils/zep_paging.py
@@ -19,6 +19,7 @@ logger = get_logger('mirofish.zep_paging')
 
 _DEFAULT_PAGE_SIZE = 100
 _MAX_NODES = 2000
+_MAX_EDGES = 5000
 _DEFAULT_MAX_RETRIES = 3
 _DEFAULT_RETRY_DELAY = 2.0  # seconds, doubles each retry
 
@@ -106,10 +107,11 @@ def fetch_all_edges(
     client: Zep,
     graph_id: str,
     page_size: int = _DEFAULT_PAGE_SIZE,
+    max_items: int = _MAX_EDGES,
     max_retries: int = _DEFAULT_MAX_RETRIES,
     retry_delay: float = _DEFAULT_RETRY_DELAY,
 ) -> list[Any]:
-    """分页获取图谱所有边，返回完整列表。每页请求自带重试。"""
+    """分页获取图谱所有边，最多返回 max_items 条（默认 5000）。每页请求自带重试。"""
     all_edges: list[Any] = []
     cursor: str | None = None
     page_num = 0
@@ -132,6 +134,10 @@ def fetch_all_edges(
             break
 
         all_edges.extend(batch)
+        if len(all_edges) >= max_items:
+            all_edges = all_edges[:max_items]
+            logger.warning(f"Edge count reached limit ({max_items}), stopping pagination for graph {graph_id}")
+            break
         if len(batch) < page_size:
             break
 

--- a/backend/app/utils/zep_paging.py
+++ b/backend/app/utils/zep_paging.py
@@ -107,9 +107,9 @@ def fetch_all_edges(
     client: Zep,
     graph_id: str,
     page_size: int = _DEFAULT_PAGE_SIZE,
-    max_items: int = _MAX_EDGES,
     max_retries: int = _DEFAULT_MAX_RETRIES,
     retry_delay: float = _DEFAULT_RETRY_DELAY,
+    max_items: int = _MAX_EDGES,
 ) -> list[Any]:
     """分页获取图谱所有边，最多返回 max_items 条（默认 5000）。每页请求自带重试。"""
     all_edges: list[Any] = []

--- a/backend/tests/test_zep_edge_paging.py
+++ b/backend/tests/test_zep_edge_paging.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+
+from app.utils import zep_paging
+
+
+def _client():
+    edge_api = SimpleNamespace(get_by_graph_id=lambda *args, **kwargs: [])
+    return SimpleNamespace(graph=SimpleNamespace(edge=edge_api))
+
+
+def test_edge_cap_stops_pagination_at_requested_limit(monkeypatch):
+    pages = [
+        [SimpleNamespace(uuid_="e1"), SimpleNamespace(uuid_="e2")],
+        [SimpleNamespace(uuid_="e3"), SimpleNamespace(uuid_="e4")],
+    ]
+    calls = []
+
+    def fake_fetch(*args, **kwargs):
+        calls.append(kwargs)
+        return pages[len(calls) - 1]
+
+    monkeypatch.setattr(zep_paging, "_fetch_page_with_retry", fake_fetch)
+
+    result = zep_paging.fetch_all_edges(_client(), "graph", page_size=2, max_items=3)
+
+    assert [edge.uuid_ for edge in result] == ["e1", "e2", "e3"]
+    assert len(calls) == 2
+    assert calls[1]["uuid_cursor"] == "e2"
+
+
+def test_existing_positional_retry_arguments_keep_their_meaning(monkeypatch):
+    observed = {}
+
+    def fake_fetch(*args, **kwargs):
+        observed.update(kwargs)
+        return []
+
+    monkeypatch.setattr(zep_paging, "_fetch_page_with_retry", fake_fetch)
+
+    zep_paging.fetch_all_edges(_client(), "graph", 25, 7, 0.25)
+
+    assert observed["limit"] == 25
+    assert observed["max_retries"] == 7
+    assert observed["retry_delay"] == 0.25


### PR DESCRIPTION
## Summary

- cap Zep edge pagination at 5,000 items by default
- preserve the existing positional meanings of `max_retries` and `retry_delay`
- add regression coverage for cursor progression, truncation, and legacy positional calls

## Why

PR #515 correctly identified that edge pagination could grow without a bound, but inserted `max_items` between existing positional parameters. Older positional callers would silently reinterpret retry values as the item cap. This maintainer version keeps the useful memory guard without changing that public call behavior.

The implementation was checked against the repository-pinned `zep-cloud==3.13.0`: `edge.get_by_graph_id` accepts `limit` and `uuid_cursor`, returns a list, and exposes the item UUID as `uuid_`.

## Validation

- `uv run pytest -q tests/test_zep_edge_paging.py` — 2 passed
- Python compileall passed
- `git diff --check` passed
- reconstructed on the current main branch

Preserves the original contributor commit and supersedes #515.

Fixes #513

🤖 Sent by the MiroFish repository maintenance agent.
