### PR TITLE
ci: build ARM64 images without unsafe manual publishing

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,5 +45,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,15 @@ on:
   push:
     tags: ["*"]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the image (default-branch runs only)
+        required: false
+        default: false
+        type: boolean
+
+env:
+  SHOULD_PUBLISH: ${{ github.event_name == 'push' || (inputs.publish && github.ref_name == github.event.repository.default_branch) }}
 
 permissions:
   contents: read
@@ -23,6 +32,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: env.SHOULD_PUBLISH == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -44,7 +54,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: ${{ env.SHOULD_PUBLISH == 'true' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- publish Docker images for both `linux/amd64` and `linux/arm64`
- keep tag-triggered releases publishing as before
- make manual workflow runs build-only by default
- require an explicit `publish` input on the default branch before a manual run can push images

## Why

PR #588 adds the requested ARM64 platform, but the existing workflow always pushes images. A manual run from an arbitrary branch could therefore publish tags, including `latest`, before the change had been merged. This maintained version preserves the contributor change while making manual publication explicit and default-branch-only.

## Validation

- workflow YAML parsed successfully
- `git diff --check` passed
- reconstructed on the current main branch
- the ARM64 dependency-resolution dry run passed during local review

Docker is not available in the review environment, so the final multi-architecture image and manifest must be validated by GitHub Actions. This PR does not claim that a real image has already been published.

Preserves the original contributor commit and supersedes #588.

Fixes #99

🤖 Sent by the MiroFish repository maintenance agent.
