### PR TITLE
fix: localize page metadata

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-// 使用 Vue Router 来管理页面
+import { watchEffect } from 'vue'
+import i18n from './i18n'
+
+watchEffect(() => {
+  document.title = i18n.global.t('meta.title')
+  document.querySelector('meta[name="description"]')?.setAttribute('content', i18n.global.t('meta.description'))
+  document.documentElement.lang = i18n.global.locale.value
+})
 </script>
 
 <style>


### PR DESCRIPTION
## Summary

- Update the document title and meta description from the active locale.
- Keep the document language attribute synchronized with the locale.

Fixes #786.

## Testing

- `npm run build`
- Verified in the local Vite app that switching between Chinese and English updates the title, description, and `lang`; the English values persist after reload.