### PR TITLE
fix(simulation): let API-started runs exit naturally (--no-wait)

### DIFF
--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -518,6 +518,7 @@ class SimulationRunner:
                 sys.executable,  # Python解释器
                 script_path,
                 "--config", config_path,  # 使用完整配置文件路径
+                "--no-wait",  # 模拟主循环完成后进程自然退出，避免 API 启动的模拟常驻内存
             ]
             
             # 如果指定了最大轮数，添加到命令行参数


### PR DESCRIPTION
## Summary
`SimulationRunner.start_simulation` spawns the platform scripts without `--no-wait`, so `wait_for_commands` stays `True` and the subprocess keeps the whole OASIS environment resident after the simulation finishes. API-started runs only end via an explicit `POST /api/simulation/stop`.

This PR adds `--no-wait` to the spawn command so processes exit naturally once the main loop completes.

## Changes
- `backend/app/services/simulation_runner.py`: append `--no-wait` to the spawned command.

## Why it is safe
All three runners already support `--no-wait`:
- `run_twitter_simulation.py` (`wait_for_commands=not args.no_wait`)
- `run_reddit_simulation.py` (same)
- `run_parallel_simulation.py` (same)

The flag only changes post-completion behavior (process exits instead of idling forever); simulation output is unchanged.

## Related
Refs #779 (reported there as a separate defect from the six config fields).

## Test plan
- `--help` on each runner lists `--no-wait`.
- Manual: start a simulation via the API, let it complete; the spawned process now exits and the monitor thread reaches its finalization block.