### PR TITLE
fix: use the supported Zep node-edge method

### DIFF
--- a/backend/app/services/zep_entity_reader.py
+++ b/backend/app/services/zep_entity_reader.py
@@ -192,7 +192,7 @@ class ZepEntityReader:
         try:
             # 使用重试机制调用Zep API
             edges = self._call_with_retry(
-                func=lambda: self.client.graph.node.get_entity_edges(node_uuid=node_uuid),
+                func=lambda: self.client.graph.node.get_edges(node_uuid=node_uuid),
                 operation_name=f"获取节点边(node={node_uuid[:8]}...)"
             )
             
@@ -433,5 +433,4 @@ class ZepEntityReader:
             enrich_with_edges=enrich_with_edges
         )
         return result.entities
-
 

--- a/backend/tests/test_zep_entity_reader_edges.py
+++ b/backend/tests/test_zep_entity_reader_edges.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+
+from app.services.zep_entity_reader import ZepEntityReader
+from zep_cloud.graph.node.client import NodeClient
+
+
+def test_pinned_zep_sdk_exposes_get_edges_not_get_entity_edges():
+    assert hasattr(NodeClient, "get_edges")
+    assert not hasattr(NodeClient, "get_entity_edges")
+
+
+def test_get_node_edges_uses_the_supported_sdk_method():
+    calls = []
+
+    class NodeApi:
+        def get_edges(self, *, node_uuid):
+            calls.append(node_uuid)
+            return [SimpleNamespace(
+                uuid_="edge-1",
+                name="KNOWS",
+                fact="Alice knows Bob",
+                source_node_uuid="node-1",
+                target_node_uuid="node-2",
+                attributes={"since": "2024"},
+            )]
+
+    class GraphApi:
+        node = NodeApi()
+
+    class Client:
+        graph = GraphApi()
+
+    reader = object.__new__(ZepEntityReader)
+    reader.client = Client()
+
+    assert reader.get_node_edges("node-1") == [{
+        "uuid": "edge-1",
+        "name": "KNOWS",
+        "fact": "Alice knows Bob",
+        "source_node_uuid": "node-1",
+        "target_node_uuid": "node-2",
+        "attributes": {"since": "2024"},
+    }]
+    assert calls == ["node-1"]


### PR DESCRIPTION
## Summary

- replace the nonexistent `graph.node.get_entity_edges` call with the supported `graph.node.get_edges` method
- add a pinned-SDK contract test for the method name
- verify that node-edge results retain UUID, fact, endpoints, and attributes

## Why

MiroFish pins `zep-cloud==3.13.0`. That SDK exposes `NodeClient.get_edges(node_uuid=...)` and does not expose `get_entity_edges`. The current invalid call is caught by the broad retry/error boundary, so it retries three times and then silently returns an empty edge list instead of crashing visibly.

The current `zep-cloud==3.25.0` SDK retains the same `get_edges` method, so this fix is compatible with both the repository baseline and the current official client.

## Validation

- focused node-edge contract tests: 2 passed
- complete backend suite: 44 passed
- Python compileall passed
- `git diff --check` passed
- reconstructed on the final round-two main branch

No `ZEP_API_KEY` was configured and no commercial online request was sent. The tests exercise the exact pinned SDK surface and a deterministic client fixture.

This is an independent baseline fix discovered during the round-two Zep compatibility review; it is not attributed to #336 or any contributor PR.

🤖 Sent by the MiroFish repository maintenance agent.
