### PR TITLE
feat(simulation): deliver event_config.scheduled_events end to end

### DIFF
--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -272,31 +272,35 @@ class OasisProfileGenerator:
                 logger.warning(f"Zep客户端初始化失败: {e}")
     
     def generate_profile_from_entity(
-        self, 
-        entity: EntityNode, 
+        self,
+        entity: EntityNode,
         user_id: int,
-        use_llm: bool = True
+        use_llm: bool = True,
+        stance: str = "neutral",
+        sentiment_bias: float = 0.0
     ) -> OasisAgentProfile:
         """
         从Zep实体生成OASIS Agent Profile
-        
+
         Args:
             entity: Zep实体节点
             user_id: 用户ID（用于OASIS）
             use_llm: 是否使用LLM生成详细人设
-            
+            stance: 该Agent对模拟话题的立场（supportive/opposing/neutral/observer）
+            sentiment_bias: 情感倾向（-1.0负面 到 1.0正面）
+
         Returns:
             OasisAgentProfile
         """
         entity_type = entity.get_entity_type() or "Entity"
-        
+
         # 基础信息
         name = entity.name
         user_name = self._generate_username(name)
-        
+
         # 构建上下文信息
         context = self._build_entity_context(entity)
-        
+
         if use_llm:
             # 使用LLM生成详细人设
             profile_data = self._generate_profile_with_llm(
@@ -304,7 +308,9 @@ class OasisProfileGenerator:
                 entity_type=entity_type,
                 entity_summary=entity.summary,
                 entity_attributes=entity.attributes,
-                context=context
+                context=context,
+                stance=stance,
+                sentiment_bias=sentiment_bias
             )
         else:
             # 使用规则生成基础人设
@@ -543,25 +549,28 @@ class OasisProfileGenerator:
         entity_type: str,
         entity_summary: str,
         entity_attributes: Dict[str, Any],
-        context: str
+        context: str,
+        stance: str = "neutral",
+        sentiment_bias: float = 0.0
     ) -> Dict[str, Any]:
         """
         使用LLM生成非常详细的人设
-        
+
         根据实体类型区分：
         - 个人实体：生成具体的人物设定
         - 群体/机构实体：生成代表性账号设定
         """
-        
         is_individual = self._is_individual_entity(entity_type)
-        
+
         if is_individual:
             prompt = self._build_individual_persona_prompt(
-                entity_name, entity_type, entity_summary, entity_attributes, context
+                entity_name, entity_type, entity_summary, entity_attributes, context,
+                stance=stance, sentiment_bias=sentiment_bias
             )
         else:
             prompt = self._build_group_persona_prompt(
-                entity_name, entity_type, entity_summary, entity_attributes, context
+                entity_name, entity_type, entity_summary, entity_attributes, context,
+                stance=stance, sentiment_bias=sentiment_bias
             )
 
         # 尝试多次生成，直到成功或达到最大重试次数
@@ -724,13 +733,15 @@ class OasisProfileGenerator:
         entity_type: str,
         entity_summary: str,
         entity_attributes: Dict[str, Any],
-        context: str
+        context: str,
+        stance: str = "neutral",
+        sentiment_bias: float = 0.0
     ) -> str:
-        """构建个人实体的详细人设提示词"""
-        
+        """构建个人实体的详细人设提示词（stance/sentiment_bias 注入人设文本）"""
+
         attrs_str = json.dumps(entity_attributes, ensure_ascii=False) if entity_attributes else "无"
         context_str = context[:3000] if context else "无额外上下文"
-        
+
         return f"""为实体生成详细的社交媒体用户人设,最大程度还原已有现实情况。
 
 实体名称: {entity_name}
@@ -741,6 +752,10 @@ class OasisProfileGenerator:
 上下文信息:
 {context_str}
 
+立场与情感设定（必须体现在人设中）:
+- stance: {stance}（对模拟话题的立场）
+- sentiment_bias: {sentiment_bias}（情感倾向，-1.0负面 到 1.0正面）
+
 请生成JSON，包含以下字段:
 
 1. bio: 社交媒体简介，200字
@@ -749,7 +764,7 @@ class OasisProfileGenerator:
    - 人物背景（重要经历、与事件的关联、社会关系）
    - 性格特征（MBTI类型、核心性格、情绪表达方式）
    - 社交媒体行为（发帖频率、内容偏好、互动风格、语言特点）
-   - 立场观点（对话题的态度、可能被激怒/感动的内容）
+   - 立场观点（对话题的态度、可能被激怒/感动的内容；**必须明确表达设定的 stance={stance} 与情感倾向 sentiment_bias={sentiment_bias}**）
    - 独特特征（口头禅、特殊经历、个人爱好）
    - 个人记忆（人设的重要部分，要介绍这个个体与事件的关联，以及这个个体在事件中的已有动作与反应）
 3. age: 年龄数字（必须是整数）
@@ -773,13 +788,15 @@ class OasisProfileGenerator:
         entity_type: str,
         entity_summary: str,
         entity_attributes: Dict[str, Any],
-        context: str
+        context: str,
+        stance: str = "neutral",
+        sentiment_bias: float = 0.0
     ) -> str:
-        """构建群体/机构实体的详细人设提示词"""
-        
+        """构建群体/机构实体的详细人设提示词（stance/sentiment_bias 注入人设文本）"""
+
         attrs_str = json.dumps(entity_attributes, ensure_ascii=False) if entity_attributes else "无"
         context_str = context[:3000] if context else "无额外上下文"
-        
+
         return f"""为机构/群体实体生成详细的社交媒体账号设定,最大程度还原已有现实情况。
 
 实体名称: {entity_name}
