### PR TITLE
fix(simulation): stop returning Python tracebacks in API error responses

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4,7 +4,6 @@ Step2: Zep实体读取与过滤、OASIS模拟准备与运行（全程自动化�
 """
 
 import os
-import traceback
 from contextlib import nullcontext
 from flask import request, jsonify, send_file
 
@@ -112,11 +111,10 @@ def get_graph_entities(graph_id: str):
         })
         
     except Exception as e:
-        logger.error(f"获取图谱实体失败: {str(e)}")
+        logger.error(f"获取图谱实体失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -145,11 +143,10 @@ def get_entity_detail(graph_id: str, entity_uuid: str):
         })
         
     except Exception as e:
-        logger.error(f"获取实体详情失败: {str(e)}")
+        logger.error(f"获取实体详情失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -182,11 +179,10 @@ def get_entities_by_type(graph_id: str, entity_type: str):
         })
         
     except Exception as e:
-        logger.error(f"获取实体失败: {str(e)}")
+        logger.error(f"获取实体失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -259,11 +255,10 @@ def create_simulation():
         })
         
     except Exception as e:
-        logger.error(f"创建模拟失败: {str(e)}")
+        logger.error(f"创建模拟失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -632,7 +627,7 @@ def prepare_simulation():
                     )
                 
             except Exception as e:
-                logger.error(f"准备模拟失败: {str(e)}")
+                logger.error(f"准备模拟失败: {str(e)}", exc_info=True)
                 task_manager.fail_task(task_id, str(e))
                 
                 # 更新模拟状态为失败
@@ -666,11 +661,10 @@ def prepare_simulation():
         }), 404
         
     except Exception as e:
-        logger.error(f"启动准备任务失败: {str(e)}")
+        logger.error(f"启动准备任务失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -780,7 +774,7 @@ def get_prepare_status():
         })
         
     except Exception as e:
-        logger.error(f"查询任务状态失败: {str(e)}")
+        logger.error(f"查询任务状态失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
             "error": str(e)
@@ -812,11 +806,10 @@ def get_simulation(simulation_id: str):
         })
         
     except Exception as e:
-        logger.error(f"获取模拟状态失败: {str(e)}")
+        logger.error(f"获取模拟状态失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -841,11 +834,10 @@ def list_simulations():
         })
         
     except Exception as e:
-        logger.error(f"列出模拟失败: {str(e)}")
+        logger.error(f"列出模拟失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -1014,11 +1006,10 @@ def get_simulation_history():
         })
         
     except Exception as e:
-        logger.error(f"获取历史模拟失败: {str(e)}")
+        logger.error(f"获取历史模拟失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -1052,11 +1043,10 @@ def get_simulation_profiles(simulation_id: str):
         }), 404
         
     except Exception as e:
-        logger.error(f"获取Profile失败: {str(e)}")
+        logger.error(f"获取Profile失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -1167,11 +1157,10 @@ def get_simulation_profiles_realtime(simulation_id: str):
         })
         
     except Exception as e:
-        logger.error(f"实时获取Profile失败: {str(e)}")
+        logger.error(f"实时获取Profile失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -1297,11 +1286,10 @@ def get_simulation_config_realtime(simulation_id: str):
         })
         
     except Exception as e:
-        logger.error(f"实时获取Config失败: {str(e)}")
+        logger.error(f"实时获取Config失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -1333,11 +1321,10 @@ def get_simulation_config(simulation_id: str):
         })
         
     except Exception as e:
-        logger.error(f"获取配置失败: {str(e)}")
+        logger.error(f"获取配置失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -1362,11 +1349,10 @@ def download_simulation_config(simulation_id: str):
         )
         
     except Exception as e:
-        logger.error(f"下载配置失败: {str(e)}")
+        logger.error(f"下载配置失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -1414,11 +1400,10 @@ def download_simulation_script(script_name: str):
         )
         
     except Exception as e:
-        logger.error(f"下载脚本失败: {str(e)}")
+        logger.error(f"下载脚本失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -1488,11 +1473,10 @@ def generate_profiles():
         })
         
     except Exception as e:
-        logger.error(f"生成Profile失败: {str(e)}")
+        logger.error(f"生成Profile失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -1777,11 +1761,10 @@ def start_simulation():
         }), 400
         
     except Exception as e:
-        logger.error(f"启动模拟失败: {str(e)}")
+        logger.error(f"启动模拟失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -1844,7 +1827,7 @@ def stop_simulation():
         }), 400
         
     except Exception as e:
-        logger.error(f"停止模拟失败: {str(e)}")
+        logger.error(f"停止模拟失败: {str(e)}", exc_info=True)
         simulation_id = (request.get_json(silent=True) or {}).get('simulation_id')
         if simulation_id:
             manager = SimulationManager()
@@ -1855,8 +1838,7 @@ def stop_simulation():
                 manager._save_simulation_state(state)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -1912,11 +1894,10 @@ def get_run_status(simulation_id: str):
         })
         
     except Exception as e:
-        logger.error(f"获取运行状态失败: {str(e)}")
+        logger.error(f"获取运行状态失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2013,11 +1994,10 @@ def get_run_status_detail(simulation_id: str):
         })
         
     except Exception as e:
-        logger.error(f"获取详细状态失败: {str(e)}")
+        logger.error(f"获取详细状态失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2067,11 +2047,10 @@ def get_simulation_actions(simulation_id: str):
         })
         
     except Exception as e:
-        logger.error(f"获取动作历史失败: {str(e)}")
+        logger.error(f"获取动作历史失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2107,11 +2086,10 @@ def get_simulation_timeline(simulation_id: str):
         })
         
     except Exception as e:
-        logger.error(f"获取时间线失败: {str(e)}")
+        logger.error(f"获取时间线失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2134,11 +2112,10 @@ def get_agent_stats(simulation_id: str):
         })
         
     except Exception as e:
-        logger.error(f"获取Agent统计失败: {str(e)}")
+        logger.error(f"获取Agent统计失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2214,11 +2191,10 @@ def get_simulation_posts(simulation_id: str):
         })
         
     except Exception as e:
-        logger.error(f"获取帖子失败: {str(e)}")
+        logger.error(f"获取帖子失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2291,11 +2267,10 @@ def get_simulation_comments(simulation_id: str):
         })
         
     except Exception as e:
-        logger.error(f"获取评论失败: {str(e)}")
+        logger.error(f"获取评论失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2422,11 +2397,10 @@ def interview_agent():
         }), 504
         
     except Exception as e:
-        logger.error(f"Interview失败: {str(e)}")
+        logger.error(f"Interview失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2560,11 +2534,10 @@ def interview_agents_batch():
         }), 504
 
     except Exception as e:
-        logger.error(f"批量Interview失败: {str(e)}")
+        logger.error(f"批量Interview失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2663,11 +2636,10 @@ def interview_all_agents():
         }), 504
 
     except Exception as e:
-        logger.error(f"全局Interview失败: {str(e)}")
+        logger.error(f"全局Interview失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2735,11 +2707,10 @@ def get_interview_history():
         })
 
     except Exception as e:
-        logger.error(f"获取Interview历史失败: {str(e)}")
+        logger.error(f"获取Interview历史失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2800,11 +2771,10 @@ def get_env_status():
         })
 
     except Exception as e:
-        logger.error(f"获取环境状态失败: {str(e)}")
+        logger.error(f"获取环境状态失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500
 
 
@@ -2870,9 +2840,8 @@ def close_simulation_env():
         }), 400
         
     except Exception as e:
-        logger.error(f"关闭环境失败: {str(e)}")
+        logger.error(f"关闭环境失败: {str(e)}", exc_info=True)
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": str(e)
         }), 500


### PR DESCRIPTION
# fix(simulation): stop returning Python tracebacks in API error responses

## Summary

The Flask blueprint `backend/app/api/simulation.py` currently returns `traceback.format_exc()` inside the JSON body of every 500 response (around 20 endpoints). Any client that triggers a handled `Exception` gets back the full Python stack trace, which discloses:

- absolute filesystem paths of the deployment (e.g. install directory, virtualenv location),
- exact versions and internal module layout of third-party libraries in use,
- internal function names, file structure, and line numbers of `MiroFish`'s own code.

This is a textbook **CWE-209: Generation of Error Message Containing Sensitive Information**. On its own the impact is information disclosure (Low/Info), but it's a useful recon primitive for an attacker planning a follow-up (dependency-CVE targeting, path guessing for other file endpoints, etc.).

### Why this is reachable by an unauthenticated attacker

- The backend has no authentication middleware on the simulation blueprint (`grep -n "before_request\|@login_required" backend/app/api/simulation.py` returns nothing).
- CORS is configured with `origins: "*"`, so any origin can call the API from a browser.
- Every affected endpoint takes user-controlled path or JSON parameters (e.g. `graph_id`, `simulation_id`, `entity_uuid`) that are easy to make invalid, which is enough to trip the `except Exception` branch and produce the leaky response.

## Fix

Replace the leaking pattern

```python
except Exception as e:
    logger.error(f"...: {str(e)}")
    return jsonify({
        "success": False,
        "error": str(e),
        "traceback": traceback.format_exc(),
    }), 500
```

with

```python
except Exception as e:
    logger.error(f"...: {str(e)}", exc_info=True)
    return jsonify({
        "success": False,
        "error": str(e),
    }), 500
```

The full traceback is still captured server-side via `logger.error(..., exc_info=True)` so operators keep the debugging signal; only the client-facing JSON is stripped. The `import traceback` line is also removed since it's no longer used.

Scope: `backend/app/api/simulation.py` only, ~20 handlers. Diff is +62/-93 in a single file — no behavior change beyond the response body shape.

## Proof of concept

With the backend running locally (`python backend/run.py` or however you normally start it):

```bash
# Any invalid graph_id trips the except branch.
curl -s http://127.0.0.1:5000/api/simulation/entities/does-not-exist | jq .
```

Before the fix, the JSON response contains a `"traceback"` field with the full Python stack, absolute paths, and library internals. After the fix, the response is `{"success": false, "error": "..."}` with no stack trace, and the traceback is written to the server log instead.

Every route mentioned above exists in `backend/app/api/simulation.py` (e.g. line 77 `@simulation_bp.route('/entities/<graph_id>', ...)`).

## Testing

- Ran the backend test suite: **130/130 passing** after the change.
- Manually triggered several of the patched handlers with bad IDs and confirmed the response no longer includes `traceback`, while `exc_info=True` produces the full trace in the server log.

## Adversarial review

Before submitting we tried to disprove this. Things we considered:

- **Is Flask running with `DEBUG=False` enough?** No — `DEBUG` only controls Flask's own default 500 page and the interactive debugger. These handlers explicitly build the JSON body themselves and include `traceback.format_exc()` regardless of debug mode.
- **Is there an auth layer we missed?** We grepped for `before_request`, `login_required`, JWT/session middleware, and router-level auth dependencies. None are applied to the simulation blueprint. Combined with `CORS(origins="*")`, the endpoints are reachable by any network-adjacent attacker.
- **Is the information really sensitive?** Filesystem paths and dependency internals on their own aren't catastrophic, but they're clearly beyond what a public API should hand out, and CWE-209 exists precisely for this. Removing the field is a straightforward hardening step with no downside.

## Note for maintainers (out of scope for this PR)

The same `"traceback": traceback.format_exc()` pattern exists in a few other files (`backend/app/api/graph.py`, `backend/app/api/report.py`). We kept this PR narrowly scoped to `simulation.py` to keep the diff reviewable, but you may want to apply the same treatment there in a follow-up.