### PR TITLE
fix: prioritize terminal simulation failure over inferred completion

### DIFF
--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -513,6 +513,7 @@ const fetchRunStatus = async () => {
       
       // 检测模拟是否已完成（通过 runner_status 或平台完成状态判断）
       const isCompleted = data.runner_status === 'completed' || data.runner_status === 'stopped'
+      const isFailed = data.runner_status === 'failed'
       
       // 额外检查：如果后端还没来得及更新 runner_status，但平台已经报告完成
       // 通过检测 twitter_completed 和 reddit_completed 状态判断
@@ -526,6 +527,11 @@ const fetchRunStatus = async () => {
         phase.value = 2
         stopPolling()
         emit('update-status', 'completed')
+      } else if (isFailed) {
+        addLog(t('log.simFailed') + (data.error ? `: ${data.error}` : ''))
+        phase.value = 2
+        stopPolling()
+        emit('update-status', 'error')
       }
     }
   } catch (err) {

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -519,7 +519,15 @@ const fetchRunStatus = async () => {
       // 通过检测 twitter_completed 和 reddit_completed 状态判断
       const platformsCompleted = checkPlatformsCompleted(data)
       
-      if (isCompleted || platformsCompleted) {
+      // An explicit runner failure is authoritative. Platform completion flags
+      // can be stale or partial when one subprocess exits successfully before
+      // another subprocess fails, so inferred completion must not mask it.
+      if (isFailed) {
+        addLog(t('log.simFailed') + (data.error ? `: ${data.error}` : ''))
+        phase.value = 2
+        stopPolling()
+        emit('update-status', 'error')
+      } else if (isCompleted || platformsCompleted) {
         if (platformsCompleted && !isCompleted) {
           addLog(t('log.allPlatformsCompleted'))
         }
@@ -527,11 +535,6 @@ const fetchRunStatus = async () => {
         phase.value = 2
         stopPolling()
         emit('update-status', 'completed')
-      } else if (isFailed) {
-        addLog(t('log.simFailed') + (data.error ? `: ${data.error}` : ''))
-        phase.value = 2
-        stopPolling()
-        emit('update-status', 'error')
       }
     }
   } catch (err) {

--- a/locales/en.json
+++ b/locales/en.json
@@ -537,6 +537,7 @@
     "stopException": "Stop error: {error}",
     "allPlatformsCompleted": "✓ All platform simulations have ended",
     "simCompleted": "✓ Simulation completed",
+    "simFailed": "✗ Simulation failed",
     "reportRequestSent": "Report generation request sent, please wait...",
     "startingReportGen": "Starting report generation...",
     "reportGenTaskStarted": "✓ Report generation task started: {reportId}",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -537,6 +537,7 @@
     "stopException": "停止异常: {error}",
     "allPlatformsCompleted": "✓ 检测到所有平台模拟已结束",
     "simCompleted": "✓ 模拟已完成",
+    "simFailed": "✗ 模拟失败",
     "reportRequestSent": "报告生成请求已发送，请稍候...",
     "startingReportGen": "正在启动报告生成...",
     "reportGenTaskStarted": "✓ 报告生成任务已启动: {reportId}",


### PR DESCRIPTION
## Summary

- stop simulation polling when the runner reports a terminal failure
- display the backend error and emit the frontend error state
- give an explicit runner failure precedence over inferred platform completion
- retain the contributor-provided English and Chinese translations

## Why

PR #518 correctly added handling for `runner_status === "failed"`, but evaluated inferred platform completion first. If one platform completed while another failed with zero actions, the UI could still report the whole simulation as completed. This maintained version makes the explicit terminal runner state authoritative.

## Validation

- deterministic terminal-state matrix passed
- reproduced the original failed-as-completed state on the contributor implementation
- verified the maintained implementation returns the error state for the same fixture
- frontend production build passed
- `git diff --check` passed

Preserves the original contributor commit and supersedes #518.

🤖 Sent by the MiroFish repository maintenance agent.