@@ -790,6 +807,10 @@ class OasisProfileGenerator:
 上下文信息:
 {context_str}
 
+立场与情感设定（必须体现在人设中）:
+- stance: {stance}（对模拟话题的立场）
+- sentiment_bias: {sentiment_bias}（情感倾向，-1.0负面 到 1.0正面）
+
 请生成JSON，包含以下字段:
 
 1. bio: 官方账号简介，200字，专业得体
@@ -798,7 +819,7 @@ class OasisProfileGenerator:
    - 账号定位（账号类型、目标受众、核心功能）
    - 发言风格（语言特点、常用表达、禁忌话题）
    - 发布内容特点（内容类型、发布频率、活跃时间段）
-   - 立场态度（对核心话题的官方立场、面对争议的处理方式）
+   - 立场态度（对核心话题的官方立场、面对争议的处理方式；**必须明确表达设定的 stance={stance} 与情感倾向 sentiment_bias={sentiment_bias}**）
    - 特殊说明（代表的群体画像、运营习惯）
    - 机构记忆（机构人设的重要部分，要介绍这个机构与事件的关联，以及这个机构在事件中的已有动作与反应）
 3. age: 固定填30（机构账号的虚拟年龄）
@@ -900,11 +921,12 @@ class OasisProfileGenerator:
         graph_id: Optional[str] = None,
         parallel_count: int = 5,
         realtime_output_path: Optional[str] = None,
-        output_platform: str = "reddit"
+        output_platform: str = "reddit",
+        agent_activity_map: Optional[Dict[str, Dict[str, Any]]] = None
     ) -> List[OasisAgentProfile]:
         """
         批量从实体生成Agent Profile（支持并行生成）
-        
+
         Args:
             entities: 实体列表
             use_llm: 是否使用LLM生成详细人设
@@ -913,7 +935,9 @@ class OasisProfileGenerator:
             parallel_count: 并行生成数量，默认5
             realtime_output_path: 实时写入的文件路径（如果提供，每生成一个就写入一次）
             output_platform: 输出平台格式 ("reddit" 或 "twitter")
-            
+            agent_activity_map: 按实体名称索引的活动配置（含 stance / sentiment_bias），
+                用于把每个 Agent 的立场与情感倾向注入人设；未提供时使用中性默认值
+
         Returns:
             Agent Profile列表
         """
@@ -967,12 +991,17 @@ class OasisProfileGenerator:
             """生成单个profile的工作函数"""
             set_locale(current_locale)
             entity_type = entity.get_entity_type() or "Entity"
-            
+
+            # 查找该实体的立场与情感倾向（未提供时使用中性默认值）
+            activity = (agent_activity_map or {}).get(entity.name, {}) or {}
+
             try:
                 profile = self.generate_profile_from_entity(
                     entity=entity,
                     user_id=idx,
-                    use_llm=use_llm
+                    use_llm=use_llm,
+                    stance=activity.get("stance", "neutral"),
+                    sentiment_bias=activity.get("sentiment_bias", 0.0)
                 )
                 
                 # 实时输出生成的人设到控制台和日志

--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -272,35 +272,31 @@ class OasisProfileGenerator:
                 logger.warning(f"Zep客户端初始化失败: {e}")
     
     def generate_profile_from_entity(
-        self,
-        entity: EntityNode,
+        self, 
+        entity: EntityNode, 
         user_id: int,
-        use_llm: bool = True,
-        stance: str = "neutral",
-        sentiment_bias: float = 0.0
+        use_llm: bool = True
     ) -> OasisAgentProfile:
         """
         从Zep实体生成OASIS Agent Profile
-
+        
         Args:
             entity: Zep实体节点
             user_id: 用户ID（用于OASIS）
             use_llm: 是否使用LLM生成详细人设
-            stance: 该Agent对模拟话题的立场（supportive/opposing/neutral/observer）
-            sentiment_bias: 情感倾向（-1.0负面 到 1.0正面）
-
+            
         Returns:
             OasisAgentProfile
         """
         entity_type = entity.get_entity_type() or "Entity"
-
+        
         # 基础信息
         name = entity.name
         user_name = self._generate_username(name)
-
+        
         # 构建上下文信息
         context = self._build_entity_context(entity)
-
+        
         if use_llm:
             # 使用LLM生成详细人设
             profile_data = self._generate_profile_with_llm(
@@ -308,9 +304,7 @@ class OasisProfileGenerator:
                 entity_type=entity_type,
                 entity_summary=entity.summary,
                 entity_attributes=entity.attributes,
-                context=context,
-                stance=stance,
-                sentiment_bias=sentiment_bias
+                context=context
             )
         else:
             # 使用规则生成基础人设
@@ -549,28 +543,25 @@ class OasisProfileGenerator:
         entity_type: str,
         entity_summary: str,
         entity_attributes: Dict[str, Any],
-        context: str,
-        stance: str = "neutral",
-        sentiment_bias: float = 0.0
+        context: str
     ) -> Dict[str, Any]:
         """
         使用LLM生成非常详细的人设
-
+        
         根据实体类型区分：
         - 个人实体：生成具体的人物设定
         - 群体/机构实体：生成代表性账号设定
         """
+        
         is_individual = self._is_individual_entity(entity_type)
-
+        
         if is_individual:
             prompt = self._build_individual_persona_prompt(
-                entity_name, entity_type, entity_summary, entity_attributes, context,
-                stance=stance, sentiment_bias=sentiment_bias
+                entity_name, entity_type, entity_summary, entity_attributes, context
             )
         else:
             prompt = self._build_group_persona_prompt(
-                entity_name, entity_type, entity_summary, entity_attributes, context,
-                stance=stance, sentiment_bias=sentiment_bias
+                entity_name, entity_type, entity_summary, entity_attributes, context
             )
 
         # 尝试多次生成，直到成功或达到最大重试次数
@@ -733,15 +724,13 @@ class OasisProfileGenerator:
         entity_type: str,
         entity_summary: str,
         entity_attributes: Dict[str, Any],
-        context: str,
-        stance: str = "neutral",
-        sentiment_bias: float = 0.0
+        context: str
     ) -> str:
-        """构建个人实体的详细人设提示词（stance/sentiment_bias 注入人设文本）"""
-
+        """构建个人实体的详细人设提示词"""
+        
         attrs_str = json.dumps(entity_attributes, ensure_ascii=False) if entity_attributes else "无"
         context_str = context[:3000] if context else "无额外上下文"
-
+        
         return f"""为实体生成详细的社交媒体用户人设,最大程度还原已有现实情况。
 
 实体名称: {entity_name}
@@ -752,10 +741,6 @@ class OasisProfileGenerator:
 上下文信息:
 {context_str}
 
-立场与情感设定（必须体现在人设中）:
-- stance: {stance}（对模拟话题的立场）
-- sentiment_bias: {sentiment_bias}（情感倾向，-1.0负面 到 1.0正面）
-
 请生成JSON，包含以下字段:
 
 1. bio: 社交媒体简介，200字
@@ -764,7 +749,7 @@ class OasisProfileGenerator:
    - 人物背景（重要经历、与事件的关联、社会关系）
    - 性格特征（MBTI类型、核心性格、情绪表达方式）
    - 社交媒体行为（发帖频率、内容偏好、互动风格、语言特点）
-   - 立场观点（对话题的态度、可能被激怒/感动的内容；**必须明确表达设定的 stance={stance} 与情感倾向 sentiment_bias={sentiment_bias}**）
+   - 立场观点（对话题的态度、可能被激怒/感动的内容）
    - 独特特征（口头禅、特殊经历、个人爱好）
    - 个人记忆（人设的重要部分，要介绍这个个体与事件的关联，以及这个个体在事件中的已有动作与反应）
 3. age: 年龄数字（必须是整数）
@@ -788,15 +773,13 @@ class OasisProfileGenerator:
         entity_type: str,
         entity_summary: str,
         entity_attributes: Dict[str, Any],
-        context: str,
-        stance: str = "neutral",
-        sentiment_bias: float = 0.0
+        context: str
     ) -> str:
-        """构建群体/机构实体的详细人设提示词（stance/sentiment_bias 注入人设文本）"""
-
+        """构建群体/机构实体的详细人设提示词"""
+        
         attrs_str = json.dumps(entity_attributes, ensure_ascii=False) if entity_attributes else "无"
         context_str = context[:3000] if context else "无额外上下文"
-
+        
         return f"""为机构/群体实体生成详细的社交媒体账号设定,最大程度还原已有现实情况。
 
 实体名称: {entity_name}
@@ -807,10 +790,6 @@ class OasisProfileGenerator:
 上下文信息:
 {context_str}
 
-立场与情感设定（必须体现在人设中）:
-- stance: {stance}（对模拟话题的立场）
-- sentiment_bias: {sentiment_bias}（情感倾向，-1.0负面 到 1.0正面）
-
 请生成JSON，包含以下字段:
 
 1. bio: 官方账号简介，200字，专业得体
@@ -819,7 +798,7 @@ class OasisProfileGenerator:
    - 账号定位（账号类型、目标受众、核心功能）
    - 发言风格（语言特点、常用表达、禁忌话题）
    - 发布内容特点（内容类型、发布频率、活跃时间段）
-   - 立场态度（对核心话题的官方立场、面对争议的处理方式；**必须明确表达设定的 stance={stance} 与情感倾向 sentiment_bias={sentiment_bias}**）
+   - 立场态度（对核心话题的官方立场、面对争议的处理方式）
    - 特殊说明（代表的群体画像、运营习惯）
    - 机构记忆（机构人设的重要部分，要介绍这个机构与事件的关联，以及这个机构在事件中的已有动作与反应）
 3. age: 固定填30（机构账号的虚拟年龄）
@@ -921,12 +900,11 @@ class OasisProfileGenerator:
         graph_id: Optional[str] = None,
         parallel_count: int = 5,
         realtime_output_path: Optional[str] = None,
-        output_platform: str = "reddit",
-        agent_activity_map: Optional[Dict[str, Dict[str, Any]]] = None
+        output_platform: str = "reddit"
     ) -> List[OasisAgentProfile]:
         """
         批量从实体生成Agent Profile（支持并行生成）
-
+        
         Args:
             entities: 实体列表
             use_llm: 是否使用LLM生成详细人设
@@ -935,9 +913,7 @@ class OasisProfileGenerator:
             parallel_count: 并行生成数量，默认5
             realtime_output_path: 实时写入的文件路径（如果提供，每生成一个就写入一次）
             output_platform: 输出平台格式 ("reddit" 或 "twitter")
-            agent_activity_map: 按实体名称索引的活动配置（含 stance / sentiment_bias），
-                用于把每个 Agent 的立场与情感倾向注入人设；未提供时使用中性默认值
-
+            
         Returns:
             Agent Profile列表
         """
@@ -991,17 +967,12 @@ class OasisProfileGenerator:
             """生成单个profile的工作函数"""
             set_locale(current_locale)
             entity_type = entity.get_entity_type() or "Entity"
-
-            # 查找该实体的立场与情感倾向（未提供时使用中性默认值）
-            activity = (agent_activity_map or {}).get(entity.name, {}) or {}
-
+            
             try:
                 profile = self.generate_profile_from_entity(
                     entity=entity,
                     user_id=idx,
-                    use_llm=use_llm,
-                    stance=activity.get("stance", "neutral"),
-                    sentiment_bias=activity.get("sentiment_bias", 0.0)
+                    use_llm=use_llm
                 )
                 
                 # 实时输出生成的人设到控制台和日志

--- a/backend/app/services/simulation_config_generator.py
+++ b/backend/app/services/simulation_config_generator.py
@@ -689,6 +689,7 @@ class SimulationConfigGenerator:
 - 提取热点话题关键词
 - 描述舆论发展方向
 - 设计初始帖子内容，**每个帖子必须指定 poster_type（发布者类型）**
+- 设计若干需要在模拟中途发布的定时事件（scheduled_events），**每个事件的 round 必须落在模拟轮次范围内（不早于第1轮，不晚于最大轮次）**
 
 **重要**: poster_type 必须从上面的"可用实体类型"中选择，这样初始帖子才能分配给合适的 Agent 发布。
 例如：官方声明应由 Official/University 类型发布，新闻由 MediaOutlet 发布，学生观点由 Student 发布。
@@ -699,6 +700,10 @@ class SimulationConfigGenerator:
     "narrative_direction": "<舆论发展方向描述>",
     "initial_posts": [
         {{"content": "帖子内容", "poster_type": "实体类型（必须从可用类型中选择）"}},
+        ...
+    ],
+    "scheduled_events": [
+        {{"round": <轮次编号>, "content": "帖子内容", "poster_type": "实体类型（必须从可用类型中选择）"}},
         ...
     ],
     "reasoning": "<简要说明>"
@@ -715,6 +720,8 @@ class SimulationConfigGenerator:
                 "hot_topics": [],
                 "narrative_direction": "",
                 "initial_posts": [],
+                # 保持 fallback 与正常路径的字典结构一致（含定时事件）
+                "scheduled_events": [],
                 "reasoning": "使用默认配置"
             }
     
@@ -722,32 +729,35 @@ class SimulationConfigGenerator:
         """解析事件配置结果"""
         return EventConfig(
             initial_posts=result.get("initial_posts", []),
-            scheduled_events=[],
+            # 不再丢弃 LLM 生成的定时事件，缺省为空列表
+            scheduled_events=result.get("scheduled_events", []),
             hot_topics=result.get("hot_topics", []),
             narrative_direction=result.get("narrative_direction", "")
         )
     
-    def _assign_initial_post_agents(
+    def _assign_agents_to_posts(
         self,
-        event_config: EventConfig,
-        agent_configs: List[AgentActivityConfig]
-    ) -> EventConfig:
+        posts: List[Dict[str, Any]],
+        agent_configs: List[AgentActivityConfig],
+        agents_by_type: Optional[Dict[str, List[AgentActivityConfig]]] = None,
+        used_indices: Optional[Dict[str, int]] = None
+    ) -> List[Dict[str, Any]]:
         """
-        为初始帖子分配合适的发布者 Agent
-        
-        根据每个帖子的 poster_type 匹配最合适的 agent_id
+        为任意帖子列表分配合适的发布者 Agent（初始帖子与定时事件共用）
+
+        根据每个帖子的 poster_type 匹配最合适的 agent_id。
+        agents_by_type / used_indices 可由调用方传入，使多次调用之间
+        共享类型索引与防重复计数；未传入时在本调用内自行构建。
         """
-        if not event_config.initial_posts:
-            return event_config
-        
-        # 按实体类型建立 agent 索引
-        agents_by_type: Dict[str, List[AgentActivityConfig]] = {}
-        for agent in agent_configs:
-            etype = agent.entity_type.lower()
-            if etype not in agents_by_type:
-                agents_by_type[etype] = []
-            agents_by_type[etype].append(agent)
-        
+        if agents_by_type is None:
+            # 按实体类型建立 agent 索引
+            agents_by_type = {}
+            for agent in agent_configs:
+                etype = agent.entity_type.lower()
+                if etype not in agents_by_type:
+                    agents_by_type[etype] = []
+                agents_by_type[etype].append(agent)
+
         # 类型映射表（处理 LLM 可能输出的不同格式）
         type_aliases = {
             "official": ["official", "university", "governmentagency", "government"],
@@ -759,18 +769,19 @@ class SimulationConfigGenerator:
             "organization": ["organization", "ngo", "company", "group"],
             "person": ["person", "student", "alumni"],
         }
-        
-        # 记录每种类型已使用的 agent 索引，避免重复使用同一个 agent
-        used_indices: Dict[str, int] = {}
-        
+
+        if used_indices is None:
+            # 记录每种类型已使用的 agent 索引，避免重复使用同一个 agent
+            used_indices = {}
+
         updated_posts = []
-        for post in event_config.initial_posts:
+        for post in posts:
             poster_type = post.get("poster_type", "").lower()
             content = post.get("content", "")
-            
+
             # 尝试找到匹配的 agent
             matched_agent_id = None
-            
+
             # 1. 直接匹配
             if poster_type in agents_by_type:
                 agents = agents_by_type[poster_type]
@@ -790,7 +801,7 @@ class SimulationConfigGenerator:
                                 break
                     if matched_agent_id is not None:
                         break
-            
+
             # 3. 如果仍未找到，使用影响力最高的 agent
             if matched_agent_id is None:
                 logger.warning(f"未找到类型 '{poster_type}' 的匹配 Agent，使用影响力最高的 Agent")
@@ -800,16 +811,58 @@ class SimulationConfigGenerator:
                     matched_agent_id = sorted_agents[0].agent_id
                 else:
                     matched_agent_id = 0
-            
-            updated_posts.append({
+
+            updated_post = {
                 "content": content,
                 "poster_type": post.get("poster_type", "Unknown"),
                 "poster_agent_id": matched_agent_id
-            })
-            
-            logger.info(f"初始帖子分配: poster_type='{poster_type}' -> agent_id={matched_agent_id}")
-        
-        event_config.initial_posts = updated_posts
+            }
+            # 定时事件需保留其轮次信息
+            if "round" in post:
+                updated_post["round"] = post["round"]
+
+            updated_posts.append(updated_post)
+
+            logger.info(f"帖子分配: poster_type='{poster_type}' -> agent_id={matched_agent_id}")
+
+        return updated_posts
+
+    def _assign_initial_post_agents(
+        self,
+        event_config: EventConfig,
+        agent_configs: List[AgentActivityConfig]
+    ) -> EventConfig:
+        """
+        为初始帖子与定时事件分配合适的发布者 Agent
+
+        两个列表共享同一类型索引与防重复计数，避免同一 Agent 被重复分配
+        """
+        if not event_config.initial_posts and not event_config.scheduled_events:
+            return event_config
+
+        # 按实体类型建立 agent 索引（初始帖子与定时事件共享）
+        agents_by_type: Dict[str, List[AgentActivityConfig]] = {}
+        for agent in agent_configs:
+            etype = agent.entity_type.lower()
+            if etype not in agents_by_type:
+                agents_by_type[etype] = []
+            agents_by_type[etype].append(agent)
+
+        # 已用索引同样跨两个列表共享
+        used_indices: Dict[str, int] = {}
+
+        event_config.initial_posts = self._assign_agents_to_posts(
+            event_config.initial_posts,
+            agent_configs,
+            agents_by_type=agents_by_type,
+            used_indices=used_indices
+        )
+        event_config.scheduled_events = self._assign_agents_to_posts(
+            event_config.scheduled_events,
+            agent_configs,
+            agents_by_type=agents_by_type,
+            used_indices=used_indices
+        )
         return event_config
     
     def _generate_agent_configs_batch(

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -591,6 +591,14 @@ class RedditSimulationRunner:
         # 执行初始事件
         event_config = self.config.get("event_config", {})
         initial_posts = event_config.get("initial_posts", [])
+        # 读取定时事件并按轮次分组（轮次为 1 基：第 1 轮对应首个循环迭代）
+        scheduled_events = event_config.get("scheduled_events", [])
+        events_by_round: Dict[int, List[Dict[str, Any]]] = {}
+        for ev in scheduled_events:
+            try:
+                events_by_round.setdefault(int(ev.get("round", 0)), []).append(ev)
+            except (TypeError, ValueError):
+                print(f"  警告: 定时事件轮次无效，已跳过: {ev}")
         
         if initial_posts:
             print(f"执行初始事件 ({len(initial_posts)}条初始帖子)...")
@@ -627,7 +635,34 @@ class RedditSimulationRunner:
             simulated_minutes = round_num * minutes_per_round
             simulated_hour = (simulated_minutes // 60) % 24
             simulated_day = simulated_minutes // (60 * 24) + 1
-            
+
+            # 触发本轮的定时事件（在活跃 Agent 决策之前发布）
+            round_events = events_by_round.pop(round_num + 1, [])
+            if round_events:
+                event_actions = {}
+                for ev in round_events:
+                    agent_id = ev.get("poster_agent_id", 0)
+                    content = ev.get("content", "")
+                    try:
+                        agent = self.env.agent_graph.get_agent(agent_id)
+                        if agent in event_actions:
+                            if not isinstance(event_actions[agent], list):
+                                event_actions[agent] = [event_actions[agent]]
+                            event_actions[agent].append(ManualAction(
+                                action_type=ActionType.CREATE_POST,
+                                action_args={"content": content}
+                            ))
+                        else:
+                            event_actions[agent] = ManualAction(
+                                action_type=ActionType.CREATE_POST,
+                                action_args={"content": content}
+                            )
+                    except Exception as e:
+                        print(f"  警告: 无法为Agent {agent_id}创建定时事件帖子: {e}")
+                if event_actions:
+                    await self.env.step(event_actions)
+                    print(f"  第 {round_num + 1} 轮触发 {len(round_events)} 条定时事件")
+
             active_agents = self._get_active_agents_for_round(
                 self.env, simulated_hour, round_num
             )

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -599,7 +599,13 @@ class RedditSimulationRunner:
                 events_by_round.setdefault(int(ev.get("round", 0)), []).append(ev)
             except (TypeError, ValueError):
                 print(f"  警告: 定时事件轮次无效，已跳过: {ev}")
-        
+        # 超出实际轮数的事件永远不会触发（total_rounds 可能已被 max_rounds 截断）：
+        # 明确告警，不要静默丢弃
+        out_of_range = sorted(r for r in events_by_round if r < 1 or r > total_rounds)
+        if out_of_range:
+            print(f"  警告: {len(out_of_range)} 条定时事件的轮次超出实际模拟轮数 "
+                  f"(total_rounds={total_rounds})，将不会触发: {out_of_range}")
+
         if initial_posts:
             print(f"执行初始事件 ({len(initial_posts)}条初始帖子)...")
             initial_actions = {}

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -606,7 +606,15 @@ class TwitterSimulationRunner:
         # 执行初始事件
         event_config = self.config.get("event_config", {})
         initial_posts = event_config.get("initial_posts", [])
-        
+        # 读取定时事件并按轮次分组（轮次为 1 基：第 1 轮对应首个循环迭代）
+        scheduled_events = event_config.get("scheduled_events", [])
+        events_by_round: Dict[int, List[Dict[str, Any]]] = {}
+        for ev in scheduled_events:
+            try:
+                events_by_round.setdefault(int(ev.get("round", 0)), []).append(ev)
+            except (TypeError, ValueError):
+                print(f"  警告: 定时事件轮次无效，已跳过: {ev}")
+
         if initial_posts:
             print(f"执行初始事件 ({len(initial_posts)}条初始帖子)...")
             initial_actions = {}
@@ -635,7 +643,26 @@ class TwitterSimulationRunner:
             simulated_minutes = round_num * minutes_per_round
             simulated_hour = (simulated_minutes // 60) % 24
             simulated_day = simulated_minutes // (60 * 24) + 1
-            
+
+            # 触发本轮的定时事件（在活跃 Agent 决策之前发布）
+            round_events = events_by_round.pop(round_num + 1, [])
+            if round_events:
+                event_actions = {}
+                for ev in round_events:
+                    agent_id = ev.get("poster_agent_id", 0)
+                    content = ev.get("content", "")
+                    try:
+                        agent = self.env.agent_graph.get_agent(agent_id)
+                        event_actions[agent] = ManualAction(
+                            action_type=ActionType.CREATE_POST,
+                            action_args={"content": content}
+                        )
+                    except Exception as e:
+                        print(f"  警告: 无法为Agent {agent_id}创建定时事件帖子: {e}")
+                if event_actions:
+                    await self.env.step(event_actions)
+                    print(f"  第 {round_num + 1} 轮触发 {len(round_events)} 条定时事件")
+
             # 获取本轮激活的Agent
             active_agents = self._get_active_agents_for_round(
                 self.env, simulated_hour, round_num

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -614,6 +614,12 @@ class TwitterSimulationRunner:
                 events_by_round.setdefault(int(ev.get("round", 0)), []).append(ev)
             except (TypeError, ValueError):
                 print(f"  警告: 定时事件轮次无效，已跳过: {ev}")
+        # 超出实际轮数的事件永远不会触发（total_rounds 可能已被 max_rounds 截断）：
+        # 明确告警，不要静默丢弃
+        out_of_range = sorted(r for r in events_by_round if r < 1 or r > total_rounds)
+        if out_of_range:
+            print(f"  警告: {len(out_of_range)} 条定时事件的轮次超出实际模拟轮数 "
+                  f"(total_rounds={total_rounds})，将不会触发: {out_of_range}")
 
         if initial_posts:
             print(f"执行初始事件 ({len(initial_posts)}条初始帖子)...")

--- a/backend/tests/test_scheduled_event_assignment.py
+++ b/backend/tests/test_scheduled_event_assignment.py
@@ -1,0 +1,78 @@
+from app.services.simulation_config_generator import (
+    AgentActivityConfig,
+    EventConfig,
+    SimulationConfigGenerator,
+)
+
+
+def _agent(agent_id: int, name: str, entity_type: str, influence: float = 1.0):
+    return AgentActivityConfig(
+        agent_id=agent_id,
+        entity_uuid=f"uuid-{agent_id}",
+        entity_name=name,
+        entity_type=entity_type,
+        influence_weight=influence,
+    )
+
+
+def _generator() -> SimulationConfigGenerator:
+    # 跳过 __init__（无需 API key），与现有测试的构造方式一致
+    return object.__new__(SimulationConfigGenerator)
+
+
+def test_assign_agents_resolves_poster_type_for_initial_posts_and_scheduled_events():
+    generator = _generator()
+    agents = [_agent(0, "官方", "Official"), _agent(1, "新闻台", "MediaOutlet")]
+
+    event_config = EventConfig(
+        initial_posts=[{"content": "初始帖子", "poster_type": "Official"}],
+        scheduled_events=[{"round": 2, "content": "定时事件", "poster_type": "MediaOutlet"}],
+    )
+
+    updated = generator._assign_initial_post_agents(event_config, agents)
+
+    assert updated.initial_posts[0]["poster_agent_id"] == 0
+    assert updated.scheduled_events[0]["poster_agent_id"] == 1
+    # 定时事件需保留其轮次信息
+    assert updated.scheduled_events[0]["round"] == 2
+
+
+def test_anti_repetition_carries_across_both_lists():
+    generator = _generator()
+    agents = [_agent(0, "甲", "Official"), _agent(1, "乙", "Official")]
+
+    event_config = EventConfig(
+        initial_posts=[{"content": "第一帖", "poster_type": "Official"}],
+        scheduled_events=[{"round": 2, "content": "第二帖", "poster_type": "Official"}],
+    )
+
+    updated = generator._assign_initial_post_agents(event_config, agents)
+
+    # used_indices 跨两个列表共享：第一帖用 agent 0，第二帖轮转到 agent 1
+    assert updated.initial_posts[0]["poster_agent_id"] == 0
+    assert updated.scheduled_events[0]["poster_agent_id"] == 1
+
+
+def test_empty_lists_are_a_no_op():
+    generator = _generator()
+    event_config = EventConfig(initial_posts=[], scheduled_events=[])
+
+    updated = generator._assign_initial_post_agents(event_config, [_agent(0, "官方", "Official")])
+
+    assert updated is event_config
+    assert updated.initial_posts == []
+    assert updated.scheduled_events == []
+
+
+def test_unknown_poster_type_falls_back_to_highest_influence_agent():
+    generator = _generator()
+    agents = [
+        _agent(0, "低影响", "Student", influence=0.5),
+        _agent(1, "高影响", "Professor", influence=2.0),
+    ]
+
+    updated = generator._assign_agents_to_posts(
+        [{"content": "未知类型", "poster_type": "Alien"}], agents
+    )
+
+    assert updated[0]["poster_agent_id"] == 1


### PR DESCRIPTION
Closes #779

`event_config.scheduled_events` is declared on the `EventConfig` dataclass but never reaches the
simulation: the event-config prompt does not ask for it, `_parse_event_config` overwrites whatever
the model returned with a hardcoded `[]`, and no runner reads the key. The README advertises
injecting variables mid-simulation from a "God's-eye view", which is exactly this field.

This wires the existing mechanism rather than inventing a new one.

### Goals

- Make `event_config.scheduled_events` reach the simulation, so the README's mid-run
  "God's-eye view" injection is backed by code.
- Keep the change strictly additive: with an empty list — what the generator emits today — the
  execution path must be indistinguishable from current behaviour.
- Cover both platforms symmetrically, Reddit and Twitter.

### Non-goals

- The five other fields reported in the issue. They are not the same case and are argued there,
  not here — see "Not included, on purpose" below.
- Any change to the recommender, to OASIS internals, or to `camel-oasis`.
- Any reordering of `prepare_simulation`. That is a maintainer decision, not an outside PR.

### Acceptance criteria

1. An event with `round: N` is published in round N, by an agent whose `poster_type` matches the
   request, and before the agents act in that round.
2. The same content does **not** appear in earlier rounds, and does not appear at all on unpatched
   code with the same config.
3. With `scheduled_events: []`: no event log lines, same round count, same normalised log flow and
   same initial posts as before the change.
4. A malformed `round` logs a warning and is skipped — the run continues rather than aborting.
5. An event whose round falls outside the actual round count logs a warning instead of being
   dropped silently (`total_rounds` can be truncated by `--max-rounds`).
6. `cd backend && python -m pytest tests -q` is green.

All six were checked on a clean `b5b53acc` checkout; evidence in **Testing** below.

### Why this is mergeable: it is the same publication path, moved inside the loop

`initial_posts` is already published through `ManualAction(action_type=ActionType.CREATE_POST)` in a
single `env.step()` before the round loop (`run_reddit_simulation.py:597-620`). A scheduled event is
that same publication, fired from inside the loop at its target round.

**With an empty `scheduled_events` the execution path is identical to today.** That is not an
argument, it is measured: two runs from the same config, one with events and one with `[]`, produced
the same number of `env.step()` calls per round, the same log flow and the same initial posts. Since
the current generator always emits `[]`, existing configs are unaffected.

### Changes

**`backend/app/services/simulation_config_generator.py`**
- ask for `scheduled_events` in the event-config prompt, constraining `round` to the simulation
  horizon, and keep the failure-path dict the same shape
- stop discarding the parsed value in `_parse_event_config`
- generalize `_assign_initial_post_agents` into `_assign_agents_to_posts`, so initial posts and
  scheduled events share **one** type index, **one** alias table and **one** anti-repetition counter
  instead of duplicating the matching logic

**`backend/scripts/run_reddit_simulation.py`, `backend/scripts/run_twitter_simulation.py`**
- read the events and group them by round
- publish the round's events at the top of the loop, before agents act
- a malformed `round` logs a warning and is skipped rather than aborting the run
- warn when an event's round falls outside the actual round count — `total_rounds` can be truncated
  by `--max-rounds`, and such events would otherwise be dropped silently

**`backend/tests/test_scheduled_event_assignment.py`** — four tests for the shared assignment helper:
resolution across both lists, anti-repetition carrying across them, empty lists as a no-op, and the
unknown-`poster_type` fallback.

Both platforms are changed, symmetrically: a fix that repairs one and leaves the other broken is an
easy excuse to close the PR.

### Testing

- `cd backend && python -m pytest tests -q` → **133 passed** (129 existing + 4 new)
- Functional, on a clean `b5b53acc` checkout: a config with one event at `round: 3` produced that
  post in round 3, published by an agent of the requested `poster_type`, and absent from rounds 1
  and 2 — with the same config on unpatched code producing nothing.
- Regression: same config with `scheduled_events: []` → no event log lines, same round count, same
  execution flow.
- End to end: a full pipeline run had the model return four events (rounds 5, 8, 12, 15), each
  assigned to a distinct agent matching its requested `poster_type`, and all four fired in their
  round.

### One design question

The trigger is the **round number**, as described in #779. I raised the alternative there — the
simulated clock would allow "at simulated hour N" — and said I would follow your preference. With no
answer yet I am shipping `round`, since it is what the loop already indexes and what the generator
can reason about directly. Switching to the clock is a small change confined to the assignment
helper, and I will make it if you prefer.

### Relationship to #573

#573 (Narrative Layer / God Mode) lists "Mid-sim OASIS prompt injection" among its explicit
non-goals, since it deliberately stays out of the OASIS core. This PR does that injection inside the
simulation, so the two are complementary: if #573 lands, its God Mode would have a real mechanism to
push events into rather than only the prose layer. There is no file overlap between them.

### Not included, on purpose (the non-goals, in detail)

The issue lists five other fields that no runner reads. I left them out:

- `stance` / `sentiment_bias` — reachable only by reordering `prepare_simulation`, which is your call
- `recency_weight` — its counterpart lives in `camel-oasis`, not in this repo
- `echo_chamber_strength` — no destination under `recsys_type='reddit'`

I would rather ship the one that is verified end to end than bundle four that are not.

No rush on this — I will rebase if it goes stale.